### PR TITLE
Port Jenkins release CI to Actions

### DIFF
--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -64,12 +64,20 @@ jobs:
           # Let ci_build script do the build
           python3 ./build/rocm/ci_build \
             --compiler clang \
-            --python-versions 3.10.12 \ # ${{ inputs.python_version }} \
-            --rocm-version 6.3.3 \ # ${{ inputs.rocm_version }} \
-            --rocm-build-job 1 \ ${{ inputs.rocm_build_job_name }} \
-            --rocm-build-num 2 \ ${{ inputs.rocm_build_job_num }} \
+            --python-versions 3.10.12 \
+            --rocm-version 6.3.3 \
+            --rocm-build-job "" \
+            --rocm-build-num "" \
             dist_docker \
-            --image-tag $RELEASE_DOCKER_IMG_NAME \
+            --image-tag $RELEASE_DOCKER_IMG_NAME
+            #python3 ./build/rocm/ci_build \
+            #--compiler clang \
+            #--python-versions ${{ inputs.python_version }} \
+            #--rocm-version ${{ inputs.rocm_version }} \
+            #--rocm-build-job ${{ inputs.rocm_build_job_name }} \
+            #--rocm-build-num ${{ inputs.rocm_build_job_num }} \
+            #dist_docker \
+            #--image-tag $RELEASE_DOCKER_IMG_NAME
       - name: Archive wheels to Github
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -57,9 +57,9 @@ jobs:
           --image-tag $RELEASE_DOCKER_IMG_NAME
     - name: Archive wheels to Github
       uses: actions/upload-artifact@v4
