### PR TITLE
add rocprofiler_configure as a global

### DIFF
--- a/jaxlib/tools/gpu_version_script.lds
+++ b/jaxlib/tools/gpu_version_script.lds
@@ -4,6 +4,7 @@ VERS_1.0 {
       GetPjrtApi;
       MosaicGpuCompile;
       MosaicGpuUnload;
+      rocprofiler_configure;
     };
 
   local:


### PR DESCRIPTION
- `rocprofiler_configure` is required to initialized rocprofiler-sdk for tracing HIP events. 