### PR TITLE
Fix scipy requirement in setup.py

### DIFF
--- a/jaxlib/setup.py
+++ b/jaxlib/setup.py
@@ -61,8 +61,8 @@ setup(
     packages=['jaxlib', 'jaxlib.xla_extension'],
     python_requires='>=3.9',
     install_requires=[
-        'scipy>=1.9',
-        "scipy>=1.11.1; python_version>='3.12'",
+        'scipy>=1.9,<1.13',
+        "scipy>=1.11.1,<1.13; python_version>='3.12'",
         'numpy>=1.22',
         'ml_dtypes>=0.2.0',
     ],

--- a/setup.py
+++ b/setup.py
@@ -78,8 +78,8 @@ setup(
         "numpy>=1.23.2; python_version>='3.11'",
         "numpy>=1.26.0; python_version>='3.12'",
         'opt_einsum',
-        'scipy>=1.9',
-        "scipy>=1.11.1; python_version>='3.12'",
+        'scipy>=1.9,<1.13',
+        "scipy>=1.11.1,<1.13; python_version>='3.12'",
         # Required by xla_bridge.discover_pjrt_plugins for forwards compat with
         # Python versions < 3.10. Can be dropped when 3.10 is the minimum
         # required Python version.


### PR DESCRIPTION
scipy 1.13 or greater is still being pulled in while installing JAX from wheels, so we need to cap scipy to 1.12 here