### PR TITLE
fix non-positive determinant error in tests/scipy_spatial_test.py::LaxBackedScipySpatialTransformTests::testRotationFromMatrix0

### DIFF
--- a/tests/scipy_spatial_test.py
+++ b/tests/scipy_spatial_test.py
@@ -196,7 +196,12 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
   )
   def testRotationFromMatrix(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: (rng(shape, dtype),)
+    
+    def args_maker():
+      # Use QR to ensure valid positive-definite rotation matrix.
+      q, _ = onp.linalg.qr(rng(shape, dtype))
+      return [q]
+
     jnp_fn = lambda m: jsp_Rotation.from_matrix(m).as_rotvec()
     np_fn = lambda m: osp_Rotation.from_matrix(m).as_rotvec().astype(dtype)
     self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=True, tol=1e-4)


### PR DESCRIPTION
The error was: ValueError: Non-positive determinant (left-handed or null coordinate frame) in rotation matrix 0: [[ 0.35880703 -7.94366074  0.82442355]
fixing it by changing the lambda function. 