### PR TITLE
Updating jaxlib BUILD file for new target and XLA commit hash

### DIFF
--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -387,7 +387,7 @@ nanobind_extension(
         ":hip_vendor",
         "//jaxlib:kernel_nanobind_helpers",
         "@local_config_rocm//rocm:rocm_headers",
-        "@local_config_rocm//rocm:hip",
+        "@local_config_rocm//rocm:rocm_hip",
         "@nanobind",
     ],
 )
@@ -431,6 +431,7 @@ nanobind_extension(
         "@com_google_absl//absl/base",
         "@local_config_rocm//rocm:rocm_headers",
         "@local_config_rocm//rocm:hip",
+	"@local_config_rocm//rocm:hip",
         "@nanobind",
         "@xla//xla/ffi/api:ffi",
     ],
@@ -499,7 +500,7 @@ nanobind_extension(
         "@com_google_absl//absl/status",
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings:string_view",
-        "@local_config_rocm//rocm:hip",
+        "@local_config_rocm//rocm:rocm_hip",
         "@nanobind",
     ],
 )

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -21,8 +21,8 @@ load("//third_party:repo.bzl", "tf_http_archive", "tf_mirror_urls")
 #    curl -L https://github.com/ROCm/xla/archive/<git hash>.tar.gz | sha256sum
 #    and update XLA_SHA256 with the result.
 
-XLA_COMMIT = "28f10a0878344a44d4259e12d1793b104ba4d3b7"
-XLA_SHA256 = "7d32a26205d3827b8e002334e8439c6c6f14d67d2f842f09b0921ec3752df870"
+XLA_COMMIT = "ff74b5fda7dec651c9ed3d7a2bab4365ca25d61f"
+XLA_SHA256 = "414d0037cf4a36c0179b1e4d87517875110afd689eff3e8a8e100b202c354cbd"
 
 def repo():
     tf_http_archive(


### PR DESCRIPTION
## Motivation

This PR is to update the jaxlib BUILD file and XLA commit hash. 

## Technical Details

Since we are also releasing the jaxlib wheels, this PR intends to update the BUILD file of jaxlib to reflect new hip target. Also it updates the XLA commit hash for completion. 

## Test Plan

Tested the jaxlib wheel for different unit tests.

## Test Result

UTs pass. 

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
