### PR TITLE
Ignore future scipy warning and not treat it as an error

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2005,6 +2005,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     self.assertAllClose(root, expected, check_dtypes=False)
 
+  @jtu.ignore_warning(category=FutureWarning, message="Don't treat future SciPy warning as error")
   @jtu.sample_product(
     cshape=[(), (4,), (8,), (3, 7), (0, 5, 1)],
     cdtype=float_types + complex_types,


### PR DESCRIPTION
Context ->

Treat following warning and gracefully ignore it ->

```
FutureWarning: Beginning in SciPy 1.17, multidimensional input will be treated as a batch, not `ravel`ed. To preserve the existing behavior and silence this warning, `ravel` arguments before passing them to `toeplitz`.
```