### PR TITLE
Add linear algebra tests to our CI workflow

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -68,5 +68,5 @@ jobs:
           GFX: "gfx90a"
         run: |
           cd $WORKSPACE_DIR
-          python3 build/rocm/ci_build test $TEST_IMAGE --test-cmd "pytest tests/core_test.py"
+          python3 build/rocm/ci_build test $TEST_IMAGE --test-cmd "pytest tests/core_test.py tests/linalg_test.py"
 


### PR DESCRIPTION
The linear algebra tests check that basic matrix operations work on AMD GPUs. We've found that these catch a lot of basic issues with the JAX plugin and the tests don't take long to run, so they'd be useful in CI.