### PR TITLE
Make daily sync permissions at the workflow level and fix merge CI

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -34,6 +34,8 @@ jobs:
           git checkout origin/main 
           git checkout -b $SYNC_BRANCH_NAME
           # Try and merge rocm-main into this new branch so that we don't run upstream's CI code
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
           git merge origin/rocm-main || true
           # If the merge creates conflicts, we want to abort and push to origin anyways so that a dev can resolve the conflicts
           git merge --abort || true

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -34,7 +34,7 @@ jobs:
           git checkout origin/main 
           git checkout -b $SYNC_BRANCH_NAME
           # Try and merge rocm-main into this new branch so that we don't run upstream's CI code
-          git merge rocm-main || true
+          git merge origin/rocm-main || true
           # If the merge creates conflicts, we want to abort and push to origin anyways so that a dev can resolve the conflicts
           git merge --abort || true
           git push origin HEAD

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -6,23 +6,27 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1-5'
+permissions:
+  contents: write
+  pull-requests: write
 env:
   SYNC_BRANCH_NAME: ci-upstream-sync-${{ github.run_number }}_${{ github.run_attempt }}
 jobs:
   sync-main:
-    permissions:
-      contents: write
+    #permissions:
+    #  contents: write
     runs-on: ubuntu-latest
     steps:
       - run: |
           gh auth status
+          gh repo view rocm/jax
           gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   create-sync-branch:
     needs: sync-main
-    permissions:
-      contents: write
+    #permissions:
+    #  contents: write
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,8 +41,8 @@ jobs:
           git push origin HEAD
   open-sync-pr:
     needs: create-sync-branch
-    permissions:
-      pull-requests: write
+    #permissions:
+    #  pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -13,20 +13,15 @@ env:
   SYNC_BRANCH_NAME: ci-upstream-sync-${{ github.run_number }}_${{ github.run_attempt }}
 jobs:
   sync-main:
-    #permissions:
-    #  contents: write
     runs-on: ubuntu-latest
     steps:
       - run: |
           gh auth status
-          #gh repo view rocm/jax
           gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   create-sync-branch:
     needs: sync-main
-    #permissions:
-    #  contents: write
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -38,11 +33,13 @@ jobs:
           git fetch
           git checkout origin/main 
           git checkout -b $SYNC_BRANCH_NAME
+          # Try and merge rocm-main into this new branch so that we don't run upstream's CI code
+          git merge rocm-main || true
+          # If the merge creates conflicts, we want to abort and push to origin anyways so that a dev can resolve the conflicts
+          git merge --abort || true
           git push origin HEAD
   open-sync-pr:
     needs: create-sync-branch
-    #permissions:
-    #  pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - run: |

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - run: |
           gh auth status
-          gh repo view rocm/jax
+          #gh repo view rocm/jax
           gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -14,7 +14,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - run: gh repo sync rocm/jax -b main
+      - run: |
+          gh auth status
+          gh repo sync rocm/jax -b main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   create-sync-branch:


### PR DESCRIPTION
This change does two things:

1. Moves the permissions from the job level to the top level. For whatever reason, putting the `contents: write` permission at the job level causes the `gh repo sync` job to fail with an HTTP403 error.
2. Merge the `rocm-main` code into our middle branch created by CI so that CI won't be run (I thought we could originally disable this through the GUI, but that's not the case since upstream CI sits in the same file as our CI).

Story: https://github.com/ROCm/frameworks-internal/issues/9948