### PR TITLE
Fix rebase command to exclude rocm-main

### DIFF
--- a/.github/workflows/rocm-open-upstream-pr.yml
+++ b/.github/workflows/rocm-open-upstream-pr.yml
@@ -19,7 +19,7 @@ jobs:
         run: |
           git fetch
           git checkout -b $NEW_BRANCH_NAME origin/${{ github.head_ref }}
-          git rebase --onto origin/main
+          git rebase --onto origin/main origin/rocm-main
           git push origin HEAD
       - name: Leave link to create PR
         env:


### PR DESCRIPTION
We need to specify that git should take all the commits after the divergence from `rocm-main` and stick those onto `main`

Story: https://github.com/ROCm/frameworks-internal/issues/9948