### PR TITLE
Fix dev build script

### DIFF
--- a/build/rocm/dev_build_rocm.py
+++ b/build/rocm/dev_build_rocm.py
@@ -86,7 +86,7 @@ def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path):
         "--verbose"
     ]
     
-    if bazel_options != "":
+    if bazel_options:
         build_command.append(bazel_options)
     if clang_option:
         build_command.append(clang_option)

--- a/build/rocm/dev_build_rocm.py
+++ b/build/rocm/dev_build_rocm.py
@@ -77,16 +77,17 @@ def build_jax_xla(xla_path, rocm_version, rocm_target, use_clang, clang_path):
     build_command = [
         "python3",
         "./build/build.py",
-        "build"
+        "build",
         f"--use_clang={str(use_clang).lower()}",
-        "--wheels=jaxlib,jax-rocm-plugin,jax-rocm-pjrt"
-        "--rocm_path=%/opt/rocm-{rocm_version}/",
+        "--wheels=jaxlib,jax-rocm-plugin,jax-rocm-pjrt",
+        f"--rocm_path=/opt/rocm-{rocm_version}/",
         "--rocm_version=60",
         f"--rocm_amdgpu_targets={rocm_target}",
-        bazel_options,
         "--verbose"
     ]
-
+    
+    if bazel_options != "":
+        build_command.append(bazel_options)
     if clang_option:
         build_command.append(clang_option)
 

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/openxla/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "eb7c01d4a33c76e5a33f52bf07a427c840b1195f"
-XLA_SHA256 = "ed683ae543d8b0a8acbb61eb6c19d477c80afeffbee3d74374a32e81cf365ee0"
+XLA_COMMIT = "2e75b1d4389728ed61cb6708cac0b05f46ab9392"
+XLA_SHA256 = "e56e9bde201c842120c04149feb794d0db8ffd29b12fafb1720d3625fedd0233"
 
 def repo():
     tf_http_archive(


### PR DESCRIPTION
The dev build script works with the added changes using the following command:
python build/rocm/dev_build_rocm.py --use-clang=true --clang-path=/usr/bin/clang-18

Giving the clang path and running with at least clang-18 is required. The errors were due to some syntax issues in command building functions. 
Also updated the XLA commit hash in the workspace.bzl file as Mathew showed. 
