### PR TITLE
Fix nightly sync permissions

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -8,13 +8,19 @@ on:
     - cron: '0 6 * * 1-5'
 jobs:
   sync-main:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - run: gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   open-sync-pr:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - run: |
           gh pr create --repo $GITHUB_REPOSITORY --head main --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds the proper write permissions for the nightly sync job. I ran these through `act`, but unfortunately I don't think `act` can verify the permission settings. The YAML checks out though.

Story: https://github.com/ROCm/frameworks-internal/issues/9948