### PR TITLE
Let the unit tests use build.py for setting up Bazel commands for unit tests

### DIFF
--- a/build/build.py
+++ b/build/build.py
@@ -620,8 +620,9 @@ async def main():
       )
 
   if "rocm" in args.wheels:
-    print("ERROR: This repo is not used for building the ROCm JAX plugins. Please use the new plugin repo: https://github.com/ROCm/rocm-jax")
-    exit(1)
+    if not args.configure_only:
+      print("ERROR: This repo is not used for building the ROCm JAX plugins. Please use the new plugin repo: https://github.com/ROCm/rocm-jax")
+      exit(1)
 
     wheel_build_command_base.append("--config=rocm_base")
     wheel_build_command_base.append("--config=rocm")


### PR DESCRIPTION
We borked ourselves when trying to disable rocm builds with build.py. We still need to use build.py for configuring Bazel when running Bazel unit tests.

Tested this by running 
```
build/ci_build test jax-ubu24.rocm702:latest --test-cmd "./ci/jax_rbe/pr_test.sh 0.8.0 3.12"
```
from the `rocm/rocm-jax` repo.
