### PR TITLE
Run GPU CI on QA PRs

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -6,16 +6,18 @@ on:
   push:
     branches:
       - rocm-main
+      - 'rocm-jaxlib-v*'
   pull_request:
     branches:
       - rocm-main
+      - 'rocm-jaxlib-v*'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-jax-in-docker: # strategy and matrix come here 
+  build-jax-in-docker: # strategy and matrix come here
     runs-on:  mi-250
     env:
       BASE_IMAGE: "ubuntu:22.04"


### PR DESCRIPTION
Run CI on PRs going into branches we use for QA (i.e. branches that match `rocm-jaxlib-v*`) so that we can make sure that `jaxlib` and `jax` build and pass a minimal set of tests before merging.