### PR TITLE
[0.6.0-UT] Adding third field to return value of get_rocm_version

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -414,8 +414,8 @@ def get_rocm_version():
   version_path = Path(rocm_path) / ".info" / "version"
   try:
     version_str = version_path.read_text().strip()
-    major, minor, *_ = version_str.split(".")
-    return int(major), int(minor)
+    major, minor, patch = version_str.split(".")
+    return int(major), int(minor), int(patch)
   except FileNotFoundError:
     raise unittest.SkipTest("ROCm was not installed")
 


### PR DESCRIPTION
## Motivation

We needed the third field for the get_rocm_version utility function for  checking the ROCm version and doing versioned skips for 4 different test files. The motivation was that there was a HIP runtime fix that was not there in ROCm 7.0.1, however it got merged in ROCm 7.0.2. Without the fix, four test file sub-tests abort. Therefore we skip them using version check. 

## Technical Details

For detailed ROCm version check, this PR adds the functionality to return x.y.z-formatted ROCm version. 
## Test Plan

This was tested using ROCm build 42, which was ROCm 7.0.1 and with tests that were aborting. 
## Test Result

All tests that were aborting are skipped on any versions of ROCm < 7.0.1 using this utility function
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
