### PR TITLE
docs: add notice to README indicating repo is for internal test purposes only

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+> ⚠️ **Note:** This repository is maintained **only for internal ROCm testing purposes**  
+> (e.g., selectively skipping or modifying JAX frontend tests).  
+> **Do not use this repository for development, issue tracking, or contributions.**  
+> Active development has moved to 👉 https://github.com/ROCm/rocm-jax
+
+-------
+
 <div align="center">
 <img src="https://raw.githubusercontent.com/jax-ml/jax/main/images/jax_logo_250px.png" alt="logo"></img>
 </div>


### PR DESCRIPTION
This repo is no longer intended for public development or issue tracking. Added a clear message at the top of the README redirecting users to https://github.com/ROCm/rocm-jax for active development.