### PR TITLE
[0.5.0-UT] unskip more tests that are passing

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1562,7 +1562,6 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testPoly(self, a_shape, dtype, rank):
-    self.skipTest("Skip Poly tests on ROCm")
     if dtype in (np.float16, jnp.bfloat16, np.int16):
       self.skipTest(f"{dtype} gets promoted to {np.float16}, which is not supported.")
     elif rank == 2 and not jtu.test_device_matches(["cpu", "gpu"]):

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -361,7 +361,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   @jtu.run_on_devices("cpu", "gpu")
   def testEigvalsInf(self):
-    self.skipTest("Skip test on ROCm")
+    #self.skipTest("Skip test on ROCm")
     # https://github.com/jax-ml/jax/issues/2661
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")
@@ -2027,12 +2027,12 @@ class ScipyLinalgTest(jtu.JaxTestCase):
 
     self.assertAllClose(root, expected, check_dtypes=False)
 
-  @jtu.ignore_warning(category=FutureWarning, message="Don't treat future SciPy warning as error")
   @jtu.sample_product(
     cshape=[(), (4,), (8,), (4, 7), (2, 1, 5)],
     cdtype=float_types + complex_types,
     rshape=[(), (3,), (7,), (4, 4), (2, 4, 0)],
     rdtype=float_types + complex_types + int_types)
+  @jtu.ignore_warning(category=FutureWarning, message="Don't treat future SciPy warning as error")
   def testToeplitzConstruction(self, rshape, rdtype, cshape, cdtype):
     if ((rdtype in [np.float64, np.complex128]
          or cdtype in [np.float64, np.complex128])

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -361,7 +361,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
 
   @jtu.run_on_devices("cpu", "gpu")
   def testEigvalsInf(self):
-    #self.skipTest("Skip test on ROCm")
     # https://github.com/jax-ml/jax/issues/2661
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -268,7 +268,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jtu.run_on_devices("cpu", "gpu")
   def testEig(self, shape, dtype, compute_left_eigenvectors,
               compute_right_eigenvectors):
-    self.skipTest("Skip Linalg Eig tests on ROCm")
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")
     rng = jtu.rand_default(self.rng())
@@ -313,7 +312,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   def testEigHandlesNanInputs(self, shape, dtype, compute_left_eigenvectors,
                               compute_right_eigenvectors):
     """Verifies that `eig` fails gracefully if given non-finite inputs."""
-    self.skipTest("Skip tests on ROCm")
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")
     a = jnp.full(shape, jnp.nan, dtype)
@@ -329,7 +327,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
  )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigvalsGrad(self, shape, dtype):
-    self.skipTest("Skip tests on ROCm")
     # This test sometimes fails for large matrices. I (@j-towns) suspect, but
     # haven't checked, that might be because of perturbations causing the
     # ordering of eigenvalues to change, which will trip up check_grads. So we
@@ -349,7 +346,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigvals(self, shape, dtype):
-    self.skipTest("Skip tests on ROCm")
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")
     rng = jtu.rand_default(self.rng())
@@ -373,7 +369,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("cpu", "gpu")
   def testEigBatching(self, shape, dtype):
-    self.skipTest("Skip on ROCm")
     if jtu.test_device_matches(["gpu"]) and jtu.jaxlib_version() <= (0, 4, 35):
       self.skipTest("eig on GPU requires jaxlib version > 0.4.35")
     rng = jtu.rand_default(self.rng())
@@ -518,7 +513,6 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       rank=[1, 3, 299],
   )
   def testEighRankDeficient(self, rank):
-    self.skipTest("Skip test on ROCm")
     rng = jtu.rand_default(self.rng())
     eps = jnp.finfo(np.float32).eps
     a = rng((300, rank), dtype=np.float32)

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -85,7 +85,6 @@ class DistributedTest(jtu.JaxTestCase):
 class MultiProcessGpuTest(jtu.JaxTestCase):
 
   def test_gpu_distributed_initialize(self):
-    self.skipTest("Skip on ROCm")
     if not jtu.test_device_matches(['gpu']):
       raise unittest.SkipTest('Tests only for GPU.')
 

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -239,7 +239,6 @@ class FusedAttentionTest(PallasBaseTest):
       causal,
       use_segment_ids,
   ):
-    self.skipTest("Skip tests on ROCm")
     k1, k2, k3 = random.split(random.key(0), 3)
     q = random.normal(
         k1, (batch_size, seq_len, num_heads, head_dim), dtype=jnp.float16

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -526,8 +526,6 @@ class OpsTest(PallasBaseTest):
   )
   @hp.given(hps.data())
   def test_unary_primitives(self, name, func, shape_dtype_strategy, data):
-    if name == "exp" or name == "logistic":
-      self.skipTest("Skip on ROCm")
     if self.INTERPRET:
       self.skipTest("This hypothesis test is slow, even more so in interpret mode.")
     # We want exact equality here to match how JAX lowers to XLA
@@ -866,8 +864,6 @@ class OpsTest(PallasBaseTest):
       for fn, dtype in itertools.product(*args)
   )
   def test_elementwise(self, fn, dtype):
-    if (dtype == "int32"): 
-      self.skipTest("Failing on ROCm")
     if not jax.config.x64_enabled and jnp.dtype(dtype).itemsize == 8:
       self.skipTest("64-bit types require x64_enabled")
 
@@ -1811,8 +1807,6 @@ class OpsTest(PallasBaseTest):
       ("min_f32", pl.atomic_min, np.array([-2, -1, 0, 1], np.float32), np.min),
   )
   def test_scalar_atomic(self, op, value, numpy_op):
-    if (numpy_op.__name__ == "max" or numpy_op.__name__ == "min"):
-      self.skipTest("Not supported on ROCm")
     # The Pallas TPU lowering currently supports only blocks of rank >= 1
     if jtu.test_device_matches(["tpu"]):
       self.skipTest("Not supported on TPU")


### PR DESCRIPTION
Removed skips on several unit tests in tests/linalg_test.py, tests/pallas/ops_test.py and tests/multiprocess_gpu_test.py. 