### PR TITLE
SWDEV-512768 - Replace hipGetLastError with hipExtGetLastError

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -661,7 +661,7 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_STREAM_NON_BLOCKING hipStreamNonBlocking
 
 #define gpuMalloc hipMalloc
-#define gpuGetLastError hipGetLastError
+#define gpuGetLastError hipExtGetLastError
 #define gpuGetErrorString hipGetErrorString
 #define gpuMemcpyAsync hipMemcpyAsync
 #define gpuMemcpyDeviceToDevice hipMemcpyDeviceToDevice


### PR DESCRIPTION
 hipGetLastError behavior is going to be changed to match the CUDA behavior. As per CUDA spec, the API is supposed to track the last failure reported in the thread while our current implementation is tracking the error code of the last API executed in the thread. So in 7.0, we will match CUDA behavior.

But since some internally developed components might be relying on the current behavior of hipGetLastError requiring them to re-design parts of their codes, we have introduced hipExtGetLastError which is an AMD-only HIP API which will retain the pre-7.0 behavior of hipGetLastError.