### PR TITLE
Correcting docker tag

### DIFF
--- a/build/rocm/ci_build.sh
+++ b/build/rocm/ci_build.sh
@@ -53,7 +53,7 @@ CUSTOM_INSTALL=""
 JAX_USE_CLANG=""
 POSITIONAL_ARGS=()
 
-RUNTIME_FLAG=1
+RUNTIME_FLAG=0
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -112,12 +112,14 @@ function upsearch (){
         cd .. && upsearch "$1"
 }
 
-# Set up WORKSPACE.
-WORKSPACE="${WORKSPACE:-$(upsearch WORKSPACE)}"
-BUILD_TAG="${BUILD_TAG:-jax}"
-
-# Determine the docker image name and BUILD_TAG.
-DOCKER_IMG_NAME="${BUILD_TAG}.${CONTAINER_TYPE}"
+# Set up WORKSPACE. 
+if [ ${RUNTIME_FLAG} -eq 0 ]; then
+  DOCKER_IMG_NAME="${BUILD_TAG}"
+else
+  WORKSPACE="${WORKSPACE:-$(upsearch WORKSPACE)}"
+  BUILD_TAG="${BUILD_TAG:-jax}"
+  DOCKER_IMG_NAME="${BUILD_TAG}.${CONTAINER_TYPE}"
+fi
 
 # Under Jenkins matrix build, the build tag may contain characters such as
 # commas (,) and equal signs (=), which are not valid inside docker image names.


### PR DESCRIPTION
At the end, docker tag has **.rocm** which is incorrect.
This change will correct the tagging.

http://rocm-ci.amd.com/job/mainline-framework-jax-manylinux/384/console
compute-artifactory.amd.com:5000/rocm-plus-docker/framework/compute-rocm-dkms-no-npi-hipclang:14989_ubuntu22.04_py3.10_jax_rocm-jaxlib-v0.4.30-qa_d0829370a.rocm