### PR TITLE
Use a GitHub app for syncing rocm-main and upstream main

### DIFF
--- a/.github/workflows/rocm-nightly-upstream-sync.yml
+++ b/.github/workflows/rocm-nightly-upstream-sync.yml
@@ -15,11 +15,18 @@ jobs:
   sync-main:
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Generate an app token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ROCM_REPO_MANAGEMENT_API_2_ID }}
+          private-key: ${{ secrets.ROCM_REPO_MANAGEMENT_API_2_PRIV_KEY }}
+      - name: Sync our main with upstream main
+        run: |
           gh auth status
           gh repo sync rocm/jax -b main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
   create-sync-branch:
     needs: sync-main
     runs-on: ubuntu-latest
@@ -44,9 +51,16 @@ jobs:
     needs: create-sync-branch
     runs-on: ubuntu-latest
     steps:
-      - run: |
+      - name: Generate an app token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ROCM_REPO_MANAGEMENT_API_2_ID }}
+          private-key: ${{ secrets.ROCM_REPO_MANAGEMENT_API_2_PRIV_KEY }}
+      - name: Open a PR to rocm-main
+        run: |
           gh pr create --repo $GITHUB_REPOSITORY --head $SYNC_BRANCH_NAME --base rocm-main --title "CI: $(date +%x) upstream sync" --body "Daily sync with upstream"
           gh pr merge --repo $GITHUB_REPOSITORY --merge --auto $SYNC_BRANCH_NAME
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
 


### PR DESCRIPTION
Currently, the nightly sync job fails if upstream makes changes to some of its CI workflows, even for workflow files that we don't use. Workflow files change probably every other day, so this means that I spend some time every other day having to babysit the sync job.

The default GitHub runner account disallows making changes to workflow files for security reasons. However, you can change workflow files if you run the workflow using a GitHub App instead of the default runner account. Divin created an app for us that should have all the right permissions. I've added the ID and key for it to this repo, and this PR adds a step that will generate a token that Actions can use to authenticate to the GitHub API as the app.