### PR TITLE
register rocm platform to mx datatype lowering path

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -66,7 +66,7 @@ def _scaled_matmul_impl(a, b, a_scale, b_scale, preferred_element_type):
   )
 
 
-def _scaled_matmul_cuda_lowering(
+def _scaled_matmul_gpu_lowering(
     ctx, a, b, a_scales, b_scales, preferred_element_type
   ):
   lhs_type = ir.RankedTensorType(a.type)
@@ -119,8 +119,8 @@ _scaled_matmul_p.def_abstract_eval(_scaled_matmul_abstract)
 
 mlir.register_lowering(
     _scaled_matmul_p,
-    _scaled_matmul_cuda_lowering,
-    platform="cuda",
+    _scaled_matmul_gpu_lowering,
+    platform="gpu",
 )
 
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")


### PR DESCRIPTION
Register rocm platform to mx datatype lowering path.

As I understand, we currently don't need another lowering path for rocm mx datatype, so I just enabled rocm platform for the current path.

XLA part: https://github.com/ROCm/xla/pull/462

```
import functools
import jax
import jax.numpy as jnp
from jax import nn

key = jax.random.PRNGKey(0)
key_a, key_b = jax.random.split(key)
B, M, N, K = 1, 128, 128, 64


lhs = jax.random.normal(key_a, (B, M, K), dtype=jnp.float32)
rhs = jax.random.normal(key_b, (B, N, K), dtype=jnp.float32)

# 1. high-precision matmul
ref = jnp.einsum("bmk,bnk->bmn", lhs, rhs)

# 2. mxfp8 matmul
configs = [nn.get_scaled_dot_general_config("mxfp8")] * 3
scaled_dot = functools.partial(
    nn.scaled_dot_general,
    configs=configs,
    preferred_element_type=jnp.float32,
)

out = scaled_dot(lhs, rhs, (((2,), (2,)), ((0,), (0,))))

# compare results
print("high-precision ref: ")
print(ref)

print("mxfp8 out: ")
print(out)

max_abs = jnp.max(jnp.abs(out - ref))
max_rel = max_abs / jnp.max(jnp.abs(ref))

print("max abs error:", max_abs)
print("max rel error:", max_rel)
```