### PR TITLE
Fix namespace rocm7 v2

### DIFF
--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -23,7 +23,7 @@ import jax._src.xla_bridge as xb
 
 # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax rocm plugin packages.
-for pkg_name in ['jax_rocm60_plugin', 'jaxlib.cuda']:
+for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.cuda']:
   try:
     rocm_plugin_extension = importlib.import_module(
         f'{pkg_name}.rocm_plugin_extension'

--- a/jaxlib/BUILD
+++ b/jaxlib/BUILD
@@ -34,7 +34,7 @@ licenses(["notice"])
 
 package(
     default_applicable_licenses = [],
-    default_visibility = ["//jax:internal"],
+    default_visibility = ["//visibility:public"],
 )
 
 py_library_providing_imports_info(

--- a/jaxlib/gpu/solver_interface.cc
+++ b/jaxlib/gpu/solver_interface.cc
@@ -62,8 +62,8 @@ JAX_GPU_DEFINE_GETRF(gpuDoubleComplex, gpusolverDnZgetrf);
 
 JAX_GPU_DEFINE_GETRF_BATCHED(float, gpublasSgetrfBatched);
 JAX_GPU_DEFINE_GETRF_BATCHED(double, gpublasDgetrfBatched);
-JAX_GPU_DEFINE_GETRF_BATCHED(gpublasComplex, gpublasCgetrfBatched);
-JAX_GPU_DEFINE_GETRF_BATCHED(gpublasDoubleComplex, gpublasZgetrfBatched);
+JAX_GPU_DEFINE_GETRF_BATCHED(gpuComplex, gpublasCgetrfBatched);
+JAX_GPU_DEFINE_GETRF_BATCHED(gpuDoubleComplex, gpublasZgetrfBatched);
 #undef JAX_GPU_DEFINE_GETRF_BATCHED
 
 // QR decomposition: geqrf
@@ -101,8 +101,8 @@ JAX_GPU_DEFINE_GEQRF(gpuDoubleComplex, gpusolverDnZgeqrf);
 
 JAX_GPU_DEFINE_GEQRF_BATCHED(float, gpublasSgeqrfBatched);
 JAX_GPU_DEFINE_GEQRF_BATCHED(double, gpublasDgeqrfBatched);
-JAX_GPU_DEFINE_GEQRF_BATCHED(gpublasComplex, gpublasCgeqrfBatched);
-JAX_GPU_DEFINE_GEQRF_BATCHED(gpublasDoubleComplex, gpublasZgeqrfBatched);
+JAX_GPU_DEFINE_GEQRF_BATCHED(gpuComplex, gpublasCgeqrfBatched);
+JAX_GPU_DEFINE_GEQRF_BATCHED(gpuDoubleComplex, gpublasZgeqrfBatched);
 #undef JAX_GPU_DEFINE_GEQRF_BATCHED
 
 // Householder transformations: orgqr
@@ -232,8 +232,8 @@ JAX_GPU_DEFINE_SYEVD(gpuDoubleComplex, gpusolverDnZheevd);
 
 JAX_GPU_DEFINE_SYRK(float, gpublasSsyrk);
 JAX_GPU_DEFINE_SYRK(double, gpublasDsyrk);
-JAX_GPU_DEFINE_SYRK(gpublasComplex, gpublasCsyrk);
-JAX_GPU_DEFINE_SYRK(gpublasDoubleComplex, gpublasZsyrk);
+JAX_GPU_DEFINE_SYRK(gpuComplex, gpublasCsyrk);
+JAX_GPU_DEFINE_SYRK(gpuDoubleComplex, gpublasZsyrk);
 #undef JAX_GPU_DEFINE_SYRK
 
 // Singular Value Decomposition: gesvd

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -403,7 +403,9 @@ constexpr uint32_t kNumThreadsPerWarp = 32;
 }  // namespace jax::JAX_GPU_NAMESPACE
 
 #elif defined(JAX_GPU_HIP)
+
 #define HIPBLAS_V2 1
+
 // IWYU pragma: begin_exports
 #include "rocm/include/hip/hip_cooperative_groups.h"
 #include "rocm/include/hip/hip_runtime_api.h"
@@ -423,12 +425,12 @@ constexpr uint32_t kNumThreadsPerWarp = 32;
 // TODO(Ruturaj4): Currently equivalent API does exist in
 // MIOpen lib. Remove when MIOpen support is complete.
 #define MIOPEN_STATUS_SUCCESS 0
-// TODO(PhamBinh): Figure out later to use hipComplex or hipFloatComplex
-typedef hipFloatComplex gpuComplex;
-typedef hipDoubleComplex gpuDoubleComplex;
 
-typedef hipFloatComplex gpublasComplex;
+typedef hipComplex gpuComplex;
+typedef hipDoubleComplex gpuDoubleComplex;
+typedef hipComplex gpublasComplex;
 typedef hipDoubleComplex gpublasDoubleComplex;
+
 typedef hipsolverHandle_t gpusolverDnHandle_t;
 typedef hipblasFillMode_t gpublasFillMode_t;
 typedef hipsolverFillMode_t gpusolverFillMode_t;

--- a/jaxlib/plugin_support.py
+++ b/jaxlib/plugin_support.py
@@ -22,8 +22,8 @@ from .version import __version__ as jaxlib_version
 
 
 _PLUGIN_MODULE_NAME = {
-    "cuda": "jax_cuda12_plugin",
-    "rocm": "jax_rocm60_plugin",
+    "cuda": ["jax_cuda12_plugin"],
+    "rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"],
 }
 
 
@@ -47,7 +47,7 @@ def import_from_plugin(
   if plugin_name not in _PLUGIN_MODULE_NAME:
     raise ValueError(f"Unknown plugin: {plugin_name}")
   return maybe_import_plugin_submodule(
-      [f".{plugin_name}", _PLUGIN_MODULE_NAME[plugin_name]],
+      [f".{plugin_name}", *_PLUGIN_MODULE_NAME[plugin_name]],
       submodule_name,
       check_version=check_version,
   )

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -387,6 +387,7 @@ nanobind_extension(
         ":hip_vendor",
         "//jaxlib:kernel_nanobind_helpers",
         "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip",
         "@nanobind",
     ],
 )
@@ -429,6 +430,7 @@ nanobind_extension(
         "//jaxlib/cpu:lapack_kernels",
         "@com_google_absl//absl/base",
         "@local_config_rocm//rocm:rocm_headers",
+        "@local_config_rocm//rocm:hip",
         "@nanobind",
         "@xla//xla/ffi/api:ffi",
     ],
@@ -501,6 +503,7 @@ nanobind_extension(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
+        "@local_config_rocm//rocm:hip",
         "@nanobind",
     ],
 )

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -26,7 +26,7 @@ licenses(["notice"])
 
 package(
     default_applicable_licenses = [],
-    default_visibility = ["//:__subpackages__"],
+    default_visibility = ["//visibility:public"],
 )
 
 cc_library(
@@ -433,10 +433,6 @@ nanobind_extension(
         "@local_config_rocm//rocm:hip",
         "@nanobind",
         "@xla//xla/ffi/api:ffi",
-    ],
-    linkopts = [
-        "-L/opt/rocm/lib",  #/opt/rocm/lib64 
-        "-lamdhip64",       
     ],
 )
 


### PR DESCRIPTION
With this PR, I cherry-picked the hipBLAS V2 commit and fixed the namespace issue. Now, JAX builds with --rocm_version=7 and runs fine.