### PR TITLE
[0.6.0-UT] Fix is_device_rocm function calls

### DIFF
--- a/tests/debugging_primitives_test.py
+++ b/tests/debugging_primitives_test.py
@@ -806,7 +806,7 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
     self._assertLinesEqual(output(), "hello: 0\nhello: 1\nhello: 2\nhello: 3\n")
 
   def test_unordered_print_with_pjit(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: tests/debugging_primitives_test.py::DebugPrintParallelTest::test_unordered_print_with_pjit")
     def f(x):
       debug_print("{}", x, ordered=False)
@@ -843,7 +843,7 @@ class DebugPrintParallelTest(jtu.JaxTestCase):
     self.assertEqual(output(), "[0 1 2 3 4 5 6 7]\n")
 
   def test_unordered_print_of_pjit_of_while(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: tests/debugging_primitives_test.py::DebugPrintParallelTest::test_unordered_print_of_pjit_of_while")
     def f(x):
       def cond(carry):

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -79,7 +79,7 @@ class PrimitiveTest(jtu.JaxTestCase):
                "operator to work around missing XLA support for pair-reductions")
   )
   def test_prim(self, harness: test_harnesses.Harness):
-    if jtu.is_device_rocm and "multi_array_shape" in harness.fullname:
+    if jtu.is_device_rocm() and "multi_array_shape" in harness.fullname:
       self.skipTest("Skip on ROCm: test_prim_multi_array_shape")
 
     if "eigh_" in harness.fullname:
@@ -194,7 +194,7 @@ class PrimitiveTest(jtu.JaxTestCase):
     self.export_and_compare_to_native(f, x)
 
   def test_random_with_threefry_gpu_kernel_lowering(self):
-    if jtu.is_device_rocm and jtu.get_rocm_version() > (6, 5):
+    if jtu.is_device_rocm() and jtu.get_rocm_version() > (6, 5):
         self.skipTest("Skip on ROCm: test_random_with_threefry_gpu_kernel_lowering")
 
     # On GPU we use a custom call for threefry2x32

--- a/tests/ffi_test.py
+++ b/tests/ffi_test.py
@@ -173,7 +173,7 @@ class FfiTest(jtu.JaxTestCase):
   @jtu.sample_product(shape=[(6, 5), (4, 5, 6)])
   @jtu.run_on_devices("gpu", "cpu")
   def test_ffi_call(self, shape):
-    if jtu.is_device_rocm and str(self).split()[0] == "test_ffi_call0":
+    if jtu.is_device_rocm() and str(self).split()[0] == "test_ffi_call0":
       self.skipTest("Skip on ROCm: test_ffi_call0")
 
     x = self.rng().randn(*shape).astype(np.float32)
@@ -189,7 +189,7 @@ class FfiTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("gpu", "cpu")
   def test_ffi_call_batching(self, shape, vmap_method):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
       self.skipTest("Skip on ROCm: test_ffi_call_batching")
 
     shape = (10,) + shape
