### PR TITLE
adding jax unit test tridiagonal for rocm platform

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1809,7 +1809,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       dtype=float_types + complex_types,
       lower=[False, True],
   )
-  @jtu.skip_on_devices("tpu","rocm")
+  @jtu.skip_on_devices("tpu")
   def testTridiagonal(self, shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
     def jax_func(a):


### PR DESCRIPTION
Test were blocked initially due to a corner case issue in hipSolver libaray, (https://ontrack-internal.amd.com/browse/SWDEV-445494), tests passing after issue is fixed and available in rocm-6.3 onward...

tests/linalg_test.py::ScipyLinalgTest::testTridiagonal0 PASSED                                                                                                               [ 10%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal1 PASSED                                                                                                               [ 20%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal2 PASSED                                                                                                               [ 30%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal3 PASSED                                                                                                               [ 40%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal4 PASSED                                                                                                               [ 50%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal5 PASSED                                                                                                               [ 60%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal6 PASSED                                                                                                               [ 70%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal7 PASSED                                                                                                               [ 80%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal8 PASSED                                                                                                               [ 90%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal9 PASSED                                                                                                               [100%]

