### PR TITLE
Add GHA workflow for opening PRs upstream

### DIFF
--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -9,9 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HEAD_REF: ${{ github.head_ref }}
-
+      NEW_BRANCH_NAME: ${{ github.head_ref }}-upstream
+      PR_TITLE: [ROCM] ${{ github.event.pull_request.title }}
     steps:
-      - run: echo ${{ github.base_ref }}
-      - run: echo "TODO" # Create a new branch that includes the changes from this PR
-      - run: gh pr create --base jax-ml/main --head ???? --title ??? --body ???
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - run: |
+          git checkout -b $NEW_BRANCH_NAME $HEAD_REF
+          git rebase --onto main
+          git push origin HEAD
+      # TODO: Change the base branch to upstream main once we've tested this out and know it works
+      - run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$PR_TITLE" --body "${{ github.event.pull_request.body }}"
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -12,13 +12,12 @@ jobs:
       NEW_PR_TITLE: "[ROCM] ${{ github.event.pull_request.title }}"
     steps:
       - name: Checkout code
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Rebase code to main
         run: |
           git checkout -b $NEW_BRANCH_NAME ${{ github.head_ref }}
           git rebase --onto main
           git push origin HEAD
-      # TODO: Change the base branch to upstream main once we've tested this out and know it works
       - name: Create a PR to upstream
         run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$NEW_PR_TITLE" --body "${{ github.event.pull_request.body }}"
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -7,8 +7,11 @@ jobs:
   open-upstream:
     if:  ${{ github.event.label.name == 'open-upstream' }}
     runs-on: ubuntu-latest
+    env:
+      HEAD_REF: ${{ github.head_ref }}
+
     steps:
       - run: echo ${{ github.base_ref }}
       - run: echo "TODO" # Create a new branch that includes the changes from this PR
-      - run: echo gh pr create --base jax-ml/main --head ???? --title ??? --body ???
+      - run: gh pr create --base jax-ml/main --head ???? --title ??? --body ???
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -5,21 +5,20 @@ on:
     branches: [ rocm-main ]
 jobs:
   open-upstream:
-    if:  ${{ github.event.label.name == 'open-upstream' }}
+    if: ${{ github.event.label.name == 'open-upstream' }}
     runs-on: ubuntu-latest
     env:
-      HEAD_REF: ${{ github.head_ref }}
-      NEW_BRANCH_NAME: ${{ github.head_ref }}-upstream
-      PR_TITLE: [ROCM] ${{ github.event.pull_request.title }}
+      NEW_BRANCH_NAME: "${{ github.head_ref }}-upstream"
+      NEW_PR_TITLE: "[ROCM] ${{ github.event.pull_request.title }}"
     steps:
       - name: Checkout code
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Rebase code to main
         run: |
-          git checkout -b $NEW_BRANCH_NAME $HEAD_REF
+          git checkout -b $NEW_BRANCH_NAME ${{ github.head_ref }}
           git rebase --onto main
           git push origin HEAD
       # TODO: Change the base branch to upstream main once we've tested this out and know it works
       - name: Create a PR to upstream
-        run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$PR_TITLE" --body "${{ github.event.pull_request.body }}"
+        run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$NEW_PR_TITLE" --body "${{ github.event.pull_request.body }}"
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -12,11 +12,14 @@ jobs:
       NEW_BRANCH_NAME: ${{ github.head_ref }}-upstream
       PR_TITLE: [ROCM] ${{ github.event.pull_request.title }}
     steps:
+      - name: Checkout code
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-      - run: |
+      - name: Rebase code to main
+        run: |
           git checkout -b $NEW_BRANCH_NAME $HEAD_REF
           git rebase --onto main
           git push origin HEAD
       # TODO: Change the base branch to upstream main once we've tested this out and know it works
-      - run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$PR_TITLE" --body "${{ github.event.pull_request.body }}"
+      - name: Create a PR to upstream
+        run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$PR_TITLE" --body "${{ github.event.pull_request.body }}"
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -1,0 +1,14 @@
+name: ROCm Open Upstream PR
+on:
+  pull_request:
+    types: [ labeled ]
+    branches: [ rocm-main ]
+jobs:
+  open-upstream:
+    if:  ${{ github.event.label.name == 'open-upstream' }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ github.base_ref }}
+      - run: echo "TODO" # Create a new branch that includes the changes from this PR
+      - run: echo gh pr create --base jax-ml/main --head ???? --title ??? --body ???
+

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -7,6 +7,8 @@ jobs:
   open-upstream:
     if: ${{ github.event.label.name == 'open-upstream' }}
     runs-on: ubuntu-latest
+    outputs:
+      new-pr-link: ${{ steps.create-pr.outputs.link }}
     env:
       NEW_BRANCH_NAME: "${{ github.head_ref }}-upstream"
       NEW_PR_TITLE: "[ROCM] ${{ github.event.pull_request.title }}"
@@ -18,6 +20,15 @@ jobs:
           git checkout -b $NEW_BRANCH_NAME ${{ github.head_ref }}
           git rebase --onto main
           git push origin HEAD
+      # TODO: Change the base of the PR to upstream main
       - name: Create a PR to upstream
-        run: gh pr create --base rocm/main --head $NEW_BRANCH_NAME --title "$NEW_PR_TITLE" --body "${{ github.event.pull_request.body }}"
+        id: create-pr
+        run: |
+          echo link=$(gh pr create --repo rocm/jax --base main --head $NEW_BRANCH_NAME --title "$NEW_PR_TITLE" --body "${{ github.event.pull_request.body }}") >> "$GITHUB_OUTPUT"
+  comment-link:
+    needs: open-upstream
+    run-on: ubuntu-latest
+    steps:
+      - name: Leave comment on old PR
+        run: gh pr comment ${{ github.event.pull_request.number }} --repo rocm/jax --body ${{ needs.open-upstream.outputs.new-pr-link.link }}
 

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   open-upstream:
     if: ${{ github.event.label.name == 'open-upstream' }}
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       new-pr-link: ${{ steps.create-pr.outputs.link }}
@@ -27,6 +30,8 @@ jobs:
           echo link=$(gh pr create --repo rocm/jax --base main --head $NEW_BRANCH_NAME --title "$NEW_PR_TITLE" --body "${{ github.event.pull_request.body }}") >> "$GITHUB_OUTPUT"
   comment-link:
     needs: open-upstream
+    permissions:
+      pull-requests: write
     run-on: ubuntu-latest
     steps:
       - name: Leave comment on old PR

--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -32,7 +32,7 @@ jobs:
     needs: open-upstream
     permissions:
       pull-requests: write
-    run-on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Leave comment on old PR
         run: gh pr comment ${{ github.event.pull_request.number }} --repo rocm/jax --body ${{ needs.open-upstream.outputs.new-pr-link.link }}


### PR DESCRIPTION
Add a new Actions workflow that will copy PRs to `rocm-main` labeled with `open-upstream` and set the copy's base branch to upstream `main`. The workflow does this by creating an new branch at the PRs head and doing a `git rebase --onto`, taking whatever changes the author made to `rocm-main` and rebasing them onto a new branch forked from our `main` branch.

For now, just point the PR at our `main` branch. After we've tested this workflow out, point it to upstream `main`.

Story: https://github.com/ROCm/frameworks-internal/issues/9948