### PR TITLE
Add token to open upstream PRs

### DIFF
--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -35,5 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Leave comment on old PR
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: gh pr comment ${{ github.event.pull_request.number }} --repo rocm/jax --body ${{ needs.open-upstream.outputs.new-pr-link.link }}
 


### PR DESCRIPTION
The GitHub CLI needs the token to open PRs against upstream. Add the token to the environment in the workflow.

Story: https://github.com/ROCm/frameworks-internal/issues/9948