### PR TITLE
add fix for jaxlib build whl

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -620,7 +620,7 @@ async def main():
       )
 
   if "rocm" in args.wheels:
-    print("ERROR: This repo is not used for building the ROCm JAX plugins. Please use the new plugin repo: https://github.com/ROCm/rocm-jax"
+    print("ERROR: This repo is not used for building the ROCm JAX plugins. Please use the new plugin repo: https://github.com/ROCm/rocm-jax")
     exit(1)
 
     wheel_build_command_base.append("--config=rocm_base")


### PR DESCRIPTION
## Motivation
jaxlib Whl build script syntax error. 
<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details
missing `)` 
<!-- Explain the changes along with any relevant GitHub links. -->
```
 File "/wheelhouse/jax_repo/./build/build.py", line 623
    print("ERROR: This repo is not used for building the ROCm JAX plugins. Please use the new plugin repo: https://github.com/ROCm/rocm-jax"
         ^
SyntaxError: '(' was never closed
```
## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
