### PR TITLE
Add workflow for updating XLA commit hash

### DIFF
--- a/.github/workflows/rocm-update-xla-hash.yml
+++ b/.github/workflows/rocm-update-xla-hash.yml
@@ -1,0 +1,50 @@
+name: ROCm Update XLA Hash
+
+on:
+  workflow_dispatch:
+    inuts:
+      xla_hash:
+        description: Full commit hash or branch name of the XLA commit
+        type: string
+        required: true
+      xla_repo:
+        description: XLA repo that the commit is from. Should be of the form <owner>/<repo>.
+        type: string
+        requird: false
+        default: openxla/xla
+
+jobs:
+  update-xla-hash:
+    env:
+      NEW_BRANCH_NAME: ci-xlahash-${{ github.ref_name }}_${{ github.run_id }}}_${{ github.run_number }}_${{ github.run_attempt }}
+      WORKSPACE_DIR: workdir_xlahash_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: ${{ env.WORKSPACE_DIR }}
+            - name: Generate an app token
+      - id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ROCM_REPO_MANAGEMENT_API_2_ID }}
+          private-key: ${{ secrets.ROCM_REPO_MANAGEMENT_API_2_PRIV_KEY }}
+      - name: Run update script
+        run: |
+          pushd ${{ env.WORKSPACE_DIR }}
+          build/rocm/tools/update_xla_hash.py -v --xla-repo ${{ inputs.xla_repo }} ${{ inputs.xla_hash }} $GH_TOKEN
+        env:
+           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+      - name: Create branch for PR
+        run: |
+          git checkout -b $NEW_BRANCH_NAME
+          git config --global user.email "github-actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git push origin HEAD
+      - name: Open PR
+        run: |
+          gh pr create --repo ${{ github.repository }} --head $NEW_BRANCH_NAME --base ${{ github.ref_name }} --title "CI: $(date +%x) XLA hash update" --body "Update the XLA commit hash"
+          gh pr merge --repo ${{ github.repository }} --rebase --auto $NEW_BRANCH_NAME
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+
+

--- a/.github/workflows/rocm-update-xla-hash.yml
+++ b/.github/workflows/rocm-update-xla-hash.yml
@@ -2,7 +2,7 @@ name: ROCm Update XLA Hash
 
 on:
   workflow_dispatch:
-    inuts:
+    inputs:
       xla_hash:
         description: Full commit hash or branch name of the XLA commit
         type: string
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: ${{ env.WORKSPACE_DIR }}
-            - name: Generate an app token
-      - id: generate-token
+      - name: Generate an app token
+        id: generate-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ vars.ROCM_REPO_MANAGEMENT_API_2_ID }}

--- a/.github/workflows/rocm-update-xla-hash.yml
+++ b/.github/workflows/rocm-update-xla-hash.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run update script
         run: |
           pushd ${{ env.WORKSPACE_DIR }}
-          build/rocm/tools/update_xla_hash.py -v --xla-repo ${{ inputs.xla_repo }} ${{ inputs.xla_hash }} $GH_TOKEN
+          build/rocm/tools/update_xla_hash.py -v --xla-repo ${{ inputs.xla_repo }} --gh-token $GH_TOKEN ${{ inputs.xla_hash }}
         env:
            GH_TOKEN: ${{ steps.generate-token.outputs.token }}
       - name: Create branch for PR

