### PR TITLE
Phambinh/jax fix copy

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -716,6 +716,9 @@ async def main():
       wheel_dir = wheel.replace("cuda", f"cuda{cuda_major_version}").replace(
           "-", "_"
       )
+    elif "rocm" in wheel:
+      # Use wildcard pattern to match any ROCm version (rocm60, rocm7, etc.)
+      wheel_dir = wheel.replace("rocm", "rocm*").replace("-", "_")
     else:
       wheel_dir = wheel
 
@@ -733,7 +736,7 @@ async def main():
           wheel_version_suffix += (
               f"+{wheel_git_hash}{custom_wheel_version_suffix}"
           )
-      if wheel in ["jax", "jax-cuda-pjrt"]:
+      if wheel in ["jax", "jax-cuda-pjrt", "jax-rocm-pjrt"]:
         python_tag = "py"
       else:
         python_tag = "cp"


### PR DESCRIPTION
The build script failed to copy ROCm 7 wheels due to hardcoded version
pattern. Changed to use wildcard (rocm*) to match any ROCm version.

Changes:
- Use rocm* wildcard instead of rocm{version} in wheel pattern
- Add jax-rocm-pjrt to py-tagged wheels list
- Supports jax_rocm60_*, jax_rocm7_*, and future versions