@@ -276,7 +276,7 @@ class FfiTest(jtu.JaxTestCase):
 
   @jtu.run_on_devices("gpu", "cpu")
   def test_shard_map(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: tests/ffi_test.py::FfiTest::test_shard_map")
     mesh = jtu.create_mesh((len(jax.devices()),), ("i",))
     x = self.rng().randn(8, 4, 5).astype(np.float32)

--- a/tests/lax_control_flow_test.py
+++ b/tests/lax_control_flow_test.py
@@ -2599,7 +2599,7 @@ class LaxControlFlowTest(jtu.JaxTestCase):
   def testAssociativeScanSolvingRegressionTest(self, shape):
     # This test checks that the batching rule doesn't raise for a batch
     # sensitive function (solve).
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
       self.skipTest("Skip on ROCm: testAssociativeScanSolvingRegressionTest")
 
     ms = np.repeat(np.eye(2).reshape(1, 2, 2), shape, axis=0)

--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -1562,10 +1562,10 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testPoly(self, a_shape, dtype, rank):
-    if jtu.is_device_rocm and a_shape == (12,) and dtype in ( np.int32,  np.int8 )  and rank == 2:
+    if jtu.is_device_rocm() and a_shape == (12,) and dtype in ( np.int32,  np.int8 )  and rank == 2:
         self.skipTest(f"Skip on ROCm: testPoly: a_shape == (12,) and dtype == {dtype} and rank == 2")
 
-    if jtu.is_device_rocm and a_shape == (6,) and dtype == np.float32 and rank == 2:
+    if jtu.is_device_rocm() and a_shape == (6,) and dtype == np.float32 and rank == 2:
         self.skipTest("Skip on ROCm: testPoly: a_shape == (6,) and dtype == numpy.float32 and rank == 2")
 
     if dtype in (np.float16, jnp.bfloat16, np.int16):
@@ -2585,7 +2585,7 @@ class LaxBackedNumpyTests(jtu.JaxTestCase):
     a2_shape=one_dim_array_shapes,
   )
   def testPolyMul(self, a1_shape, a2_shape, dtype):
-    if jtu.is_device_rocm and str(self).split()[0] == "testPolyMul1":
+    if jtu.is_device_rocm() and str(self).split()[0] == "testPolyMul1":
       self.skipTest("Skip on ROCm: testPolyMul")
 
     rng = jtu.rand_default(self.rng())

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -874,7 +874,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   @jax.default_matmul_precision("float32")
   def testSVD(self, b, m, n, dtype, full_matrices, compute_uv, hermitian, algorithm):
     if algorithm is not None:
-      if jtu.is_device_rocm and algorithm == lax.linalg.SvdAlgorithm.JACOBI and dtype in {np.float32, np.complex64}:
+      if jtu.is_device_rocm() and algorithm == lax.linalg.SvdAlgorithm.JACOBI and dtype in {np.float32, np.complex64}:
         self.skipTest("Skip on ROCm: testSVD Jacobi tests")
       if hermitian:
         self.skipTest("Hermitian SVD doesn't support the algorithm parameter.")
@@ -1006,7 +1006,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
   )
   @jax.default_matmul_precision("float32")
   def testQr(self, shape, dtype, full_matrices):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
       self.skipTest("Skip on ROCm: tests/linalg_test.py::NumpyLinalgTest::testQr")
 
     if (jtu.test_device_matches(["cuda"]) and
@@ -1084,7 +1084,7 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     dtype=float_types + complex_types,
   )
   def testQrBatching(self, shape, dtype):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
       self.skipTest("Skip on ROCm: tests/linalg_test.py::NumpyLinalgTest::testQrBatching")
 
     rng = jtu.rand_default(self.rng())

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -93,7 +93,7 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
 
   def test_distributed_jax_visible_devices(self):
     """Test jax_visible_devices works in distributed settings."""
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_distributed_jax_visible_devices")
     if not jtu.test_device_matches(['gpu']):
       raise unittest.SkipTest('Tests only for GPU.')

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -201,7 +201,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
-    if jtu.is_device_rocm and dtype == jnp.float16 and group_num == 4 and impl == 'xla':
+    if jtu.is_device_rocm() and dtype == jnp.float16 and group_num == 4 and impl == 'xla':
         self.skipTest("Skip on ROCm: testDotProductAttention[21,23]")
     if impl == 'cudnn' and not _is_required_cudnn_version_satisfied("8.0", 8904):
       raise unittest.SkipTest("CUDA or cuDNN versions are not compatible.")

--- a/tests/pallas/gpu_attention_test.py
+++ b/tests/pallas/gpu_attention_test.py
@@ -104,7 +104,7 @@ class DecodeAttentionTest(PallasBaseTest):
       kv_seq_len,
       return_residuals,
   ):
-    if jtu.is_device_rocm and 'gfx950' in [d.compute_capability for d in jax.devices()]:
+    if jtu.is_device_rocm() and 'gfx950' in [d.compute_capability for d in jax.devices()]:
       self.skipTest("Skip on ROCm: test_mqa: LLVM ERROR: Do not know how to scalarize the result of this operator!")
     del kwargs
     normalize_output = not return_residuals
