### PR TITLE
Build with ROCm 7.0 on new runner

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -18,11 +18,11 @@ concurrency:
 
 jobs:
   build-jax-in-docker:
-    runs-on:  mi-250
+    runs-on: internal
     strategy:
       matrix:
         python: ["3.10.13"]
-        rocm: ["6.2.4", "6.3.3"]
+        rocm: ["7.0"]
     env:
       BASE_IMAGE: "ubuntu:22.04"
       TEST_IMAGE: ubuntu-jax-${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}
@@ -43,7 +43,7 @@ jobs:
           whoami
           printenv
           df -h
-          rocm-smi
+          rocm-smi || true
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           path: ${{ env.WORKSPACE_DIR }}
@@ -52,6 +52,8 @@ jobs:
           pushd $WORKSPACE_DIR
           python3 build/rocm/ci_build \
             --rocm-version $ROCM_VERSION \
+            --rocm-build-job "compute-rocm-dkms-no-npi-hipclang" \
+            --rocm-build-num "16118" \
             --base-docker $BASE_IMAGE \
             --python-versions $PYTHON_VERSION \
             --compiler=clang \


### PR DESCRIPTION
Use the internal runner and use an internal ROCm build