### PR TITLE
[JAX] Fix wheelhouse install

### DIFF
--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -84,5 +84,5 @@ LABEL com.amdgpu.rocm_version="$ROCM_VERSION" \
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
-    pip install --find-links /wheelhouse jax jaxlib jax_rocm60_plugin jax_rocm60_pjrt
+    pip3 install wheelhouse/*none*.whl && pip3 install wheelhouse/*.whl
 

--- a/build/rocm/docker/Dockerfile.jax-ubu22
+++ b/build/rocm/docker/Dockerfile.jax-ubu22
@@ -61,4 +61,4 @@ LABEL com.amdgpu.rocm_version="$ROCM_VERSION" \
 
 RUN --mount=type=cache,mode=0755,target=/root/.cache/pip \
     --mount=type=bind,source=wheelhouse,target=/wheelhouse \
-    pip3 install --find-links /wheelhouse jax jaxlib jax_rocm60_plugin jax_rocm60_pjrt
+    pip3 install wheelhouse/*none*.whl && pip3 install wheelhouse/*.whl


### PR DESCRIPTION
When we install wheels using ->

```
pip install --find-links /wheelhouse jax jaxlib jax_rocm60_plugin jax_rocm60_pjrt
```

They pick up latest version of JAX and JAXlib from pypi and plugins from what we have built.

![image](https://github.com/user-attachments/assets/3538f0b9-94b9-4ab7-8772-e43139a1fc4e)

notice the version mismatch.

**This PR makes it such that all wheels are installed from the build**