### PR TITLE
add rocprofiler_configure as a global

### DIFF
--- a/jax/_src/profiler.py
+++ b/jax/_src/profiler.py
@@ -444,8 +444,7 @@ class PGLEProfiler:
         if runner.fdo_profiles[-1] == b'':
           warnings.warn(
               "PGLE collected an empty trace, may be due to contention with "
-              "another tool that subscribes to CUPTI, such as Nsight Systems - check "
-              "for CUPTI_ERROR_MULTIPLE_SUBSCRIBERS_NOT_SUPPORTED from XLA. "
+              "another tool that subscribes to rocprofiler-sdk - check "
               "Consider populating a persistent compilation cache with PGLE enabled, "
               "and then profiling a second run that has the "
               "JAX_COMPILATION_CACHE_EXPECT_PGLE option enabled.",

--- a/jaxlib/tools/gpu_version_script.lds
+++ b/jaxlib/tools/gpu_version_script.lds
@@ -4,6 +4,7 @@ VERS_1.0 {
       GetPjrtApi;
       MosaicGpuCompile;
       MosaicGpuUnload;
+      rocprofiler_configure;
     };
 
   local:

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -245,7 +245,7 @@ class ProfilerTest(unittest.TestCase):
     self.assertEqual(1, len(glob.glob(path)),
                      'Expected one path match: ' + path)
 
-  @unittest.skip("Test causes OOMs")
+  # @unittest.skip("Test causes OOMs")
   @unittest.skipIf(not (portpicker and profiler_client and tf_profiler),
     "Test requires tensorflow.profiler and portpicker")
   def testSingleWorkerSamplingMode(self, delay_ms=None):

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -244,8 +244,7 @@ class ProfilerTest(unittest.TestCase):
     path = os.path.join(logdir, 'plugins', 'profile', '*', '*.xplane.pb')
     self.assertEqual(1, len(glob.glob(path)),
                      'Expected one path match: ' + path)
-
-  # @unittest.skip("Test causes OOMs")
+  
   @unittest.skipIf(not (portpicker and profiler_client and tf_profiler),
     "Test requires tensorflow.profiler and portpicker")
   def testSingleWorkerSamplingMode(self, delay_ms=None):


### PR DESCRIPTION
- rocprofiler_configure is exposed to initialized rocprofiler-sdk to trace HIP events as it is required by rocprofiler-sdk
- enable a previously skipped test as rocprofiler-sdk does not cause OOMs any more https://github.com/ROCm/jax/commit/c8184a87a5902d715d3214eb2c25042792dd5542
- give more appropriate warning message when using PGLE with rocprofiler-sdk