### PR TITLE
Bugfix bazel debug rule

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -418,7 +418,7 @@ build:rbe_cross_compile_darwin_x86_64 --config=rbe_cross_compile_base
 #############################################################################
 
 build:debug_symbols --strip=never --per_file_copt="xla/pjrt|xla/python@-g3"
-build:debug --config debug_symbols -c fastbuild
+build:debug --config=debug_symbols -c fastbuild
 
 # Load `.jax_configure.bazelrc` file written by build.py
 try-import %workspace%/.jax_configure.bazelrc


### PR DESCRIPTION
Bazel (likely starting from some version) requires that rules in `.bazelrc` be specified in a one-token format `--variable=value`, instead of old format `--variable value`. This one character change fixes `debug` rule that improperly included `debug_symbols` rule, which caused bazel to fail.