### PR TITLE
Add workflow for nightly pull from upstream

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     name: "build ${{ matrix.name-prefix }} (py ${{ matrix.python-version }} on ubuntu-20.04, x64=${{ matrix.enable-x64}})"
-    runs-on: linux-x86-n2-32
+    runs-on: ROCM-Ubuntu
     container:
       image: index.docker.io/library/ubuntu@sha256:6d8d9799fe6ab3221965efac00b4c34a2bcc102c086a58dff9e19a08b913c7ef # ratchet:ubuntu:20.04
     timeout-minutes: 60

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -15,4 +15,5 @@ jobs:
   open-sync-pr:
     runs-on: ubuntu-latest
     steps:
-      - run: gh pr create --repo rocm/jax --head main --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"
+      - run: |
+          gh pr create --repo $GITHUB_REPOSITORY --head main --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -1,0 +1,18 @@
+# Pulls the latest changes from upstream into main and opens a PR to merge
+# them into rocm-main.
+
+name: ROCm Nightly Upstream Sync
+on:
+  schedule:
+    - cron: '0 6 * * *'
+jobs:
+  sync-main:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh repo sync rocm/jax -b main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  open-sync-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh pr create --repo rocm/jax --head main --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -4,7 +4,7 @@
 name: ROCm Nightly Upstream Sync
 on:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 6 * * 1-5'
 jobs:
   sync-main:
     runs-on: ubuntu-latest

--- a/.github/workflows/upstream-nightly.yml
+++ b/.github/workflows/upstream-nightly.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   upstream-dev:
-    runs-on: ubuntu-20.04-16core
+    runs-on: ROCM-Ubuntu
     permissions:
       contents: read
       checks: write  # for upload-artifact


### PR DESCRIPTION
Adds a new GitHub Actions workflow for pulling in changes from upstream `main`. The workflow pulls upstream `main` into our local `main`, and then opens up a PR from our `main` to `rocm-main`. This lets CI run unit tests on the upstream code to make sure we don't break CI on `rocm-main`, but it'll be up to us to merge the PR every day.

Story: https://github.com/ROCm/frameworks-internal/issues/9948