### PR TITLE
Skip test_dot_precision() with TF32 for gfx11xx and gfx12xx architecture (#520)

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -674,6 +674,12 @@ class PallasCallTest(PallasBaseTest):
     if not jtu.test_device_matches(["gpu"]):
       self.skipTest("`DotAlgorithmPreset` only supported on GPU.")
 
+    if precision in (
+        jax.lax.DotAlgorithmPreset.TF32_TF32_F32,
+        jax.lax.DotAlgorithmPreset.TF32_TF32_F32_X3,
+      ) and any(gfx.compute_capability.startswith(("gfx11", "gfx12")) for gfx in jax.devices()):
+      self.skipTest("Navi3x and Navi4x doesn't have hardware support for TF32")
+
     @functools.partial(
         self.pallas_call,
         out_shape=jax.ShapeDtypeStruct((32, 64), jnp.float32),


### PR DESCRIPTION
## Motivation

tests/pallas/pallas_tests.py test suite failure.

## Technical Details

RDNA3 / gfx11xx and RDNA4 / gfx12xx don't support TF32/XF32 hence relevant `tests/pallas/pallas_test.py::PallasCallInterpretTest::test_dot_precision*` tests needs to be skipped.

## Test Plan

Running tests/pallas/pallas_tests.py

## Test Result

tests/pallas/pallas_tests.py and test_dot_precision() with TF32 are skipped on gfx11xx and gfx12xx.
