### PR TITLE
Revert "[0.6.0-UT] unskip test_select_n"

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -528,6 +528,8 @@ class OpsTest(PallasBaseTest):
   @hp.given(select_n_strategy(max_cases=2, min_rank=2, max_rank=4,
                               min_size_exp=1))
   def test_select_n(self, args):
+    if jtu.is_device_rocm:
+        self.skipTest("Skip on ROCm: test_select_n")
     pred, *cases = args
     scalar_pred = not pred.shape
 


### PR DESCRIPTION
Reverts ROCm/jax#496. The test is flaky, so skipping it back.