### PR TITLE
[0.6.0-UT] Skip additional tests

### DIFF
--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -79,6 +79,9 @@ class PrimitiveTest(jtu.JaxTestCase):
                "operator to work around missing XLA support for pair-reductions")
   )
   def test_prim(self, harness: test_harnesses.Harness):
+    if jtu.is_device_rocm and "multi_array_shape_complex64" in harness.fullname:
+      self.skipTest("Skip on ROCm: test_prim_multi_array_shape_complex64")
+
     if "eigh_" in harness.fullname:
       self.skipTest("Eigenvalues are sorted and it is not correct to compare "
                     "decompositions for equality.")

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -79,8 +79,8 @@ class PrimitiveTest(jtu.JaxTestCase):
                "operator to work around missing XLA support for pair-reductions")
   )
   def test_prim(self, harness: test_harnesses.Harness):
-    if jtu.is_device_rocm and "multi_array_shape_complex64" in harness.fullname:
-      self.skipTest("Skip on ROCm: test_prim_multi_array_shape_complex64")
+    if jtu.is_device_rocm and "multi_array_shape" in harness.fullname:
+      self.skipTest("Skip on ROCm: test_prim_multi_array_shape")
 
     if "eigh_" in harness.fullname:
       self.skipTest("Eigenvalues are sorted and it is not correct to compare "

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -186,6 +186,8 @@ class FfiTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("gpu", "cpu")
   def test_ffi_call_batching(self, shape, vmap_method):
+    if jtu.is_device_rocm:
+      self.skipTest("Skip on ROCm: test_ffi_call_batching")
     shape = (10,) + shape
     x = self.rng().randn(*shape).astype(np.float32)
     expected = lax_linalg_internal.geqrf(x)

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -188,6 +188,7 @@ class FfiTest(jtu.JaxTestCase):
   def test_ffi_call_batching(self, shape, vmap_method):
     if jtu.is_device_rocm:
       self.skipTest("Skip on ROCm: test_ffi_call_batching")
+
     shape = (10,) + shape
     x = self.rng().randn(*shape).astype(np.float32)
     expected = lax_linalg_internal.geqrf(x)

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -173,6 +173,9 @@ class FfiTest(jtu.JaxTestCase):
   @jtu.sample_product(shape=[(6, 5), (4, 5, 6)])
   @jtu.run_on_devices("gpu", "cpu")
   def test_ffi_call(self, shape):
+    if jtu.is_device_rocm and str(self).split()[0] == "test_ffi_call0":
+      self.skipTest("Skip on ROCm: test_ffi_call0")
+
     x = self.rng().randn(*shape).astype(np.float32)
     expected = lax_linalg_internal.geqrf(x)
     actual = ffi_call_geqrf(x)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2599,6 +2599,8 @@ class LaxControlFlowTest(jtu.JaxTestCase):
   def testAssociativeScanSolvingRegressionTest(self, shape):
     # This test checks that the batching rule doesn't raise for a batch
     # sensitive function (solve).
+    if jtu.is_device_rocm:
+      self.skipTest("Skip on ROCm: testAssociativeScanSolvingRegressionTest")
     ms = np.repeat(np.eye(2).reshape(1, 2, 2), shape, axis=0)
     vs = np.ones((shape, 2))
 

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2601,6 +2601,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
     # sensitive function (solve).
     if jtu.is_device_rocm:
       self.skipTest("Skip on ROCm: testAssociativeScanSolvingRegressionTest")
+
     ms = np.repeat(np.eye(2).reshape(1, 2, 2), shape, axis=0)
     vs = np.ones((shape, 2))
 

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2587,6 +2587,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   def testPolyMul(self, a1_shape, a2_shape, dtype):
     if jtu.is_device_rocm and str(self).split()[0] == "testPolyMul1":
       self.skipTest("Skip on ROCm: testPolyMul")
+
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polymul(arg1, arg2)
     jnp_fun_np = lambda arg1, arg2: jnp.polymul(arg1, arg2, trim_leading_zeros=True)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -2585,6 +2585,8 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     a2_shape=one_dim_array_shapes,
   )
   def testPolyMul(self, a1_shape, a2_shape, dtype):
