### PR TITLE
Limiting pallas kernels tilesize to 64 on rocm platform

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -278,8 +278,13 @@ class FusedAttentionTest(PallasBaseTest):
       segment_ids = None
 
     def f(q, k, v):
-      return attention.mha(q, k, v, segment_ids, causal=causal,
-                           interpret=self.INTERPRET).sum()
+      if jtu.is_device_rocm():
+        return attention.mha(q, k, v, segment_ids, 1.0, causal, 64, 64,
+                             interpret=self.INTERPRET).sum()
+      else:
+        return attention.mha(q, k, v, segment_ids, causal=causal,
+                             interpret=self.INTERPRET).sum()
+      
 
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, segment_ids, causal=causal).sum()


### PR DESCRIPTION
Pallas kernel runs fine on NV HW, but fails on AMD HW for bigger tile size. Reason is:
Mi300 has less amount of shared memory compared to H100 or H200. A bigger tile size requires more shared memory. 

64 tile size is passing on MI300, so limiting the tile size to max 64 for AMD platform. Default tile size is set to 128.