-        with:
-          name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
-          path: ./dist/*.whl
+      with:
+        name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
+        path: ./dist/*.whl
     - name: Test Docker image
       run: |
         # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Clean up Docker and old run directories
         run: |
           # Remove old docker images
-          docker image rm rocm/jax-build:rocm*
+          # TODO: Need to do a string replace . with empty on rocm_version
+          docker images rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }}
           # Make sure we own all the files that we clean up
           docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -43,11 +43,16 @@ jobs:
       RELEASE_DOCKER_IMG_NAME: "rocm/jax-build:rocm${{ inputs.rocm_version}}-jax${{ inputs.jax_version }}-py${{ inputs.python_version }}-${{ github.sha }}"
       WORKSPACE_DIR: workdir_release_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
     steps:
+      - name: Strip . from ROCm version
+        id: strip-rocm-version
+        run: |
+          rocm_version=${{ inputs.rocm_version }}
+          echo "rocm_version=${rocm_version//./}" >> $GITHUB_ENV
       - name: Clean up Docker and old run directories
         run: |
           # Remove old docker images
           # TODO: Need to do a string replace . with empty on rocm_version
-          docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }} || true
+          docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ steps.strip-rocm-version.outputs.rocm_version }} || true
           # Make sure we own all the files that we clean up
           docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -89,13 +89,21 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
-          path: ${{ env.WORKSPACE_DIR }}/dist/*.whl
+          path: ${{ env.WORKSPACE_DIR }}/wheelhouse/*.whl
+          if-no-files-found: error
       - name: Test Docker image
         run: |
           pushd $WORKSPACE_DIR
           # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh
           # in ./build/rocm, which in turn run tests in ./tests with pytest.
           python3 ./build/rocm/ci_build test $RELEASE_DOCKER_IMG_NAME
+      - name: Archive test summary JSON to Github
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: rocm_jax_test_summary.json
+          path: ${{ env.WORKSPACE_DIR }}/logs/final_compiled_report.json
+          if-no-files-found: error
       - name: Publish wheels to PyPI
         run: |
           echo "Not implemeneted yet"

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -51,7 +51,7 @@ jobs:
           # Make sure we own all the files that we clean up
           docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine
-          rm -rf ./workdir_release_*
+          rm -rf ./workdir_release_* || true
       - name: Print system info
         run: |
           pwd

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -49,6 +49,9 @@ jobs:
         run: |
           # Remove old directories and docker images
           echo "Not implemented yet"
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          path: ${{ env.WORKSPACE_DIR }}
       - name: Build plugin wheels and Docker image
         run: |
           pushd $WORKSPACE_DIR

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -1,6 +1,10 @@
 name: ROCm Release JAX
 
 on:
+  # TODO: Remove the push after we find this is working
+  push:
+    branches:
+      - '*'
   workflow_dispatch:
     inputs:
       jax_version:

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -36,8 +36,17 @@ jobs:
     runs-on: mi-250
     env:
       RELEASE_DOCKER_IMG_NAME: "rocm/jax-build:rocm${{ inputs.rocm_version}}-jax${{ inputs.jax_version }}-py${{ inputs.python_version }}-${{ github.sha }}"
-      WORKSPACE_DIR: workdir_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
+      WORKSPACE_DIR: workdir_release_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
     steps:
+      - name: Clean up Docker and old run directories
+        run: |
+          # Remove old docker images
+          docker image rm rocm/jax-build:rocm*
+          # Make sure we own all the files that we clean up
+          docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
+          # Remove old work directories from this machine
+          rm -rf workdir_release_*
+          ls
       - name: Print system info
         run: |
           echo RELEASE_DOCKER_IMAGE_NAME=$RELEASE_DOCKER_IMAGE_NAME
@@ -45,10 +54,6 @@ jobs:
           whoami
           df -h
           rocm-smi
-      - name: Clean up Docker and old runs
-        run: |
-          # Remove old directories and docker images
-          echo "Not implemented yet"
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: ${{ env.WORKSPACE_DIR }}
@@ -58,12 +63,12 @@ jobs:
           # Let ci_build script do the build
           python3 ./build/rocm/ci_build \
             --compiler clang \
-            --python-versions ${{ inputs.python_version }} \
-            --rocm-version ${{ inputs.rocm_version }} \
-            --rocm-build-job ${{ inputs.rocm_build_job_name }} \
-            --rocm-build-num ${{ inputs.rocm_build_job_num }} \
+            --python-versions 3.10.12 \ # ${{ inputs.python_version }} \
+            --rocm-version 6.3.3 \ # ${{ inputs.rocm_version }} \
+            --rocm-build-job 1 \ ${{ inputs.rocm_build_job_name }} \
+            --rocm-build-num 2 \ ${{ inputs.rocm_build_job_num }} \
             dist_docker \
-            --image-tag $RELEASE_DOCKER_IMG_NAME
+            --image-tag $RELEASE_DOCKER_IMG_NAME \
       - name: Archive wheels to Github
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -49,12 +49,13 @@ jobs:
           # TODO: Need to do a string replace . with empty on rocm_version
           docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }} || true
           # Make sure we own all the files that we clean up
-          docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
+          docker run -v "./jax:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine
-          rm -rf workdir_release_*
-          ls
+          rm -rf ./jax/workdir_release_*
       - name: Print system info
         run: |
+          pwd
+          ls
           echo RELEASE_DOCKER_IMAGE_NAME=$RELEASE_DOCKER_IMAGE_NAME
           echo WORKSPACE_DIR=$WORKSPACE_DIR
           whoami

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -1,0 +1,74 @@
+name: ROCm Release JAX
+
+on:
+  workflow_dispatch:
+    inputs:
+      jax_version:
+        required: true
+        type: string
+      rocm_version:
+        description: "ROCm version that wheels will be built against and that will be package in the Docker image"
+        required: true
+        type: string
+      rocm_build_job_name:
+        description: "If you want to use an AMD internal build of ROCm, set the name of the Jenkins job that built it"
+        required: false
+        type: string
+      rocm_build_job_num:
+        description: "If you want to use an AMD internal build of ROCm, set the build number of the job that built it"
+        required: false
+        type: string
+      python_version:
+        description: "Python version to include in Docker image"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test-jax:
+    runs-on: mi-250
+  env:
+    RELEASE_DOCKER_IMG_NAME: "rocm/jax-build:rocm${{ inputs.rocm_version}}-jax${{ inputs.jax_version }}-py${{ inputs.python_version }}-${{ github.sha }}"
+    WORKSPACE_DIR: workdir_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
+  steps:
+    - name: Print system info
+      run: |
+        echo RELEASE_DOCKER_IMAGE_NAME=$RELEASE_DOCKER_IMAGE_NAME
+        echo WORKSPACE_DIR=$WORKSPACE_DIR
+        whoami
+        df -h
+        rocm-smi
+    - name: Clean up Docker and old runs
+      run: |
+        # Remove old directories and docker images
+    - name: Build plugin wheels and Docker image
+      run: |
+        # Let ci_build script do the build
+        python3 ./build/rocm/ci_build \
+          --compiler clang \
+          --python-versions ${{ inputs.python_version }} \
+          --rocm-version ${{ inputs.rocm_version }} \
+          --rocm-build-job ${{ inputs.rocm_build_job_name }} \
+          --rocm-build-num ${{ inputs.rocm_build_job_num }} \
+          dist_docker \
+          --image-tag $RELEASE_DOCKER_IMG_NAME
+    - name: Archive wheels to Github
+      uses: actions/upload-artifact@v4
+        with:
+          name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
+          path: ./dist/*.whl
+    - name: Test Docker image
+      run: |
+        # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh
+        # in ./build/rocm, which in turn run tests in ./tests with pytest.
+        python3 ./build/rocm/ci_build test $RELEASE_DOCKER_IMG_NAME
+    - name: Publish wheels to PyPI
+      run: |
+        echo "Not implemeneted yet"
+    - name: Publish Docker image to Docker Hub
+      run: |
+        echo "Not implemented yet"
+

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: "ubuntu:22.04"
         type: string
+      publish_wheels:
+        description: "Should this job publish wheels to PyPI at the end of its run?"
+        required: true
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -73,24 +78,15 @@ jobs:
         run: |
           pushd $WORKSPACE_DIR
           # Let ci_build script do the build
-          python3 ./build/rocm/ci_build \
+            python3 ./build/rocm/ci_build \
             --compiler clang \
-            --base-docker "ubuntu:22.04" \
-            --python-versions 3.10.12 \
-            --rocm-version 6.3.3 \
-            --rocm-build-job "" \
-            --rocm-build-num "" \
+            --base-docker ${{ inputs.base_docker }}
+            --python-versions ${{ inputs.python_version }} \
+            --rocm-version ${{ inputs.rocm_version }} \
+            --rocm-build-job ${{ inputs.rocm_build_job_name }} \
+            --rocm-build-num ${{ inputs.rocm_build_job_num }} \
             dist_docker \
             --image-tag $RELEASE_DOCKER_IMG_NAME
-            #python3 ./build/rocm/ci_build \
-            #--compiler clang \
-            #--base-docker ${{ inputs.base_docker }}
-            #--python-versions ${{ inputs.python_version }} \
-            #--rocm-version ${{ inputs.rocm_version }} \
-            #--rocm-build-job ${{ inputs.rocm_build_job_name }} \
-            #--rocm-build-num ${{ inputs.rocm_build_job_num }} \
-            #dist_docker \
-            #--image-tag $RELEASE_DOCKER_IMG_NAME
       - name: Archive wheels to Github
         uses: actions/upload-artifact@v4
         with:
@@ -111,9 +107,7 @@ jobs:
           path: ./${{ env.WORKSPACE_DIR }}/logs/final_compiled_report.json
           if-no-files-found: error
       - name: Publish wheels to PyPI
+        if: ${{ inputs.publish_wheels }}
         run: |
           echo "Not implemeneted yet"
-      - name: Publish Docker image to Docker Hub
-        run: |
-          echo "Not implemented yet"
 

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           # Remove old docker images
           # TODO: Need to do a string replace . with empty on rocm_version
-          docker images rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }}
+          docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }} || true
           # Make sure we own all the files that we clean up
           docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -89,9 +89,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
-          path: ./dist/*.whl
+          path: ${{ env.WORKSPACE_DIR }}/dist/*.whl
       - name: Test Docker image
         run: |
+          pushd $WORKSPACE_DIR
           # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh
           # in ./build/rocm, which in turn run tests in ./tests with pytest.
           python3 ./build/rocm/ci_build test $RELEASE_DOCKER_IMG_NAME

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -1,10 +1,6 @@
 name: ROCm Release JAX
 
 on:
-  # TODO: Remove the push after we find this is working
-  push:
-    branches:
-      - '*'
   workflow_dispatch:
     inputs:
       jax_version:
@@ -56,7 +52,6 @@ jobs:
       - name: Clean up Docker and old run directories
         run: |
           # Remove old docker images
-          # TODO: Need to do a string replace . with empty on rocm_version
           docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ steps.strip-rocm-version.outputs.rocm_version }} || true
           # Make sure we own all the files that we clean up
           docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -26,6 +26,11 @@ on:
         description: "Python version to include in Docker image"
         required: true
         type: string
+      base_docker:
+        description: "What docker image will the release image be built from?"
+        required: false
+        default: "ubuntu:22.04"
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -64,6 +69,7 @@ jobs:
           # Let ci_build script do the build
           python3 ./build/rocm/ci_build \
             --compiler clang \
+            --base-docker "ubuntu:22.04" \
             --python-versions 3.10.12 \
             --rocm-version 6.3.3 \
             --rocm-build-job "" \
@@ -72,6 +78,7 @@ jobs:
             --image-tag $RELEASE_DOCKER_IMG_NAME
             #python3 ./build/rocm/ci_build \
             #--compiler clang \
+            #--base-docker ${{ inputs.base_docker }}
             #--python-versions ${{ inputs.python_version }} \
             #--rocm-version ${{ inputs.rocm_version }} \
             #--rocm-build-job ${{ inputs.rocm_build_job_name }} \

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -30,45 +30,46 @@ concurrency:
 jobs:
   build-and-test-jax:
     runs-on: mi-250
-  env:
-    RELEASE_DOCKER_IMG_NAME: "rocm/jax-build:rocm${{ inputs.rocm_version}}-jax${{ inputs.jax_version }}-py${{ inputs.python_version }}-${{ github.sha }}"
-    WORKSPACE_DIR: workdir_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
-  steps:
-    - name: Print system info
-      run: |
-        echo RELEASE_DOCKER_IMAGE_NAME=$RELEASE_DOCKER_IMAGE_NAME
-        echo WORKSPACE_DIR=$WORKSPACE_DIR
-        whoami
-        df -h
-        rocm-smi
-    - name: Clean up Docker and old runs
-      run: |
-        # Remove old directories and docker images
-    - name: Build plugin wheels and Docker image
-      run: |
-        # Let ci_build script do the build
-        python3 ./build/rocm/ci_build \
-          --compiler clang \
-          --python-versions ${{ inputs.python_version }} \
-          --rocm-version ${{ inputs.rocm_version }} \
-          --rocm-build-job ${{ inputs.rocm_build_job_name }} \
-          --rocm-build-num ${{ inputs.rocm_build_job_num }} \
-          dist_docker \
-          --image-tag $RELEASE_DOCKER_IMG_NAME
-    - name: Archive wheels to Github
-      uses: actions/upload-artifact@v4
-      with:
-        name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
-        path: ./dist/*.whl
-    - name: Test Docker image
-      run: |
-        # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh
-        # in ./build/rocm, which in turn run tests in ./tests with pytest.
-        python3 ./build/rocm/ci_build test $RELEASE_DOCKER_IMG_NAME
-    - name: Publish wheels to PyPI
-      run: |
-        echo "Not implemeneted yet"
-    - name: Publish Docker image to Docker Hub
-      run: |
-        echo "Not implemented yet"
+    env:
+      RELEASE_DOCKER_IMG_NAME: "rocm/jax-build:rocm${{ inputs.rocm_version}}-jax${{ inputs.jax_version }}-py${{ inputs.python_version }}-${{ github.sha }}"
+      WORKSPACE_DIR: workdir_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
+    steps:
+      - name: Print system info
+        run: |
+          echo RELEASE_DOCKER_IMAGE_NAME=$RELEASE_DOCKER_IMAGE_NAME
+          echo WORKSPACE_DIR=$WORKSPACE_DIR
+          whoami
+          df -h
+          rocm-smi
+      - name: Clean up Docker and old runs
+        run: |
+          # Remove old directories and docker images
+          echo "Not implemented yet"
+      - name: Build plugin wheels and Docker image
+        run: |
+          # Let ci_build script do the build
+          python3 ./build/rocm/ci_build \
+            --compiler clang \
+            --python-versions ${{ inputs.python_version }} \
+            --rocm-version ${{ inputs.rocm_version }} \
+            --rocm-build-job ${{ inputs.rocm_build_job_name }} \
+            --rocm-build-num ${{ inputs.rocm_build_job_num }} \
+            dist_docker \
+            --image-tag $RELEASE_DOCKER_IMG_NAME
+      - name: Archive wheels to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
+          path: ./dist/*.whl
+      - name: Test Docker image
+        run: |
+          # Let ci_build do the testing. By default, it runs run_single_gpu.py and run_multi_gpu.sh
+          # in ./build/rocm, which in turn run tests in ./tests with pytest.
+          python3 ./build/rocm/ci_build test $RELEASE_DOCKER_IMG_NAME
+      - name: Publish wheels to PyPI
+        run: |
+          echo "Not implemeneted yet"
+      - name: Publish Docker image to Docker Hub
+        run: |
+          echo "Not implemented yet"
 

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -51,6 +51,7 @@ jobs:
           echo "Not implemented yet"
       - name: Build plugin wheels and Docker image
         run: |
+          pushd $WORKSPACE_DIR
           # Let ci_build script do the build
           python3 ./build/rocm/ci_build \
             --compiler clang \

--- a/.github/workflows/rocm-release-jax.yml
+++ b/.github/workflows/rocm-release-jax.yml
@@ -49,9 +49,9 @@ jobs:
           # TODO: Need to do a string replace . with empty on rocm_version
           docker image rm jax-build-manylinux_2_28_x86_64_rocm${{ inputs.rocm_version }} || true
           # Make sure we own all the files that we clean up
-          docker run -v "./jax:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
+          docker run -v "./:/jax" ubuntu /bin/bash -c "chown -R $UID /jax/workdir_release_* || true"
           # Remove old work directories from this machine
-          rm -rf ./jax/workdir_release_*
+          rm -rf ./workdir_release_*
       - name: Print system info
         run: |
           pwd
@@ -90,7 +90,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rocm_jax_r${{ inputs.rocm_version }}_py${{ inputs.python_version }}_id${{ github.run_id }}
-          path: ${{ env.WORKSPACE_DIR }}/wheelhouse/*.whl
+          path: ./${{ env.WORKSPACE_DIR }}/wheelhouse/*.whl
           if-no-files-found: error
       - name: Test Docker image
         run: |
@@ -103,7 +103,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: rocm_jax_test_summary.json
-          path: ${{ env.WORKSPACE_DIR }}/logs/final_compiled_report.json
+          path: ./${{ env.WORKSPACE_DIR }}/logs/final_compiled_report.json
           if-no-files-found: error
       - name: Publish wheels to PyPI
         run: |


### PR DESCRIPTION
Port over the Jenkins CI job used to build new releases of JAX over to Github Actions. This adds a new workflow that can be run manually through the Actions tab in this repo. The workflow builds the necessary Python wheels and a Docker image with the wheels installed. It then runs our full suite of tests on the Docker image and pushes the Docker image to Dockerhub.