### PR TITLE
Rename the CI flow to 'ROCm CI' and only run it on PRs to rocm-main

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: ROCm CI
 
 # We test all supported Python versions as follows:
 # - 3.10 : Documentation build
@@ -11,10 +11,10 @@ on:
   # but only for the main branch
   push:
     branches:
-      - main
+      - rocm-main
   pull_request:
     branches:
-      - main
+      - rocm-main
 
 permissions:
   contents: read  # to fetch code

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,4 +1,4 @@
-name: ROCm CI
+name: ROCm CPU CI
 
 # We test all supported Python versions as follows:
 # - 3.10 : Documentation build


### PR DESCRIPTION
Needed to get our daily upstream sync to work. We can disable the "CI" workflow, and then enable this "ROCm CI" workflow that will. It's basically the same workflow, but will only use our runners and not the ones that upstream uses.

Story: https://github.com/ROCm/frameworks-internal/issues/9948