### PR TITLE
Pin scipy to 1.12.0 for jax 0.4.23 builds

### DIFF
--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -32,7 +32,7 @@ RUN git clone https://github.com/pyenv/pyenv.git /pyenv
 ENV PYENV_ROOT /pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN pyenv install $PYTHON_VERSION
-RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy pytest pytest-rerunfailures matplotlib absl-py flatbuffers hypothesis
+RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy==1.12.0 pytest pytest-rerunfailures matplotlib absl-py flatbuffers hypothesis
 
 ################################################################################
 ARG BASE_DOCKER=ubuntu:20.04
@@ -121,6 +121,6 @@ RUN git clone https://github.com/pyenv/pyenv.git /pyenv
 ENV PYENV_ROOT /pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN pyenv install $PYTHON_VERSION
-RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy pytest pytest-rerunfailures matplotlib absl-py
+RUN eval "$(pyenv init -)" && pyenv local ${PYTHON_VERSION} && pip3 install --upgrade --force-reinstall setuptools pip && pip install numpy setuptools build wheel six auditwheel scipy==1.12.0 pytest pytest-rerunfailures matplotlib absl-py
 
 CMD [ "/bin/bash" ]


### PR DESCRIPTION
Post scipy version 1.12.0, there has been attributes (symbols) that JAX depends upon that have been removed in 1.13 and greater.

Until this is fixed in JAX, we will need to build with a pinned version of scipy.

Resolves: SWDEV-455438
Resolves: SWDEV-462664
Resolves: SWDEV-456406