### PR TITLE
Update ci_build- correct the wheelhouse path

### DIFF
--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -94,7 +94,7 @@ def dist_wheels(
         "-v",
         "./:/jax",
         "-v",
-        "./wheelhouse:/wheelhouse",
+        "/$(pwd)/wheelhouse:/wheelhouse",
     ]
 
     if xla_path:


### PR DESCRIPTION
To correct,

[2024-09-09T04:50:52.593Z] #7 DONE 174.2s
[2024-09-09T04:50:52.593Z] docker: Error response from daemon: create ./wheelhouse: "./wheelhouse" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path. [2024-09-09T04:50:52.593Z] See 'docker run --help'. [2024-09-09T04:50:52.593Z] Traceback (most recent call last):
[2024-09-09T04:50:52.593Z]   File "/data/jenkins_workspace/mainline-framework-jax-manylinux/jax/./build/rocm/ci_build", line 328, in <module>
[2024-09-09T04:50:52.593Z]     main()
[2024-09-09T04:50:52.593Z]   File "/data/jenkins_workspace/mainline-framework-jax-manylinux/jax/./build/rocm/ci_build", line 307, in main
[2024-09-09T04:50:52.593Z]     dist_wheels(
[2024-09-09T04:50:52.593Z]   File "/data/jenkins_workspace/mainline-framework-jax-manylinux/jax/./build/rocm/ci_build", line 120, in dist_wheels
[2024-09-09T04:50:52.593Z]     _ = subprocess.run(cmd, check=True)
[2024-09-09T04:50:52.593Z]   File "/usr/lib/python3.10/subprocess.py", line 526, in run
[2024-09-09T04:50:52.593Z]     raise CalledProcessError(retcode, process.args,
[2024-09-09T04:50:52.593Z] subprocess.CalledProcessError: Command '['docker', 'run', '-v', './:/jax', '-v', './wheelhouse:/wheelhouse', '--init', '--rm', 'jax-manylinux_2_28_x86_64_rocm630', 'bash', '-c', 'python3 /jax/build/rocm/tools/build_wheels.py --rocm-version 6.3.0 --python-versions 3.10.0 --compiler gcc /jax']' returned non-zero exit status 125.