### PR TITLE
[v0.5.0] Add support for ROCm wheel based install

### DIFF
--- a/jax_plugins/rocm/plugin_setup.py
+++ b/jax_plugins/rocm/plugin_setup.py
@@ -72,4 +72,20 @@ setup(
     },
     zip_safe=False,
     distclass=BinaryDistribution,
+    extras_require={
+        "with_rocm": [
+            "amd_rocm_hip_runtime_devel_instinct",
+            "amd_rocm_hip_runtime_instinct",
+            "amd_hipblas_instinct",
+            "amd_hipsparse_instinct",
+            "amd_hipsolver_instinct",
+            "amd_miopen_hip_instinct",
+            "amd_rocm_llvm_instinct",
+            "amd_rocm_language_runtime_instinct",
+            "amd_rccl_instinct",
+            "amd_hipfft_instinct",
+            "amd_rocm_device_libs_instinct",
+            "amd_hipsparselt_instinct",
+        ],
+    },
 )

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -388,6 +388,7 @@ cc_library(
         "@com_google_absl//absl/algorithm:container",
         "@com_google_absl//absl/status",
         "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip",
         "@xla//xla/ffi/api:c_api",
         "@xla//xla/ffi/api:ffi",
         "@xla//xla/service:custom_call_status",
@@ -444,6 +445,7 @@ cc_library(
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
         "@com_google_absl//absl/types:span",
+        "@local_config_rocm//rocm:hip",
         "@xla//xla/ffi/api:ffi",
     ],
 )
@@ -489,6 +491,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_absl//absl/synchronization",
+        "@local_config_rocm//rocm:hip",
         "@tsl//tsl/platform:env",
         "@xla//xla/service:custom_call_status",
         "@xla//xla/tsl/util:env_var",

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -21,6 +21,7 @@ import argparse
 import functools
 import os
 import pathlib
+import subprocess
 import tempfile
 
 from bazel_tools.tools.python.runfiles import runfiles
@@ -152,6 +153,40 @@ def prepare_wheel_rocm(
           "__main__/jaxlib/version.py",
       ],
   )
+
+  # NOTE(mrodden): this is a hack to change/set rpath values
+  # in the shared objects that are produced by the bazel build
+  # before they get pulled into the wheel build process.
+  # we have to do this change here because setting rpath
+  # using bazel requires the rpath to be valid during the build
+  # which won't be correct until we make changes to
+  # the xla/tsl/jax plugin build
+
+  try:
+    subprocess.check_output(["which", "patchelf"])
+  except subprocess.CalledProcessError as ex:
+    mesg = (
+        "rocm plugin and kernel wheel builds require patchelf. "
+        "please install 'patchelf' and run again"
+    )
+    raise Exception(mesg) from ex
+
+  files = [
+      f"_blas.{pyext}",
+      f"_linalg.{pyext}",
+      f"_prng.{pyext}",
+      f"_solver.{pyext}",
+      f"_sparse.{pyext}",
+      f"_hybrid.{pyext}",
+      f"_rnn.{pyext}",
+      f"_triton.{pyext}",
+      f"rocm_plugin_extension.{pyext}",
+  ]
+  runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib'
+  # patchelf --force-rpath --set-rpath $RUNPATH $so
+  for f in files:
+    so_path = os.path.join(plugin_dir, f)
+    subprocess.check_call(["patchelf", "--force-rpath", "--set-rpath", runpath, so_path])
 
 # Build wheel for cuda kernels
 if args.enable_rocm:


### PR DESCRIPTION
This also requires some changes on the XLA side
for the paths and such to have any effect.

The plugin init now looks for a `rocm` python
package install and extracts ROCm toolkit paths
from the python packages that it finds. We hand
these into the XLA portions of the plugin via
environment variables to avoid changing any interfaces like protobuf or PJRT C APIs.

We also have to patch the rpath in the shared object files included in the plugin and kernel wheels so they look relative to their install path just like the cuda based plugin objects do.

Some other changes are fixing missing dynamic link libraries and also adding an optional feature target to pull in rocm python dependencies for the plugin.