### PR TITLE
[0.5.0-UT] skipped testDotProductAttention on 0.5.0

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -61,6 +61,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
+    if jtu.is_device_rocm:
+      self.skipTest("Skip on ROCm")
     if impl == 'cudnn' and not _is_required_cudnn_version_satisfied(8904):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
     if impl == 'cudnn' and dtype == jnp.float32:

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -61,8 +61,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
-    if jtu.is_device_rocm:
-      self.skipTest("Skip on ROCm")
+    if dtype == jax.dtypes.bfloat16 and jtu.is_device_rocm:
+      self.skipTest("Skip bfloat16 tests on ROCm")
     if impl == 'cudnn' and not _is_required_cudnn_version_satisfied(8904):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")
     if impl == 'cudnn' and dtype == jnp.float32:


### PR DESCRIPTION
Skipping this test as it will be triaged in 0.6.0 later. (Has seg fault)