--- a/build/rocm/tools/update_xla_hash.py
+++ b/build/rocm/tools/update_xla_hash.py
@@ -1,0 +1,92 @@
+"""Update the third_party/xla/workspace.bzl file to use the given XLA commit"""
+
+import argparse
+import os.path
+import re
+import subprocess
+
+
+def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
+    # Verify that the workspace_file exists
+    if not os.path.isfile(workspace_file_path):
+        raise ValueError(f"Workspace file '{workspace_file}' does not exist")
+
+    # Convert xla_commit to a commit hash if it's a branch
+    xla_commit_hash = xla_commit
+
+    # Get the sha256 of this commit
+    curl_proc = subprocess.Popen(
+        args=[
+            "curl",
+            "--output",
+            "-",
+            "-L",
+            f"{xla_repo}/archive/{xla_commit_hash}.tar.gz",
+        ],
+        stdout=subprocess.PIPE,
+    )
+    sha256_proc = subprocess.Popen(
+        args=["sha256sum"],
+        stdin=curl_proc.stdout,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    sha256_text, _ = sha256_proc.communicate()
+    # Sometimes sha256sum sticks some extra characters onto its output
+    # Just take the first 64, since sha256s area always 64 characters long
+    sha256_text = sha256_text[:64]
+    print(sha256_text)
+
+    # Open the workspace file
+    with open(workspace_file_path, "r+") as workspace_file:
+        contents = workspace_file.read()
+        # Edit the commit hash, sha256 hash, and repo
+        contents = re.sub(
+            'XLA_COMMIT = "[a-z0-9]*"',
+            f'XLA_COMIT = "{xla_commit_hash}"',
+            contents,
+            flags=re.M,
+        )
+        contents = re.sub(
+            'XLA_SHA256 = "[a-z0-9]*"',
+            f'XLA_SHA256 = "{sha256_text}"',
+            contents,
+            flags=re.M,
+        )
+        contents = re.sub(
+            'tf_mirror_urls\("[a-zA-Z0-9:/.]+/archive',
+            f'tf_mirror_urls\("{xla_repo}/archive',
+            contents,
+            flags=re.M,
+        )
+        # Write to the workspace file
+        # workspace_file.seek(0)
+        # workspace_file.write(contents)
+        # workspace_file.truncate()
+        print(contents)
+
+
+def parse_args():
+    arg_parser = argparse.ArgumentParser(
+        description="Update the XLA commit hash in the workspace.bzl file"
+    )
+    arg_parser.add_argument(
+        "xla_commit",
+        help="Branch or commit to put in the workspace file",
+    )
+    arg_parser.add_argument(
+        "--xla-repo",
+        default="https://github.com/openxla/xla",
+        help="URL to the XLA repo where this branch or commit can be found",
+    )
+    arg_parser.add_argument(
+        "--workspace-file",
+        default="./third_party/xla/workspace.bzl",
+        help="Path to the workspace.bzl file to put the hash",
+    )
+    return arg_parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    update_xla_hash(args.xla_commit, args.xla_repo, args.workspace_file)

--- a/build/rocm/tools/update_xla_hash.py
+++ b/build/rocm/tools/update_xla_hash.py
@@ -1,9 +1,12 @@
 """Update the third_party/xla/workspace.bzl file to use the given XLA commit"""
 
 import argparse
+import logging
 import os.path
 import re
 import subprocess
+
+logger = logging.getLogger(__name__)
 
 
 def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
@@ -32,8 +35,8 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
         text=True,
     )
     sha256_text, _ = sha256_proc.communicate()
-    # Sometimes sha256sum sticks some extra characters onto its output
-    # Just take the first 64, since sha256s area always 64 characters long
+    # sha256sum sticks some extra characters onto its output. Just take the
+    # first 64, since sha256s area always 64 characters long.
     sha256_text = sha256_text[:64]
     print(sha256_text)
 
@@ -60,10 +63,9 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
             flags=re.M,
         )
         # Write to the workspace file
-        # workspace_file.seek(0)
-        # workspace_file.write(contents)
-        # workspace_file.truncate()
-        print(contents)
+        workspace_file.seek(0)
+        workspace_file.write(contents)
+        workspace_file.truncate()
 
 
 def parse_args():
