### PR TITLE
Pin scipy to 1.12.0 in docker

### DIFF
--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -32,7 +32,7 @@ RUN git clone https://github.com/pyenv/pyenv.git /pyenv
 ENV PYENV_ROOT /pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN pyenv install $PYTHON_VERSION
-RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy pytest pytest-rerunfailures matplotlib absl-py flatbuffers hypothesis
+RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy==1.12.0 pytest pytest-rerunfailures matplotlib absl-py flatbuffers hypothesis
 
 ################################################################################
 ARG BASE_DOCKER=ubuntu:20.04


### PR DESCRIPTION
Needed due to scipy.tril being deprecated in scipy 1.13 and some JAX things still depending on it.

https://ontrack-internal.amd.com/browse/SWDEV-456406