@@ -185,7 +185,7 @@ class DecodeAttentionTest(PallasBaseTest):
       kv_seq_len,
       return_residuals,
   ):
-    if jtu.is_device_rocm and 'gfx950' in [d.compute_capability for d in jax.devices()]:
+    if jtu.is_device_rocm() and 'gfx950' in [d.compute_capability for d in jax.devices()]:
       self.skipTest("Skip on ROCm: test_gqa: LLVM ERROR: Do not know how to scalarize the result of this operator!")
     del kwargs
     normalize_output = not return_residuals

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -175,10 +175,10 @@ class FusedAttentionTest(PallasBaseTest):
       use_fwd,
       use_segment_ids,
   ):
-    if jtu.is_device_rocm and 'gfx950' in [d.compute_capability for d in jax.devices()]:
+    if jtu.is_device_rocm() and 'gfx950' in [d.compute_capability for d in jax.devices()]:
       self.skipTest("Skip on ROCm: test_fused_attention_fwd: LLVM ERROR: Do not know how to scalarize the result of this operator!")
 
-    if jtu.is_device_rocm and batch_size == 2 and seq_len == 384 and  num_heads == 8 and head_dim == 64 and block_sizes == (('block_q', 128), ('block_k', 128)) and causal and use_fwd and use_segment_ids:
+    if jtu.is_device_rocm() and batch_size == 2 and seq_len == 384 and  num_heads == 8 and head_dim == 64 and block_sizes == (('block_q', 128), ('block_k', 128)) and causal and use_fwd and use_segment_ids:
       self.skipTest("Skip on ROCm: tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd4")
     k1, k2, k3 = random.split(random.key(0), 3)
     q = random.normal(
@@ -232,7 +232,7 @@ class FusedAttentionTest(PallasBaseTest):
   # RESOURCE_EXHAUSTED: Shared memory size limit exceeded" error.
   @jtu.sample_product(
       batch_size=(1, 2),
-      seq_len=(32, 64) if jtu.is_device_rocm else (128, 384),
+      seq_len=(32, 64) if jtu.is_device_rocm() else (128, 384),
       num_heads=(1, 2),
       head_dim=(32, 64, 128,),
       block_sizes=(
@@ -253,7 +253,7 @@ class FusedAttentionTest(PallasBaseTest):
               ("block_kv_dq", 32),
           ),
       )
-      if jtu.is_device_rocm else (
+      if jtu.is_device_rocm() else (
           (
               ("block_q", 128),
               ("block_k", 128),
@@ -295,9 +295,9 @@ class FusedAttentionTest(PallasBaseTest):
   ):
     test_name = str(self).split()[0]
     skip_suffix_list = [4, 6, 7, 8, 9]
-    if jtu.is_device_rocm and 'gfx950' in [d.compute_capability for d in jax.devices()]:
+    if jtu.is_device_rocm() and 'gfx950' in [d.compute_capability for d in jax.devices()]:
         self.skipTest("Skip on ROCm: test_fused_attention_bwd: LLVM ERROR: Do not know how to scalarize the result of this operator!")
-    if jtu.is_device_rocm and self.INTERPRET and any(test_name.endswith(str(suffix)) for suffix in skip_suffix_list):
+    if jtu.is_device_rocm() and self.INTERPRET and any(test_name.endswith(str(suffix)) for suffix in skip_suffix_list):
       self.skipTest("Skip on ROCm: tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd[4, 6, 7, 8, 9]")
 
     k1, k2, k3 = random.split(random.key(0), 3)

--- a/tests/pallas/gpu_paged_attention_test.py
+++ b/tests/pallas/gpu_paged_attention_test.py
@@ -122,12 +122,12 @@ class PagedAttentionKernelTest(PallasBaseTest):
       k_splits,
       attn_logits_soft_cap,
   ):
-    if jtu.is_device_rocm and 'gfx950' in [d.compute_capability for d in jax.devices()]:
+    if jtu.is_device_rocm() and 'gfx950' in [d.compute_capability for d in jax.devices()]:
       self.skipTest("Skip on ROCm: test_paged_attention: LLVM ERROR: Do not know how to scalarize the result of this operator!")
 
     test_name = str(self).split()[0]
     skip_numbers = {0, 1, 3, 5, 6, 7, 9}
-    if jtu.is_device_rocm and test_name in {f"test_paged_attention{i}" for i in skip_numbers}:
+    if jtu.is_device_rocm() and test_name in {f"test_paged_attention{i}" for i in skip_numbers}:
       self.skipTest("Skip on ROCm: tests/pallas/gpu_paged_attention_test.py::PagedAttentionKernelTest::test_paged_attention0")
     max_kv_len = 2048
     seq_lens = np.asarray([3, 256, 513, 1023, 2048], dtype=jnp.int32)

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -528,7 +528,7 @@ class OpsTest(PallasBaseTest):
   @hp.given(select_n_strategy(max_cases=2, min_rank=2, max_rank=4,
                               min_size_exp=1))
   def test_select_n(self, args):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_select_n")
     pred, *cases = args
     scalar_pred = not pred.shape
@@ -560,7 +560,7 @@ class OpsTest(PallasBaseTest):
   )
   @hp.given(hps.data())
   def test_unary_primitives(self, name, func, shape_dtype_strategy, data):
-    if jtu.is_device_rocm and name in {"logistic", "reciprocal"}:
+    if jtu.is_device_rocm() and name in {"logistic", "reciprocal"}:
         self.skipTest("Skip on ROCm: test_unary_primitives_[logistic,reciprocal]")
     if name in ["abs", "log1p", "pow2", "reciprocal", "relu", "sin", "sqrt"]:
       self.skip_if_mosaic_gpu()
@@ -1485,7 +1485,7 @@ class OpsTest(PallasBaseTest):
       for fn, dtype in itertools.product(*args)
   )
   def test_binary(self, f, dtype):
