### PR TITLE
Allow devs to kick off sync job manually

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -3,6 +3,7 @@
 
 name: ROCm Nightly Upstream Sync
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1-5'
 jobs:


### PR DESCRIPTION
Add an `on.workflow_dispatch` event trigger so that developers can trigger the nightly sync job from the GitHub Actions web GUI if they don't want to wait for the nightly job to run.

Story: https://github.com/ROCm/frameworks-internal/issues/9948