### PR TITLE
[ROCm] Fix invalid command in dev build script 

### DIFF
--- a/build/rocm/dev_build_rocm.py
+++ b/build/rocm/dev_build_rocm.py
@@ -83,8 +83,10 @@ def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path):
         f"--use_clang={str(use_clang).lower()}",
         f"--rocm_amdgpu_targets={rocm_target}",
         f"--rocm_path=/opt/rocm-{rocm_version}/",
-        bazel_options,
     ]
+
+    if bazel_options:
+        build_command.append(bazel_options)
 
     if clang_option:
         build_command.append(clang_option)


### PR DESCRIPTION
When bazel options were empty, the args to build/build.py were leaving an empty string arg which is invalid.