### PR TITLE
SWDEV-512768 - Replace hipGetLastError with hipExtGetLastError

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -661,7 +661,7 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_STREAM_NON_BLOCKING hipStreamNonBlocking
 
 #define gpuMalloc hipMalloc
-#define gpuGetLastError hipGetLastError
+#define gpuGetLastError hipExtGetLastError
 #define gpuGetErrorString hipGetErrorString
 #define gpuMemcpyAsync hipMemcpyAsync
 #define gpuMemcpyDeviceToDevice hipMemcpyDeviceToDevice


### PR DESCRIPTION
(cherry picked from commit a42f4722150f4dfc97fae38a12b8aa050d9f5f60)