### PR TITLE
jaxlib with rocm version extra tag

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -747,16 +747,12 @@ async def main():
       else:
         python_tag = "cp"
 
-      logger.info(f"ALL ARGS: {args}")
-      logger.info(f"Using ROCm path: {args.rocm_path} - {wheel_version_suffix} -{custom_wheel_version_suffix}") 
       if args.rocm_path:
         rocm_tag = args.rocm_path.split("-")[-1]
         logger.info(f"Using ROCm tag: {rocm_tag}")
       else:
         rocm_tag = None
 
-      logger.info(f"Final wheel version suffix: {wheel_version_suffix}")
-      logger.info(f"Copying wheel files for {wheel_dir} with suffix {wheel_version_suffix} and python tag {python_tag} - Bazel dir: {bazel_dir} - output path: {output_path}")
       utils.copy_individual_files(
           bazel_dir,
           output_path,

--- a/build/tools/utils.py
+++ b/build/tools/utils.py
@@ -271,8 +271,8 @@ def copy_individual_files(src: str, dst: str, glob_pattern: str, rocm_tag: str):
     f"Copying files matching pattern {glob_pattern!r} from {src!r} to {dst!r}"
   )
   for f in glob.glob(os.path.join(src, glob_pattern)):
-    logging.debug(f"Found file to copy: {f!r}")
     if rocm_tag:
+      logging.info(f"Adding Rocm tag {rocm_tag} to file {f}")
       f_list = f.split("-")
       f_list[2] = f_list[2]+"+rocm"+rocm_tag
       new_f = "-".join(f_list)


### PR DESCRIPTION
## Motivation - ⁠[SWDEV-563344](https://ontrack-internal.amd.com/browse/SWDEV-563344)
[SWDEV-563344](https://ontrack-internal.amd.com/browse/SWDEV-563344)
 [ROCm QA][TheRock] Build specific JAX whl are not available in artifactory

This PR adds an wheel tagging feature enable rocm version management of JAX ROCm jaxlib wheels in automated build pipelines, which is essential for maintaining consistent versioning across different ROCm builds and integrating with existing S3 upload workflows.

## Technical Details
Pattern Transformation:

jaxlib-0.7.1-cp312-cp312-manylinux_2_28_x86_64.whl
→ jaxlib-0.7.1+rocm7.1.0a20251107-cp312-cp312-manylinux_2_28_x86_64.whl

## Test Result


## Submission Checklist
 [*]Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.