### PR TITLE
[0.5.0-UT] Cherry pick 0.5.0 UTs

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2064,6 +2064,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     cdtype=float_types + complex_types,
     rshape=[(), (3,), (7,), (4, 4), (2, 4, 0)],
     rdtype=float_types + complex_types + int_types)
+  @jtu.ignore_warning(category=FutureWarning, message="Don't treat future SciPy warning as error")
   def testToeplitzConstruction(self, rshape, rdtype, cshape, cdtype):
     if ((rdtype in [np.float64, np.complex128]
          or cdtype in [np.float64, np.complex128])


### PR DESCRIPTION
Unskip tests in tests/lax_numpy_test and tests/pallas/gpy_ops_test.py (were skipped in 4.35-qa) and fix decorator order in tests/linalg_test
(cherry picked from commit 847bda761d876c356e154881c71998847e161df7)