### PR TITLE
[0.6.0-UT] Fix Test Shard

### DIFF
--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -276,10 +276,12 @@ class FfiTest(jtu.JaxTestCase):
 
   @jtu.run_on_devices("gpu", "cpu")
   def test_shard_map(self):
-    if jtu.is_device_rocm:
-        self.skipTest("Skip on ROCm: tests/ffi_test.py::FfiTest::test_shard_map")
+    # if jtu.is_device_rocm:
+    #     self.skipTest("Skip on ROCm: tests/ffi_test.py::FfiTest::test_shard_map")
     mesh = jtu.create_mesh((len(jax.devices()),), ("i",))
     x = self.rng().randn(8, 4, 5).astype(np.float32)
+    n = len(jax.devices())
+    x = x[:(x.shape[0] // n) * n]  
 
     @partial(shard_map, mesh=mesh, in_specs=P("i"), out_specs=P("i"))
     def f(x):


### PR DESCRIPTION
This fix addresses a failure on the MI200 GPU, where the test case was unable to run due to the input array size not being divisible by the number of available GPUs, which is 7 for MI200. The solution trims the input array to ensure its size is divisible by the number of GPUs, allowing for proper distribution across the devices.