### PR TITLE
Fix upstream sync checkout

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create branch
         run: |
           git checkout origin/main 
-          git checkout -b $SYNC_BRANCH_NAME main
+          git checkout -b $SYNC_BRANCH_NAME
           git push origin HEAD
   open-sync-pr:
     needs: create-sync-branch

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Create branch
         run: |
+          git checkout origin/main 
           git checkout -b $SYNC_BRANCH_NAME main
           git push origin HEAD
   open-sync-pr:


### PR DESCRIPTION
The `checkout` action only checks out the `rocm-main` branch, causing the `checkout ... main` command to fail with an error about not being able to find the `main` branch. We need to checkout `origin/main` and create the new branch from that.

Story: https://github.com/ROCm/frameworks-internal/issues/9948