@@ -77,12 +79,14 @@ def parse_args():
     arg_parser.add_argument(
         "--xla-repo",
         default="https://github.com/openxla/xla",
-        help="URL to the XLA repo where this branch or commit can be found",
+        help="URL to the XLA repo where this branch or commit can be "
+        "found. Defaults to https://github.com/openxla/xla.",
     )
     arg_parser.add_argument(
         "--workspace-file",
         default="./third_party/xla/workspace.bzl",
-        help="Path to the workspace.bzl file to put the hash",
+        help="Path to the workspace.bzl file to put the hash. Defaults to "
+        "./third_party/xla/workspace.bzl.",
     )
     return arg_parser.parse_args()
 

--- a/build/rocm/tools/update_xla_hash.py
+++ b/build/rocm/tools/update_xla_hash.py
@@ -4,18 +4,39 @@ import argparse
 import logging
 import os.path
 import re
+import requests
 import subprocess
 
+GH_COMMIT_URL = "https://api.github.com/repos/{0}/commits/{1}"
+GH_BASE_URL = "https://github.com"
 logger = logging.getLogger(__name__)
 
 
-def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
+def update_xla_hash(xla_commit, xla_repo, workspace_file_path, gh_token):
     # Verify that the workspace_file exists
     if not os.path.isfile(workspace_file_path):
         raise ValueError(f"Workspace file '{workspace_file}' does not exist")
 
-    # Convert xla_commit to a commit hash if it's a branch
-    xla_commit_hash = xla_commit
+    # If we were given a GH auth token, use it to make sure that the commit
+    # exists and convert a branch name to a commit hash
+    if gh_token:
+        logger.debug(GH_COMMIT_URL.format(xla_repo, xla_commit))
+        commit_info_resp = requests.get(
+            url=GH_COMMIT_URL.format(xla_repo, xla_commit),
+            headers={
+                "Accept": "application/vnd.github.sha",
+                "Authorization": f"Bearer {gh_token}",
+                "X-Github-Api-Version": "2022-11-28",
+            }
+        )
+        commit_info_resp.raise_for_status()
+        logger.info("Found commit hash via GH API: %s", commit_info_resp.text)
+        xla_commit_hash = commit_info_resp.text
+    # If the user didn't give us a token make sure the commit hash looks hashy
+    else:
+        if not xla_commit.isalnum():
+            raise ValueError(f"XLA commit hash '{xla_commit}' is not a valid commit hash")
+        xla_commit_hash = xla_commit
 
     # Get the sha256 of this commit
     curl_proc = subprocess.Popen(
@@ -24,7 +45,7 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
             "--output",
             "-",
             "-L",
-            f"{xla_repo}/archive/{xla_commit_hash}.tar.gz",
+            f"{GH_BASE_URL}/{xla_repo}/archive/{xla_commit_hash}.tar.gz",
         ],
         stdout=subprocess.PIPE,
     )
@@ -58,7 +79,7 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path):
         )
         contents = re.sub(
             'tf_mirror_urls\("[a-zA-Z0-9:/.]+/archive',
-            f'tf_mirror_urls\("{xla_repo}/archive',
+            f'tf_mirror_urls("{GH_BASE_URL}/{xla_repo}/archive',
             contents,
             flags=re.M,
         )
@@ -77,20 +98,30 @@ def parse_args():
         help="Branch or commit to put in the workspace file",
     )
     arg_parser.add_argument(
+        "gh_token",
+        help="Github token to authenticate with. Either the GIHUB_TOKEN from Actions or your PAT."
+    )
+    arg_parser.add_argument(
         "--xla-repo",
-        default="https://github.com/openxla/xla",
-        help="URL to the XLA repo where this branch or commit can be "
-        "found. Defaults to https://github.com/openxla/xla.",
+        default="openxla/xla",
+        help="The repo where this branch or commit can be found. Should be in the form of <owner>/<repo>. Defaults to openxla/xla.",
     )
     arg_parser.add_argument(
         "--workspace-file",
         default="./third_party/xla/workspace.bzl",
-        help="Path to the workspace.bzl file to put the hash. Defaults to "
-        "./third_party/xla/workspace.bzl.",
+        help="Path to the workspace.bzl file to put the hash. Defaults to ./third_party/xla/workspace.bzl.",
+    )
+    arg_parser.add_argument(
+        "-v", "--verbose",
+        help="Turn on debug logging",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG
     )
     return arg_parser.parse_args()
 
 
 if __name__ == "__main__":
     args = parse_args()
