### PR TITLE
Enable upstream CI on release

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -12,9 +12,11 @@ on:
   push:
     branches:
       - rocm-main
+      - 'rocm-jaxlib-v*'
   pull_request:
     branches:
       - rocm-main
+      - 'rocm-jaxlib-v*'
 
 permissions:
   contents: read  # to fetch code


### PR DESCRIPTION
Enable CI jobs that we inherit from upstream to run on release branches.