### PR TITLE
Fix and enable RNN tests on JAX 0.5.0 branch

### DIFF
--- a/jax/experimental/rnn.py
+++ b/jax/experimental/rnn.py
@@ -463,7 +463,7 @@ rnn_fwd_p.def_impl(partial(xla.apply_primitive, rnn_fwd_p))
 rnn_fwd_p.def_abstract_eval(rnn_abstract_eval)
 if gpu_rnn:
   mlir.register_lowering(rnn_fwd_p, gpu_rnn.cudnn_rnn_lowering, platform='cuda')
-  if hasattr(gpu_rnn, "miopen_rnn_fwd_lowering"):
+  if hasattr(gpu_rnn, "miopen_rnn_lowering"):
     mlir.register_lowering(rnn_fwd_p, gpu_rnn.miopen_rnn_lowering, platform='rocm')
 
 

--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -39,9 +39,6 @@ class RnnTest(jtu.JaxTestCase):
   @jax.default_matmul_precision("float32")
   def test_lstm(self, batch_size: int, seq_len: int, input_size: int,
                 hidden_size: int, num_layers: int, bidirectional: bool):
-    # TODO(ruturaj4): skip RNN tests.
-    if jtu.is_device_rocm():
-      self.skipTest("RNN tests are failing on ROCm. Check to see what is wrong.")
     # TODO(ruturaj4): Bidirectional doesn't quite work well with rocm.
     if bidirectional and jtu.is_device_rocm():
       self.skipTest("Bidirectional mode is not available for ROCm.")


### PR DESCRIPTION
Enable RNN/ LSTM tests and implement a fix in the lowering code.