### PR TITLE
Make Clang use manylinux C++ standard library

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -23,7 +23,7 @@ jobs:
       BASE_IMAGE: "ubuntu:22.04"
       TEST_IMAGE: ubuntu-jax-${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
       PYTHON_VERSION: "3.10"
-      ROCM_VERSION: "6.2.4"
+      ROCM_VERSION: "6.3.3"
       WORKSPACE_DIR: workdir_${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
     steps:
       - name: Clean up old runs

--- a/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
+++ b/build/rocm/build_wheels/Dockerfile.manylinux_2_28_x86_64.rocm
@@ -6,7 +6,7 @@ ARG ROCM_BUILD_NUM
 
 # Install system GCC and C++ libraries, and build deps
 RUN --mount=type=cache,target=/var/cache/dnf \
-    dnf install -y gcc-c++.x86_64 patchelf numactl-devel
+    dnf install -y numactl-devel
 
 RUN --mount=type=cache,target=/var/cache/dnf \
     --mount=type=bind,source=build/rocm/tools/get_rocm.py,target=get_rocm.py \
@@ -21,6 +21,12 @@ RUN --mount=type=cache,target=/var/cache/dnf \
 RUN mkdir /tmp/llvm-project && wget -qO - https://github.com/llvm/llvm-project/archive/refs/tags/llvmorg-18.1.8.tar.gz | tar -xz -C /tmp/llvm-project --strip-components 1 && \
     mkdir /tmp/llvm-project/build && cd /tmp/llvm-project/build && cmake -DLLVM_ENABLE_PROJECTS='clang;lld' -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr/lib/llvm-18/ ../llvm && \
     make -j$(nproc) && make -j$(nproc) install && rm -rf /tmp/llvm-project
+
+# Set some clang config
+COPY ./build/rocm/build_wheels/clang.cfg /usr/lib/llvm-18/bin/clang++.cfg
+COPY ./build/rocm/build_wheels/clang.cfg /usr/lib/llvm-18/bin/clang.cfg
+COPY ./build/rocm/build_wheels/clang.cfg /opt/rocm/llvm/bin/clang++.cfg
+COPY ./build/rocm/build_wheels/clang.cfg /opt/rocm/llvm/bin/clang.cfg
 
 # Stop git from erroring out when we don't own the repo
 RUN git config --global --add safe.directory '*'

--- a/build/rocm/build_wheels/clang.cfg
+++ b/build/rocm/build_wheels/clang.cfg
@@ -1,0 +1,3 @@
+# Tell clang where it can find gcc so that it can use gcc's standard libraries
+--gcc-toolchain=/opt/rh/gcc-toolset-14/root/usr/
+

--- a/build/rocm/ci_build
+++ b/build/rocm/ci_build
@@ -98,7 +98,10 @@ def dist_wheels(
 
     bw_cmd.append("/jax")
 
-    cmd = ["docker", "run"]
+    cmd = [
+        "docker",
+        "run",
+    ]
 
     mounts = [
         "-v",

--- a/build/rocm/tools/fixwheel.py
+++ b/build/rocm/tools/fixwheel.py
@@ -87,7 +87,7 @@ def fix_wheel(path):
     exclude = list(ext_libs.keys())
 
     # call auditwheel repair with excludes
-    cmd = ["auditwheel", "repair", "--plat", plat, "--only-plat"]
+    cmd = ["auditwheel", "-v", "repair", "--plat", plat, "--only-plat"]
 
     for ex in exclude:
         cmd.append("--exclude")


### PR DESCRIPTION
Get rid of our hacky GCC install to get C++ standard library and tell Clang to use the standard library found in the manylinux image.

Story: https://github.com/ROCm/jax-internal/issues/75
Cherry-pick from: https://github.com/jax-ml/jax/pull/28041