### PR TITLE
Add is_device_rocm() check to CSR matmat and matvec test skip conditions (#384)

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -219,8 +219,11 @@ class cuSparseTest(sptu.SparseTestCase):
     transpose=[True, False],
   )
   def test_csr_matvec(self, shape, dtype, transpose):
-    rocm_ver = get_rocm_version()
-    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+    if (
+        jtu.is_device_rocm() and
+        rocm_ver < (6, 4) and
+        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
+    ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
 
     op = lambda M: M.T if transpose else M
@@ -243,8 +246,11 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   def test_csr_matmat(self, shape, dtype, transpose):
-    rocm_ver = get_rocm_version()
-    if rocm_ver < (6, 4) and dtype in (jtu.dtypes.floating + jtu.dtypes.complex):
+    if (
+        jtu.is_device_rocm() and
+        rocm_ver < (6, 4) and
+        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
+    ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
 
     op = lambda M: M.T if transpose else M

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -221,7 +221,7 @@ class cuSparseTest(sptu.SparseTestCase):
   def test_csr_matvec(self, shape, dtype, transpose):
     if (
         jtu.is_device_rocm() and
-        rocm_ver < (6, 4) and
+        get_rocm_version() < (6, 4) and
         dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
     ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
@@ -248,7 +248,7 @@ class cuSparseTest(sptu.SparseTestCase):
   def test_csr_matmat(self, shape, dtype, transpose):
     if (
         jtu.is_device_rocm() and
-        rocm_ver < (6, 4) and
+        get_rocm_version() < (6, 4) and
         dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
     ):
       self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")


### PR DESCRIPTION
Cherry-pick back from rocm-main as CI tests caught an issue, include reverted change