### PR TITLE
Remove cuda include from gpu plugin extension

### DIFF
--- a/jaxlib/gpu_plugin_extension.cc
+++ b/jaxlib/gpu_plugin_extension.cc
@@ -22,7 +22,6 @@ limitations under the License.
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_format.h"
-#include "third_party/gpus/cuda/include/cuda.h"
 #include "jaxlib/kernel_nanobind_helpers.h"
 #include "xla/ffi/api/c_api.h"
 #include "xla/pjrt/c/pjrt_c_api.h"


### PR DESCRIPTION
This got added in this commit: https://github.com/ROCm/jax/commit/593143e17e746812b25d7e302e165d986a039c7e#diff-b52f574a70f65685ee099dc763c8de233db507c50ea331d6a6c82e8dcb54fc08R25. It's not needed for the CUDA build, as `third_party/gpus/cuda/include/cuda.h` gets included inside of `jaxlib/cuda_plugin_extension.cc`, and this breaks the ROCm build since CUDA isn't there.