### PR TITLE
Add missing header `warnings` for test_util.py

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -34,6 +34,7 @@ import textwrap
 import threading
 from typing import Any, TextIO
 import unittest
+import warnings
 import zlib
 
 from absl.testing import parameterized


### PR DESCRIPTION
The header is used in get_rocm_version().