### PR TITLE
Add gfx1101 to build targets

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -151,7 +151,7 @@ build:win_clang --compiler=clang-cl
 build:rocm_base --crosstool_top=@local_config_rocm//crosstool:toolchain
 build:rocm_base --define=using_rocm=true --define=using_rocm_hipcc=true
 build:rocm_base --repo_env TF_NEED_ROCM=1
-build:rocm_base --action_env TF_ROCM_AMDGPU_TARGETS="gfx900,gfx906,gfx908,gfx90a,gfx940,gfx941,gfx942,gfx1030,gfx1100,gfx1200,gfx1201"
+build:rocm_base --action_env TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
 
 # Build with hipcc for ROCm and clang for the host.
 build:rocm --config=rocm_base

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -28,7 +28,7 @@ from typing import List
 
 
 DEFAULT_GPU_DEVICE_TARGETS = (
-    "gfx906,gfx908,gfx90a,gfx942,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+    "gfx908,gfx90a,gfx942,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
 )
 
 

--- a/build/rocm/tools/build_wheels.py
+++ b/build/rocm/tools/build_wheels.py
@@ -36,7 +36,7 @@ from typing import List
 LOG = logging.getLogger(__name__)
 
 
-DEFAULT_GPU_DEVICE_TARGETS = "gfx900,gfx906,gfx908,gfx90a,gfx940,gfx941,gfx942,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+DEFAULT_GPU_DEVICE_TARGETS = "gfx908,gfx90a,gfx942,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
 
 
 def build_rocm_path(rocm_version_str):


### PR DESCRIPTION
Also sync up the ones in build scripts, which
apparently aren't used for our jax build,
but will be used for runtime builds with hipcc