### PR TITLE
linalg_test testToeplitzConstruction Decorator Fix

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2005,7 +2005,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     self.assertAllClose(root, expected, check_dtypes=False)
 
-  @jtu.ignore_warning(category=FutureWarning, message="Don't treat future SciPy warning as error")
   @jtu.sample_product(
     cshape=[(), (4,), (8,), (3, 7), (0, 5, 1)],
     cdtype=float_types + complex_types,


### PR DESCRIPTION
Having ignore warning decorator before the parameterized test decorator gives an error that tells the ignorewarning decorator hinders the parameterized test creation, hence no tests are ran for testToeplitzConstruction. The extra decorator is removed as Ruturaj created an ignorewarning statement in a finer granularity.