### PR TITLE
BUILD_DOCKERKIT issue for jax ci mainline SWDEV-482397

### DIFF
--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -43,6 +43,9 @@ def dist_wheels(
     # create manylinux image with requested ROCm installed
     image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "")
 
+    env = os.environ.copy()  
+    env['DOCKER_BUILDKIT'] = '1'
+
     cmd = [
         "docker",
         "build",
@@ -55,11 +58,8 @@ def dist_wheels(
         ".",
     ]
 
-    env = os.environ.copy()  
-    env['DOCKER_BUILDKIT'] = '1'
-
     if not image_by_name(image):
-        _ = subprocess.run(cmd, check=True)
+        _ = subprocess.run(cmd, check=True, env=env)
 
     # use image to build JAX/jaxlib wheels
     os.makedirs("wheelhouse", exist_ok=True)

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -44,6 +44,7 @@ def dist_wheels(
     image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "")
 
     cmd = [
+        "DOCKER_BUILDKIT=1",
         "docker",
         "build",
         "-f",
@@ -155,6 +156,7 @@ def dist_docker(
     md = _fetch_jax_metadata(xla_path)
 
     cmd = [
+        "DOCKER_BUILDKIT=1",
         "docker",
         "build",
         "-f",

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -175,7 +175,7 @@ def dist_docker(
     ]
 
     env = os.environ.copy()  
-    env['DOCKER_BUILDKIT'] = '1'
+    env["DOCKER_BUILDKIT"] = "1"
 
     if not keep_image:
         cmd.append("--rm")

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -44,7 +44,6 @@ def dist_wheels(
     image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "")
 
     cmd = [
-        "DOCKER_BUILDKIT=1",
         "docker",
         "build",
         "-f",
@@ -55,6 +54,9 @@ def dist_wheels(
         "--tag=%s" % image,
         ".",
     ]
+
+    env = os.environ.copy()  
+    env['DOCKER_BUILDKIT'] = '1'
 
     if not image_by_name(image):
         _ = subprocess.run(cmd, check=True)
@@ -156,7 +158,6 @@ def dist_docker(
     md = _fetch_jax_metadata(xla_path)
 
     cmd = [
-        "DOCKER_BUILDKIT=1",
         "docker",
         "build",
         "-f",
@@ -172,6 +173,9 @@ def dist_docker(
         "--build-arg=XLA_COMMIT=%(xla_commit)s" % md,
         "--tag=%s" % tag,
     ]
+
+    env = os.environ.copy()  
+    env['DOCKER_BUILDKIT'] = '1'
 
     if not keep_image:
         cmd.append("--rm")

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -174,14 +174,14 @@ def dist_docker(
         "--tag=%s" % tag,
     ]
 
-    env = os.environ.copy()  
-    env["DOCKER_BUILDKIT"] = "1"
-
     if not keep_image:
         cmd.append("--rm")
 
     # context dir
     cmd.append(".")
+
+    env = os.environ.copy()  
+    env["DOCKER_BUILDKIT"] = "1"
 
     subprocess.check_call(cmd)
 

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -183,7 +183,7 @@ def dist_docker(
     env = os.environ.copy()  
     env["DOCKER_BUILDKIT"] = "1"
 
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, env=env)
 
 
 def test(image_name):

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -44,7 +44,7 @@ def dist_wheels(
     image = "jax-manylinux_2_28_x86_64_rocm%s" % rocm_version.replace(".", "")
 
     env = os.environ.copy()  
-    env['DOCKER_BUILDKIT'] = '1'
+    env["DOCKER_BUILDKIT"] = "1"
 
     cmd = [
         "docker",


### PR DESCRIPTION
Added BUILD_DOCKERKIT  as env for dist_wheels and dist_docker. 

This is to fix QA Blocker issue, https://ontrack-internal.amd.com/browse/SWDEV-482397