-    if jtu.is_device_rocm and f == jnp.bitwise_right_shift and dtype == "uint32":
+    if jtu.is_device_rocm() and f == jnp.bitwise_right_shift and dtype == "uint32":
         self.skipTest("Skip on ROCm: binary_bitwise_right_shift for uint32")
     self.skip_if_mosaic_gpu()
 
@@ -1559,7 +1559,7 @@ class OpsTest(PallasBaseTest):
 
   @parameterized.parameters("float16", "bfloat16", "float32")
   def test_approx_tanh(self, dtype):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_approx_tanh")
 
     self.skip_if_mosaic_gpu()
@@ -1591,7 +1591,7 @@ class OpsTest(PallasBaseTest):
     )
 
   def test_elementwise_inline_asm(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_elementwise_inline_asm")
 
     self.skip_if_mosaic_gpu()
@@ -1876,7 +1876,7 @@ class OpsTest(PallasBaseTest):
   def test_dot(self, lhs_and_rhs_shape, dtype, trans_x, trans_y):
     test_name = str(self).split()[0]
     skip_numbers = list(range(12, 20))
-    if jtu.is_device_rocm and jtu.get_rocm_version() == (7, 0) and test_name in {f"test_dot{i}" for i in skip_numbers}:
+    if jtu.is_device_rocm() and jtu.get_rocm_version() == (7, 0) and test_name in {f"test_dot{i}" for i in skip_numbers}:
         self.skipTest("Skip on ROCm: test_dot[12-19]")
     if (
         jtu.is_device_rocm() and
@@ -2169,7 +2169,7 @@ class OpsTest(PallasBaseTest):
       ("min_f32", pl.atomic_min, np.array([1, 2, 3, 4], np.float32), np.min),
   )
   def test_scalar_atomic(self, op, value, numpy_op):
-    if jtu.is_device_rocm and value.dtype == np.float32 and (op == pl.atomic_min or op == pl.atomic_max):
+    if jtu.is_device_rocm() and value.dtype == np.float32 and (op == pl.atomic_min or op == pl.atomic_max):
         self.skipTest("Skip on ROCm: test_scalar_atomic_(max/min)_f32")
 
     self.skip_if_mosaic_gpu()
@@ -2410,7 +2410,7 @@ class OpsTest(PallasBaseTest):
       dtype=["float16", "float32", "int32", "uint32"],
   )
   def test_cumsum(self, dtype, axis):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_cumsum")
     self.skip_if_mosaic_gpu()
 

