### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require approvals for changes to ROCm build and CI scripts
+/build/rocm/ @charleshofer
+


### PR DESCRIPTION
Add a CODEOWNERS file that locks down the `build/rocm` directory and all subdirectories so that it requires owner approval before merging.