### PR TITLE
When creating wheels, fix permissions of libraries before patching them

### DIFF
--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -186,7 +186,17 @@ def prepare_wheel_rocm(
   # patchelf --force-rpath --set-rpath $RUNPATH $so
   for f in files:
     so_path = os.path.join(plugin_dir, f)
+    exists = os.path.exists(so_path)
+    fix_perms = False
+    if exists:
+        import stat
+        perms = os.stat(so_path).st_mode
+        if not perms & stat.S_IWUSR:
+            fix_perms = True
+            os.chmod(so_path, perms | stat.S_IWUSR)
     subprocess.check_call(["patchelf", "--force-rpath", "--set-rpath", runpath, so_path])
+    if (fix_perms):
+        os.chmod(so_path, perms)
 
 # Build wheel for cuda kernels
 if args.enable_rocm:

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -162,8 +162,17 @@ def prepare_rocm_plugin_wheel(sources_path: pathlib.Path, *, cpu, rocm_version):
   shared_obj_path = os.path.join(plugin_dir, "xla_rocm_plugin.so")
   runpath = '$ORIGIN/../rocm/lib:$ORIGIN/../../rocm/lib'
   # patchelf --force-rpath --set-rpath $RUNPATH $so
+  exists = os.path.exists(shared_obj_path)
+  fix_perms = False
+  if exists:
+      import stat
+      perms = os.stat(shared_obj_path).st_mode
+      if not perms & stat.S_IWUSR:
+          fix_perms = True
+          os.chmod(shared_obj_path, perms | stat.S_IWUSR)
   subprocess.check_call(["patchelf", "--force-rpath", "--set-rpath", runpath, shared_obj_path])
-
+  if (fix_perms):
+      os.chmod(shared_obj_path, perms)
 
 
 tmpdir = None


### PR DESCRIPTION
I found that on at least 2 machines, shared libraries had permissions of "555" after being copied to /tmp.
On these machines, patchelf was failing with a "permission denied" error.

This patch will make sure that the files are user writable before calling patchelf.
If they are not, the patch makes the files user writable before calling patchelf, and restores the original permissions afterwards