+    if jtu.is_device_rocm and str(self).split()[0] == "testPolyMul1":
+      self.skipTest("Skip on ROCm: testPolyMul")
     rng = jtu.rand_default(self.rng())
     np_fun = lambda arg1, arg2: np.polymul(arg1, arg2)
     jnp_fun_np = lambda arg1, arg2: jnp.polymul(arg1, arg2, trim_leading_zeros=True)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1006,6 +1006,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testQr(self, shape, dtype, full_matrices):
+    if jtu.is_device_rocm:
+      self.skipTest("Skip on ROCm: tests/linalg_test.py::NumpyLinalgTest::testQr")
+
     if (jtu.test_device_matches(["cuda"]) and
         _is_required_cuda_version_satisfied(12000)):
       self.skipTest("Triggers a bug in cuda-12 b/287345077")
@@ -1081,6 +1084,9 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testQrBatching(self, shape, dtype):
+    if jtu.is_device_rocm:
+      self.skipTest("Skip on ROCm: tests/linalg_test.py::NumpyLinalgTest::testQrBatching")
+
     rng = jtu.rand_default(self.rng())
     args = rng(shape, jnp.float32)
     qs, rs = vmap(jsp.linalg.qr)(args)

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -549,6 +549,8 @@ class PallasCallTest(PallasBaseTest):
   def test_matmul(self, m, n, k, dtype, bm, bn, bk, gm):
     if jtu.test_device_matches(["tpu"]) and not self.INTERPRET:
       self.skipTest("On TPU the test works only in interpret mode")
+    if jtu.is_device_rocm and self.INTERPRET:
+      self.skipTest("Skip on ROCm: test_matmul")                                                                                                                                                   [835/1847]
     k1, k2 = random.split(random.key(0))
     x = random.normal(k1, (m, k), dtype=dtype)
     y = random.normal(k2, (k, n), dtype=dtype)

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -550,7 +550,8 @@ class PallasCallTest(PallasBaseTest):
     if jtu.test_device_matches(["tpu"]) and not self.INTERPRET:
       self.skipTest("On TPU the test works only in interpret mode")
     if jtu.is_device_rocm and self.INTERPRET:
-      self.skipTest("Skip on ROCm: test_matmul")                                                                                                                                                   [835/1847]
+      self.skipTest("Skip on ROCm: test_matmul")
+
     k1, k2 = random.split(random.key(0))
     x = random.normal(k1, (m, k), dtype=dtype)
     y = random.normal(k2, (k, n), dtype=dtype)

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -740,6 +740,9 @@ class DistributionsTest(RandomTestBase):
   )
   @jax.default_matmul_precision("float32")
   def testOrthogonal(self, n, shape, dtype, m):
+    if jtu.is_device_rocm and not (n == 0 or m == 0):
+      self.skipTest("Skip on ROCm: testOrthogonal[1-3, 8-9]")
+
     if m is None:
       m = n
 

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -350,8 +350,8 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
   def testWelchWithDefaultStepArgsAgainstNumpy(
       self, *, shape, dtype, nperseg, noverlap, use_nperseg, use_noverlap,
       use_window, timeaxis):
-    if jtu.is_device_rocm and not use_nperseg:
-      raise unittest.SkipTest("Skip on ROCm: testWelchWithDefaultStepArgsAgainstNumpy[1,2,7,8]")
+    if jtu.is_device_rocm and (not use_nperseg or (use_nperseg and use_noverlap and use_window)):
+      raise unittest.SkipTest("Skip on ROCm: testWelchWithDefaultStepArgsAgainstNumpy[1,2,3,7,8]")
 
     if tuple(shape) == (2, 3, 389, 5) and nperseg == 17 and noverlap == 13:
       raise unittest.SkipTest("Test fails for these inputs")

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -353,7 +353,6 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
     if jtu.is_device_rocm and not use_nperseg:
       raise unittest.SkipTest("Skip on ROCm: testWelchWithDefaultStepArgsAgainstNumpy[1,2,7,8]")
 
