### PR TITLE
[0.5.0-UT] adding jax unit test tridiagonal for rocm platform

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1788,7 +1788,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       dtype=float_types + complex_types,
       lower=[False, True],
   )
-  @jtu.skip_on_devices("tpu","rocm")
+  @jtu.skip_on_devices("tpu")
   def testTridiagonal(self, shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
     def jax_func(a):


### PR DESCRIPTION
Cherry picked from commit [4e3ae88](https://github.com/ROCm/jax/pull/369/commits/4e3ae8896b6a9798e63872b7916aca8cce579d56)