### PR TITLE
Fix upstream PR workflow to use origin branches

### DIFF
--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -20,8 +20,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Rebase code to main
         run: |
-          git checkout -b $NEW_BRANCH_NAME ${{ github.head_ref }}
-          git rebase --onto main
+          git fetch
+          git checkout -b $NEW_BRANCH_NAME origin/${{ github.head_ref }}
+          git rebase --onto origin/main
           git push origin HEAD
       # TODO: Change the base of the PR to upstream main
       - name: Create a PR to upstream


### PR DESCRIPTION
Fixes an error in the upstream sync PR. Use the `origin/...` to specify that we want the origin version of branches when we create a new branch and rebase onto main.

Story: https://github.com/ROCm/frameworks-internal/issues/9948