### PR TITLE
fix non-positive determinant error in tests/scipy_spatial_test.py::...::testRotationFromMatrix0

### DIFF
--- a/tests/scipy_spatial_test.py
+++ b/tests/scipy_spatial_test.py
@@ -196,7 +196,10 @@ class LaxBackedScipySpatialTransformTests(jtu.JaxTestCase):
   )
   def testRotationFromMatrix(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
-    args_maker = lambda: (rng(shape, dtype),)
+    def args_maker():
+      # Use QR to ensure valid positive-definite rotation matrix.
+      q, _ = onp.linalg.qr(rng(shape, dtype))
+      return [q]
     jnp_fn = lambda m: jsp_Rotation.from_matrix(m).as_rotvec()
     np_fn = lambda m: osp_Rotation.from_matrix(m).as_rotvec().astype(dtype)
     self._CheckAgainstNumpy(np_fn, jnp_fn, args_maker, check_dtypes=True, tol=1e-4)


### PR DESCRIPTION
(cherry picked from commit 4d433d063e2274d2998913d615aa168889a91b9a)