-
     if tuple(shape) == (2, 3, 389, 5) and nperseg == 17 and noverlap == 13:
       raise unittest.SkipTest("Test fails for these inputs")
     kwargs = {'axis': timeaxis}

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -350,6 +350,10 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
   def testWelchWithDefaultStepArgsAgainstNumpy(
       self, *, shape, dtype, nperseg, noverlap, use_nperseg, use_noverlap,
       use_window, timeaxis):
+    if jtu.is_device_rocm and not use_nperseg:
+      raise unittest.SkipTest("Skip on ROCm: testWelchWithDefaultStepArgsAgainstNumpy[1,2,7,8]")
+
+
     if tuple(shape) == (2, 3, 389, 5) and nperseg == 17 and noverlap == 13:
       raise unittest.SkipTest("Test fails for these inputs")
     kwargs = {'axis': timeaxis}

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -3624,11 +3624,12 @@ class ShapePolyHarnessesTest(jtu.JaxTestCase):
       #one_containing="",
   )
   def test_harness(self, harness: PolyHarness):
-
-    if jtu.is_device_rocm and harness.group_name == "svd" and harness.dtype in {np.float32, np.complex64}:
-        raise unittest.SkipTest("Skip for ROCm: shape_poly_test svd for float32 and complex64.")
+    if jtu.is_device_rocm and harness.group_name in {"qr", "svd"} and harness.dtype in {np.float32, np.complex64}:
+        raise unittest.SkipTest("Skip for ROCm: shape_poly_test svd and qr for float32 and complex64.")
     if jtu.is_device_rocm and harness.group_name == "vmap_eigh" and harness.dtype == np.complex64:
         raise unittest.SkipTest("Skip for ROCm: shape_poly_test vmap_eigh for complex64.")
+    if jtu.is_device_rocm and "vmap_qr_multi_array" in harness.fullname and harness.dtype == np.float32:
+        raise unittest.SkipTest("Skip for ROCm: shape_poly_test vmap_qr_multi_array for comple64 (note: when printed out, harness.dtype is np.float32.)")
 
     # We do not expect the associative scan error on TPUs
     if harness.expect_error == expect_error_associative_scan and jtu.test_device_matches(["tpu"]):

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -16,6 +16,7 @@ import contextlib
 from functools import partial
 import itertools
 import math
+import unittest
 
 from absl.testing import absltest
 from absl.testing import parameterized
@@ -46,6 +47,7 @@ jax.config.parse_flags_with_absl()
 
 all_dtypes = jtu.dtypes.integer + jtu.dtypes.floating + jtu.dtypes.complex
 
+@unittest.skipIf(jtu.is_device_rocm, "Skip on ROCm: cuSparseTest")
 class cuSparseTest(sptu.SparseTestCase):
   def gpu_dense_conversion_warning_context(self, dtype):
     if jtu.test_device_matches(["gpu"]) and np.issubdtype(dtype, np.integer):
@@ -804,6 +806,7 @@ class SparseGradTest(sptu.SparseTestCase):
         self.assertAllClose(jax.grad(g, argnums=0, has_aux=has_aux)(y, Xtree_de),
                             sparse.grad(g, argnums=0, has_aux=has_aux)(y, Xtree_sp))
 
+@unittest.skipIf(jtu.is_device_rocm, "Skip on ROCm: SparseObjectTest")
 class SparseObjectTest(sptu.SparseTestCase):
   @parameterized.named_parameters(
     {"testcase_name": f"_{cls.__name__}", "cls": cls}


### PR DESCRIPTION
This commit skips additional tests:
tests/export_harnesses_multi_platform_test.py
tests/ffi_test.py
tests/lax_control_flow_test.py
tests/lax_numpy_test.py
tests/linalg_test.py
tests/pallas/pallas_test.py
tests/random_lax_test.py
tests/scipy_signal_test.py
tests/sparse_test.py
