### PR TITLE
Wrap HIP inline functions in anonymous namespaces in vendor.h 

### DIFF
--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -469,7 +469,6 @@ typedef hipsolverSyevjInfo_t gpuSyevjInfo_t;
 typedef hipsolverEigMode_t gpusolverEigMode_t;
 typedef hipsolverStatus_t gpusolverStatus_t;
 typedef hipsparseIndexType_t gpusparseIndexType_t;
-// typedef hipsparseHandle_t gpusparseHandle_t;
 typedef hipsparseOperation_t gpusparseOperation_t;
 typedef hipsparseStatus_t gpusparseStatus_t;
 typedef hipsparseSpMatDescr_t gpusparseSpMatDescr_t;
@@ -629,8 +628,6 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 
 #define gpusparseCreate(handle) hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle))
 #define gpusparseSetStream hipsparseSetStream
-
-
 #define gpusparseCreateCoo hipsparseCreateCoo
 #define gpusparseCreateCsr hipsparseCreateCsr
 #define gpusparseCreateDnMat hipsparseCreateDnMat

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -434,6 +434,7 @@ typedef hipDoubleComplex gpublasDoubleComplex;
 // Create unique opaque pointer types for proper singleton separation - BLAS and SOLVER only
 typedef struct hipblasHandle_* gpublasHandle_t;
 typedef struct hipsolverHandle_* gpusolverDnHandle_t;
+typedef struct hipsparseHandle_* gpusparseHandle_t;
 
 typedef hipblasFillMode_t gpublasFillMode_t;
 typedef hipsolverFillMode_t gpusolverFillMode_t;
@@ -468,7 +469,7 @@ typedef hipsolverSyevjInfo_t gpuSyevjInfo_t;
 typedef hipsolverEigMode_t gpusolverEigMode_t;
 typedef hipsolverStatus_t gpusolverStatus_t;
 typedef hipsparseIndexType_t gpusparseIndexType_t;
-typedef hipsparseHandle_t gpusparseHandle_t;
+// typedef hipsparseHandle_t gpusparseHandle_t;
 typedef hipsparseOperation_t gpusparseOperation_t;
 typedef hipsparseStatus_t gpusparseStatus_t;
 typedef hipsparseSpMatDescr_t gpusparseSpMatDescr_t;
@@ -625,8 +626,11 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPUBLAS_OP_C HIPBLAS_OP_C
 
 #define gpusparseCooSetStridedBatch hipsparseCooSetStridedBatch
-#define gpusparseCreate hipsparseCreate
+
+#define gpusparseCreate(handle) hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle))
 #define gpusparseSetStream hipsparseSetStream
+
+
 #define gpusparseCreateCoo hipsparseCreateCoo
 #define gpusparseCreateCsr hipsparseCreateCsr
 #define gpusparseCreateDnMat hipsparseCreateDnMat

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -431,7 +431,7 @@ typedef hipDoubleComplex gpuDoubleComplex;
 typedef hipComplex gpublasComplex;
 typedef hipDoubleComplex gpublasDoubleComplex;
 
-// Create unique opaque pointer types for proper singleton separation - BLAS and SOLVER only
+// Create unique opaque pointer types for proper singleton separation - BLAS, SOLVER and SPARSE
 typedef struct hipblasHandle_* gpublasHandle_t;
 typedef struct hipsolverHandle_* gpusolverDnHandle_t;
 typedef struct hipsparseHandle_* gpusparseHandle_t;
@@ -483,7 +483,9 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_R_64F HIP_R_64F
 
 // Wrapper functions for BLAS handles to ensure unique types
-#define gpublasCreate(handle) hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle))
+inline hipblasStatus_t gpublasCreate(gpublasHandle_t* handle) {
+    return hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle));
+}
 #define gpublasSetStream hipblasSetStream
 
 #define gpublasSgeqrfBatched hipblasSgeqrfBatched
@@ -536,7 +538,9 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPUDNN_BIDIRECTIONAL miopenRNNbidirection
 
 // Wrapper functions for SOLVER handles to ensure unique types
-#define gpusolverDnCreate(handle) hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle))
+inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
+    return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+}
 #define gpusolverDnSetStream hipsolverSetStream
 
 #define gpusolverDnCreateSyevjInfo hipsolverCreateSyevjInfo
@@ -626,8 +630,12 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 
 #define gpusparseCooSetStridedBatch hipsparseCooSetStridedBatch
 
-#define gpusparseCreate(handle) hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle))
+// Wrapper functions for BLAS handles to ensure unique types
+inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
+    return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+}
 #define gpusparseSetStream hipsparseSetStream
+
 #define gpusparseCreateCoo hipsparseCreateCoo
 #define gpusparseCreateCsr hipsparseCreateCsr
 #define gpusparseCreateDnMat hipsparseCreateDnMat

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -542,8 +542,9 @@ inline hipblasStatus_t gpublasCreate(gpublasHandle_t* handle) {
 
 // Wrapper functions for SOLVER handles to ensure unique types
 namespace{
-  inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
-      return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
+    return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+}
 }
 
 
@@ -638,8 +639,9 @@ namespace{
 
 // Wrapper functions for BLAS handles to ensure unique types
 namespace{
-  inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
-      return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
+    return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+}
 }
 
 #define gpusparseSetStream hipsparseSetStream

--- a/jaxlib/gpu/vendor.h
+++ b/jaxlib/gpu/vendor.h
@@ -483,8 +483,10 @@ typedef hipsparseDnVecDescr_t gpusparseDnVecDescr_t;
 #define GPU_R_64F HIP_R_64F
 
 // Wrapper functions for BLAS handles to ensure unique types
+namespace{
 inline hipblasStatus_t gpublasCreate(gpublasHandle_t* handle) {
     return hipblasCreate(reinterpret_cast<hipblasHandle_t*>(handle));
+}
 }
 #define gpublasSetStream hipblasSetStream
 
@@ -538,8 +540,10 @@ inline hipblasStatus_t gpublasCreate(gpublasHandle_t* handle) {
 #define GPUDNN_BIDIRECTIONAL miopenRNNbidirection
 
 // Wrapper functions for SOLVER handles to ensure unique types
-inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
-    return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+namespace{
+  inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
+      return hipsolverCreate(reinterpret_cast<hipsolverHandle_t*>(handle));
+}
 }
 #define gpusolverDnSetStream hipsolverSetStream
 
@@ -631,8 +635,10 @@ inline hipsolverStatus_t gpusolverDnCreate(gpusolverDnHandle_t* handle) {
 #define gpusparseCooSetStridedBatch hipsparseCooSetStridedBatch
 
 // Wrapper functions for BLAS handles to ensure unique types
-inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
-    return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+namespace{
+  inline hipsparseStatus_t gpusparseCreate(gpusparseHandle_t* handle) {
+      return hipsparseCreate(reinterpret_cast<hipsparseHandle_t*>(handle));
+}
 }
 #define gpusparseSetStream hipsparseSetStream
 


### PR DESCRIPTION
Fixes issue identified in PR #[535 ](https://github.com/ROCm/jax/pull/535) inline functions could cause One Definition Rule violations when CUDA and ROCm object files are linked together. 