### PR TITLE
Skip CSR matmat and matvec float tests on ROCm <6.4 (NaN issue with beta==0)

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -219,8 +219,11 @@ class cuSparseTest(sptu.SparseTestCase):
     transpose=[True, False],
   )
   def test_csr_matvec(self, shape, dtype, transpose):
-    rocm_ver = get_rocm_version()
-    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+    if (
+        jtu.is_device_rocm() and
+        rocm_ver < (6, 4) and
+        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
+    ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
 
     op = lambda M: M.T if transpose else M
@@ -243,8 +246,11 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   def test_csr_matmat(self, shape, dtype, transpose):
-    rocm_ver = get_rocm_version()
-    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+    if (
+        jtu.is_device_rocm() and
+        rocm_ver < (6, 4) and
+        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
+    ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
 
     op = lambda M: M.T if transpose else M

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -16,6 +16,8 @@ import contextlib
 from functools import partial
 import itertools
 import math
+import os
+from pathlib import Path
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -41,6 +43,15 @@ import jax.numpy as jnp
 from jax.util import split_list
 import numpy as np
 import scipy.sparse
+
+def get_rocm_version():
+  rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
+  version_path = Path(rocm_path) / ".info" / "version"
+  if not version_path.exists():
+    raise FileNotFoundError(f"Expected ROCm version file at {version_path}")
+  version_str = version_path.read_text().strip()
+  major, minor, *_ = version_str.split(".")
+  return int(major), int(minor)
 
 jax.config.parse_flags_with_absl()
 
@@ -208,6 +219,10 @@ class cuSparseTest(sptu.SparseTestCase):
     transpose=[True, False],
   )
   def test_csr_matvec(self, shape, dtype, transpose):
+    rocm_ver = get_rocm_version()
+    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+      self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
+
     op = lambda M: M.T if transpose else M
 
     v_rng = jtu.rand_default(self.rng())
@@ -228,6 +243,10 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   def test_csr_matmat(self, shape, dtype, transpose):
+    rocm_ver = get_rocm_version()
+    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+      self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
+
     op = lambda M: M.T if transpose else M
 
     B_rng = jtu.rand_default(self.rng())

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -221,7 +221,7 @@ class cuSparseTest(sptu.SparseTestCase):
   def test_csr_matvec(self, shape, dtype, transpose):
     if (
         jtu.is_device_rocm() and
-        rocm_ver < (6, 4) and
+        get_rocm_version() < (6, 4) and
         dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
     ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
@@ -248,7 +248,7 @@ class cuSparseTest(sptu.SparseTestCase):
   def test_csr_matmat(self, shape, dtype, transpose):
     if (
         jtu.is_device_rocm() and
-        rocm_ver < (6, 4) and
+        get_rocm_version() < (6, 4) and
         dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
     ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")


### PR DESCRIPTION
Older versions of rocSPARSE (<6.4) did not zero out memory when beta==0, which could allow NaNs to propagate through

(cherry picked from commit 51b4c6767fd1aa23a43411dc0cc989b1e1a60073)