### PR TITLE
Fix GPU handle pool singleton aliasing for HipSPARSE

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -431,7 +431,7 @@ typedef hipDoubleComplex gpuDoubleComplex;
 typedef hipComplex gpublasComplex;
 typedef hipDoubleComplex gpublasDoubleComplex;
 
-// Create unique opaque pointer types for proper singleton separation - BLAS and SOLVER only
+// Create unique opaque pointer types for proper singleton separation - BLAS, SOLVER and SPARSE
 typedef struct hipblasHandle_* gpublasHandle_t;
 typedef struct hipsolverHandle_* gpusolverDnHandle_t;
 typedef struct hipsparseHandle_* gpusparseHandle_t;
@@ -483,7 +483,9 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_R_64F HIP_R_64F
 
 // Wrapper functions for BLAS handles to ensure unique types
-#define gpublasCreate(handle) hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle))
+inline hipblasStatus_t gpublasCreate(gpublasHandle_t* handle) {
+    return hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle));
+}
 #define gpublasSetStream hipblasSetStream
 
 #define gpublasSgeqrfBatched hipblasSgeqrfBatched
@@ -536,7 +538,9 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPUDNN_BIDIRECTIONAL miopenRNNbidirection
 
 // Wrapper functions for SOLVER handles to ensure unique types
-#define gpusolverDnCreate(handle) hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle))
+inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
+    return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+}
 #define gpusolverDnSetStream hipsolverSetStream
 
 #define gpusolverDnCreateSyevjInfo hipsolverCreateSyevjInfo
@@ -626,8 +630,12 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 
 #define gpusparseCooSetStridedBatch hipsparseCooSetStridedBatch
 
-#define gpusparseCreate(handle) hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle))
+// Wrapper functions for BLAS handles to ensure unique types
+inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
+    return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+}
 #define gpusparseSetStream hipsparseSetStream
+
 #define gpusparseCreateCoo hipsparseCreateCoo
 #define gpusparseCreateCsr hipsparseCreateCsr
 #define gpusparseCreateDnMat hipsparseCreateDnMat


### PR DESCRIPTION

## Motivation

Sequential tests failed with "hipBlas resource allocation failed" errors when running ffi_test.py, but passed when run individually. HipSPARSE handles were still sharing singleton instance with other GPU libraries. 

## Failing tests

tests/ffi_test.py::BatchPartitioningTest::test_batch_partitioning
tests/ffi_test.py::BatchPartitioningTest::test_shard_map

## Technical Details

Extended opaque pointer solution to HipSPARSE:
- Added typedef struct hipsparseHandle_* gpusparseHandle_t;
- Added wrapper macro for gpusparseCreate with proper type casting
- Completes handle pool separation for all three GPU libraries


## Test Plan

Retest ffi_test.py that previously had failing test cases with changes

## Test Result

Failing tests in ffi_test.py now pass without resource allocation errors.

