### PR TITLE
Use middle branch for upstream sync

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1-5'
+env:
+  SYNC_BRANCH_NAME: ci-upstream-sync-${{ github.run_number }}_${{ github.run_attempt }}
 jobs:
   sync-main:
     permissions:
@@ -15,12 +17,28 @@ jobs:
       - run: gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  create-sync-branch:
+    needs: sync-main
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - name: Create branch
+        run: |
+          git checkout -b $SYNC_BRANCH_NAME main
+          git push origin HEAD
   open-sync-pr:
+    needs: create-sync-branch
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - run: |
-          gh pr create --repo $GITHUB_REPOSITORY --head main --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"
+          gh pr create --repo $GITHUB_REPOSITORY --head $SYNC_BRANCH_NAME --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
This is a solution for the problem of merge conflicts between `main` and `rocm-main` when syncing with upstream. The original logic for this workflow was to pull changes from upstream `main` into our `main`, and then open a PR from our `main` to `rocm-main`. This works fine when there's no merge conflicts. The usual way to resolve merge conflicts on GitHub PRs is to change the head branch (in this case `main`) so that a merge to the base branch (in this case `rocm-main`) would be conflict-free, usually by either rebasing the head onto the base or merging the base into the head. Adding changes to our `main` won't work with the rest of our CI plan. We want to maintain `main` as a read-only branch that is a copy of upstream's `main` branch. This allows us to create branches off of `main` that will be head refs for PRs targeting upstream's `main`.

In order to not make changes to our `main` branch to resolve merge conflicts in GitHub's PR process, this PR changes the nightly upstream workflow to do the following:
1. Sync (pull) our `main` with upstream's `main`
2. Create a new branch off of `main`
3. Open a PR against `rocm-main` from the new branch

This way, we can make changes to resolve merge conflicts to the new branch without making any changes to our `main` branch. The new branch can be deleted after the PR is merged. I did some experimenting with my local git repo, seeing how git would handle the conflict resolution, and I think this will work fine for us. I only ever had to fix a merge conflict once. I also ran this code through `act` to make sure the workflow was valid.

Story: https://github.com/ROCm/frameworks-internal/issues/9948