### PR TITLE
Fix test_gpu_distributed_initialize() to get a more proper GPUs number

### DIFF
--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -50,7 +50,7 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
 
     port = portpicker.pick_unused_port()
     # ROCm will fail if HIP_VISIBLE_DEVICES is set to a single non existent device
-    num_gpus = 4 if not jtu.is_device_rocm() else min(4, len(jax.devices()))
+    num_gpus = 4 if not jtu.is_device_rocm() else min(4, jax.local_device_count())
     num_gpus_per_task = 1
     num_tasks = num_gpus // num_gpus_per_task
 


### PR DESCRIPTION
If I'm not mistaken, `HIP_VISIBLE_DEVICES` could only address local devices, hence since it's used later, amount of devices shall be restricted to local only.