### PR TITLE
Fix circular import in pallas core file

### DIFF
--- a/jax/_src/pallas/mosaic/core.py
+++ b/jax/_src/pallas/mosaic/core.py
@@ -28,7 +28,6 @@ from jax._src import core as jax_core
 from jax._src import dtypes
 from jax._src import util
 from jax._src.pallas import core as pallas_core
-from jax._src.pallas import pallas_call
 import jax.numpy as jnp
 import numpy as np
 


### PR DESCRIPTION
Context:

The test

```
tests/pallas/tpu_pallas_random_test.py::collect
```

is failing due to circular import error. This PR fixes this issue.