-    update_xla_hash(args.xla_commit, args.xla_repo, args.workspace_file)
+    logging.basicConfig(level=args.loglevel)
+    update_xla_hash(args.xla_commit, args.xla_repo, args.workspace_file, args.gh_token)

--- a/build/rocm/tools/update_xla_hash.py
+++ b/build/rocm/tools/update_xla_hash.py
@@ -30,7 +30,7 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path, gh_token):
                 "Accept": "application/vnd.github.sha",
                 "Authorization": f"Bearer {gh_token}",
                 "X-Github-Api-Version": "2022-11-28",
-            }
+            },
         )
         commit_info_resp.raise_for_status()
         logger.info("Found commit hash via GH API: %s", commit_info_resp.text)
@@ -38,11 +38,15 @@ def update_xla_hash(xla_commit, xla_repo, workspace_file_path, gh_token):
     # If the user didn't give us a token make sure the commit hash looks hashy
     else:
         if not xla_commit.isalnum():
-            raise ValueError(f"XLA commit hash '{xla_commit}' is not a valid commit hash")
+            raise ValueError(
+                f"XLA commit hash '{xla_commit}' is not a valid commit hash"
+            )
         xla_commit_hash = xla_commit
 
     # Get the sha256 of this commit
-    xla_zip_resp = requests.get(f"{GH_BASE_URL}/{xla_repo}/archive/{xla_commit_hash}.tar.gz")
+    xla_zip_resp = requests.get(
+        f"{GH_BASE_URL}/{xla_repo}/archive/{xla_commit_hash}.tar.gz"
+    )
     xla_zip_resp.raise_for_status()
     hasher = hashlib.sha256()
     hasher.update(xla_zip_resp.content)
@@ -87,7 +91,7 @@ def parse_args():
     )
     arg_parser.add_argument(
         "gh_token",
-        help="Github token to authenticate with. Either the GIHUB_TOKEN from Actions or your PAT."
+        help="Github token to authenticate with. Either the GIHUB_TOKEN from Actions or your PAT.",
     )
     arg_parser.add_argument(
         "--xla-repo",
@@ -100,11 +104,12 @@ def parse_args():
         help="Path to the workspace.bzl file to put the hash. Defaults to ./third_party/xla/workspace.bzl.",
     )
     arg_parser.add_argument(
-        "-v", "--verbose",
+        "-v",
+        "--verbose",
         help="Turn on debug logging",
         action="store_const",
         dest="loglevel",
-        const=logging.DEBUG
+        const=logging.DEBUG,
     )
     return arg_parser.parse_args()
 
@@ -113,4 +118,3 @@ if __name__ == "__main__":
     args = parse_args()
     logging.basicConfig(level=args.loglevel)
     update_xla_hash(args.xla_commit, args.xla_repo, args.workspace_file, args.gh_token)
-

--- a/build/rocm/tools/update_xla_hash.py
+++ b/build/rocm/tools/update_xla_hash.py
@@ -90,7 +90,7 @@ def parse_args():
         help="Branch or commit to put in the workspace file",
     )
     arg_parser.add_argument(
-        "gh_token",
+        "--gh-token",
         help="Github token to authenticate with. Either the GIHUB_TOKEN from Actions or your PAT.",
     )
     arg_parser.add_argument(


### PR DESCRIPTION
Add a script and workflow that will update the XLA commit hash in `third_party/xla/workspace.bzl` given either a commit hash or an XLA branch. This can run periodically to update release and rocm-main branches to help keep them on the latest XLA and find bugs before we cut releases.

See: https://github.com/ROCm/jax-internal/issues/17