--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -549,7 +549,7 @@ class PallasCallTest(PallasBaseTest):
   def test_matmul(self, m, n, k, dtype, bm, bn, bk, gm):
     if jtu.test_device_matches(["tpu"]) and not self.INTERPRET:
       self.skipTest("On TPU the test works only in interpret mode")
-    if jtu.is_device_rocm and self.INTERPRET:
+    if jtu.is_device_rocm() and self.INTERPRET:
       self.skipTest("Skip on ROCm: test_matmul")
 
     k1, k2 = random.split(random.key(0))

--- a/tests/pallas/tpu_pallas_interpret_test.py
+++ b/tests/pallas/tpu_pallas_interpret_test.py
@@ -92,7 +92,7 @@ class InterpretTest(jtu.JaxTestCase):
       self.skipTest(f'requires 1 device, found {self.num_devices}')
 
   def test_matmul_example(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_matmul_example")
     def matmul_kernel(x_ref, y_ref, z_ref):
       z_ref[...] = x_ref[...] @ y_ref[...]

--- a/tests/pgle_test.py
+++ b/tests/pgle_test.py
@@ -481,7 +481,7 @@ class PgleTest(jtu.JaxTestCase):
   @parameterized.parameters([True, False])
   @jtu.thread_unsafe_test()
   def testAutoPgleWithCommandBuffers(self, enable_compilation_cache):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers")
     with (config.pgle_profiling_runs(1),
           config.enable_compilation_cache(enable_compilation_cache),

--- a/tests/python_callback_test.py
+++ b/tests/python_callback_test.py
@@ -948,7 +948,7 @@ class PureCallbackTest(jtu.JaxTestCase):
     np.testing.assert_allclose(g(x), x)
 
   def test_can_shard_pure_callback_maximally(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
       self.skipTest("Skip on ROCm: test_can_shard_pure_callback_maximally")
     mesh = Mesh(np.array(jax.devices()), axis_names=('x',))
 
@@ -969,7 +969,7 @@ class PureCallbackTest(jtu.JaxTestCase):
     )
 
   def test_can_shard_pure_callback_maximally_with_sharding(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_can_shard_pure_callback_maximally_with_sharding")
     mesh = Mesh(np.array(jax.devices()), axis_names=('x',))
 
@@ -1244,7 +1244,7 @@ class IOCallbackTest(jtu.JaxTestCase):
   def test_can_use_io_callback_in_pjit(
       self, *, ordered: bool, with_sharding: bool
   ):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_can_use_io_callback_in_pjit")
     devices = jax.devices()
     mesh = jax.sharding.Mesh(np.array(devices), ['dev'])
@@ -1304,7 +1304,7 @@ class IOCallbackTest(jtu.JaxTestCase):
       self.assertIn(f"{{maximal device={callback_device_index}}}", stablehlo_ir)
 
   def test_sequence_pjit_io_callback_ordered(self):
-    if jtu.is_device_rocm:
+    if jtu.is_device_rocm():
         self.skipTest("Skip on ROCm: test_sequence_pjit_io_callback_ordered")
     # A sequence of pairs of calls to pjit(io_callback(ordered=True)) with each
     # pair on a different device assignment.

--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -740,7 +740,7 @@ class DistributionsTest(RandomTestBase):
   )
   @jax.default_matmul_precision("float32")
   def testOrthogonal(self, n, shape, dtype, m):
-    if jtu.is_device_rocm and not (n == 0 or m == 0):
+    if jtu.is_device_rocm() and not (n == 0 or m == 0):
       self.skipTest("Skip on ROCm: testOrthogonal[1-3, 8-9]")
 
     if m is None:

--- a/tests/scipy_signal_test.py
+++ b/tests/scipy_signal_test.py
@@ -350,7 +350,7 @@ class LaxBackedScipySignalTests(jtu.JaxTestCase):
   def testWelchWithDefaultStepArgsAgainstNumpy(
       self, *, shape, dtype, nperseg, noverlap, use_nperseg, use_noverlap,
       use_window, timeaxis):
-    if jtu.is_device_rocm and (not use_nperseg or (use_nperseg and use_noverlap and use_window)):
+    if jtu.is_device_rocm() and (not use_nperseg or (use_nperseg and use_noverlap and use_window)):
       raise unittest.SkipTest("Skip on ROCm: testWelchWithDefaultStepArgsAgainstNumpy[1,2,3,7,8]")
 
     if tuple(shape) == (2, 3, 389, 5) and nperseg == 17 and noverlap == 13:

--- a/tests/shape_poly_test.py
+++ b/tests/shape_poly_test.py
@@ -3624,11 +3624,11 @@ class ShapePolyHarnessesTest(jtu.JaxTestCase):
       #one_containing="",
   )
   def test_harness(self, harness: PolyHarness):
-    if jtu.is_device_rocm and harness.group_name in {"qr", "svd"} and harness.dtype in {np.float32, np.complex64}:
+    if jtu.is_device_rocm() and harness.group_name in {"qr", "svd"} and harness.dtype in {np.float32, np.complex64}:
         raise unittest.SkipTest("Skip for ROCm: shape_poly_test svd and qr for float32 and complex64.")
-    if jtu.is_device_rocm and harness.group_name == "vmap_eigh" and harness.dtype == np.complex64:
+    if jtu.is_device_rocm() and harness.group_name == "vmap_eigh" and harness.dtype == np.complex64:
         raise unittest.SkipTest("Skip for ROCm: shape_poly_test vmap_eigh for complex64.")
-    if jtu.is_device_rocm and "vmap_qr_multi_array" in harness.fullname and harness.dtype == np.float32:
+    if jtu.is_device_rocm() and "vmap_qr_multi_array" in harness.fullname and harness.dtype == np.float32:
         raise unittest.SkipTest("Skip for ROCm: shape_poly_test vmap_qr_multi_array for comple64 (note: when printed out, harness.dtype is np.float32.)")
 
     # We do not expect the associative scan error on TPUs

--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -47,7 +47,7 @@ jax.config.parse_flags_with_absl()
 
 all_dtypes = jtu.dtypes.integer + jtu.dtypes.floating + jtu.dtypes.complex
 
-@unittest.skipIf(jtu.is_device_rocm, "Skip on ROCm: cuSparseTest")
+@unittest.skipIf(jtu.is_device_rocm(), "Skip on ROCm: cuSparseTest")
 class cuSparseTest(sptu.SparseTestCase):
   def gpu_dense_conversion_warning_context(self, dtype):
     if jtu.test_device_matches(["gpu"]) and np.issubdtype(dtype, np.integer):
@@ -806,7 +806,7 @@ class SparseGradTest(sptu.SparseTestCase):
         self.assertAllClose(jax.grad(g, argnums=0, has_aux=has_aux)(y, Xtree_de),
                             sparse.grad(g, argnums=0, has_aux=has_aux)(y, Xtree_sp))
 
-@unittest.skipIf(jtu.is_device_rocm, "Skip on ROCm: SparseObjectTest")
+@unittest.skipIf(jtu.is_device_rocm(), "Skip on ROCm: SparseObjectTest")
 class SparseObjectTest(sptu.SparseTestCase):
   @parameterized.named_parameters(
     {"testcase_name": f"_{cls.__name__}", "cls": cls}


### PR DESCRIPTION
The is_device_rocm function calls should be function calls not attributes. Fixing all of them in this PR. 