### PR TITLE
update a test for checking zero ROCm GPU event

### DIFF
--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -25,6 +25,9 @@ import unittest
 import unittest.mock
 from absl.testing import absltest
 import pathlib
+import importlib
+import json
+import subprocess
 
 import jax
 import jax.numpy as jnp
@@ -48,6 +51,132 @@ except ImportError:
 
 jax.config.parse_flags_with_absl()
 
+
+def _import_xplane_pb2():
+  """Try a few common module paths for XPlane protos and return the module."""
+  candidates = [
+      "tsl.profiler.protobuf.xplane_pb2",
+      # Add more candidates here if your tree uses a different path.
+  ]
+  for name in candidates:
+    try:
+      return importlib.import_module(name)
+    except ModuleNotFoundError:
+      continue
+  raise ModuleNotFoundError(
+      "Could not import xplane_pb2. Add a py_test dep that provides "
+      "`tsl.profiler.protobuf.xplane_pb2` (or extend _import_xplane_pb2())."
+  )
+
+
+def _count_gpu_events_xspace(xplane_pb_path: str) -> int:
+  """Return total number of events across all /device:GPU* planes in XSpace."""
+  xplane_pb2 = _import_xplane_pb2()
+
+  xs = xplane_pb2.XSpace()
+  xs.ParseFromString(pathlib.Path(xplane_pb_path).read_bytes())
+
+  total = 0
+  for plane in xs.planes:
+    # On multi-GPU, plane names may be "/device:GPU:0", "/device:GPU:1", etc.
+    if plane.name.startswith("/device:GPU"):
+      for line in plane.lines:
+        total += len(line.events)
+  return total
+
+
+def _run_child_and_get_xplane(outdir: str, env_overrides: dict) -> str:
+  """Run a minimal JAX trace in a fresh process; return path to *.xplane.pb."""
+  code = r"""
+import glob, json, os
+import jax, jax.numpy as jnp
+from jax import jit
+import jax.profiler
+
+# Keep this minimal and avoid any eager device queries before tracing.
+
+@jit
+def f(a, b):
+  return jnp.dot(a, b)
+
+a = jnp.ones((1024, 1024), dtype=jnp.float16)
+b = jnp.ones((1024, 1024), dtype=jnp.float16)
+
+# Warm-up compile OUTSIDE the trace so the trace mostly captures runtime work.
+f(a, b).block_until_ready()
+
+outdir = os.environ["OUTDIR"]
+with jax.profiler.trace(outdir):
+  # Run a few iterations to ensure we get recorded GPU activity.
+  for _ in range(3):
+    f(a, b).block_until_ready()
+
+pbs = glob.glob(os.path.join(outdir, "**", "*.xplane.pb"), recursive=True)
+assert len(pbs) == 1, pbs
+print(json.dumps({"xplane": pbs[0]}))
+"""
+
+  env = os.environ.copy()
+  env["OUTDIR"] = outdir
+  # You can use "gpu" if that's how your wheel is configured; "rocm" is safer
+  # for forcing ROCm specifically.
+  env.setdefault("JAX_PLATFORMS", "rocm")
+  env.update(env_overrides)
+
+  r = subprocess.run([sys.executable, "-c", code], env=env,
+                     capture_output=True, text=True)
+
+  if r.returncode != 0:
+    raise RuntimeError(
+        "Child process failed.\n"
+        f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
+    )
+
+  info = json.loads(r.stdout.splitlines()[-1])
+  return info["xplane"]
+
+
+@jtu.thread_unsafe_test_class()
+class RocmProfilerPositiveControlTest(unittest.TestCase):
+
+  @jtu.run_on_devices("gpu")
+  def test_gpu_events_present_when_configure_happens_early(self):
+    # Skip if not ROCm. (On CUDA this test’s assumptions don’t apply.)
+    backend = jax.lib.xla_bridge.get_backend()
+    if "rocm" not in backend.platform_version.lower():
+      self.skipTest(f"Not ROCm backend: {backend.platform_version}")
+
+    force_configure_so = os.environ.get("FORCE_CONFIGURE_SO")
+    if not force_configure_so:
+      self.skipTest("FORCE_CONFIGURE_SO is not set (need a preload .so).")
+
+    # Ensure the .so exists (helps avoid confusing LD_PRELOAD failures).
+    if not os.path.exists(force_configure_so):
+      self.fail(f"FORCE_CONFIGURE_SO does not exist: {force_configure_so}")
+
+    with tempfile.TemporaryDirectory() as td:
+      outdir = os.path.join(td, "profile")
+
+      # Preload the configure-forcer. Preserve any existing LD_PRELOAD.
+      prev = os.environ.get("LD_PRELOAD", "")
+      ld_preload = force_configure_so if not prev else f"{force_configure_so}:{prev}"
+
+      xplane = _run_child_and_get_xplane(
+          outdir,
+          env_overrides={
+              "LD_PRELOAD": ld_preload,
+              # Optional diagnostics:
+              # "ROCPROFILER_LOG_LEVEL": "trace",
+              # "AMD_LOG_LEVEL": "5",
+          },
+      )
+
+      gpu_events = _count_gpu_events_xspace(xplane)
+      self.assertGreater(
+          gpu_events, 0,
+          f"Expected >0 GPU events when configure happens early; got {gpu_events}. "
+          f"xplane={xplane}"
+      )
 
 # We do not allow multiple concurrent profiler sessions.
 @jtu.thread_unsafe_test_class()

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -52,131 +52,86 @@ except ImportError:
 jax.config.parse_flags_with_absl()
 
 
-def _import_xplane_pb2():
-  """Try a few common module paths for XPlane protos and return the module."""
-  candidates = [
-      "tsl.profiler.protobuf.xplane_pb2",
-      # Add more candidates here if your tree uses a different path.
-  ]
-  for name in candidates:
-    try:
-      return importlib.import_module(name)
-    except ModuleNotFoundError:
-      continue
-  raise ModuleNotFoundError(
-      "Could not import xplane_pb2. Add a py_test dep that provides "
-      "`tsl.profiler.protobuf.xplane_pb2` (or extend _import_xplane_pb2())."
-  )
+def _run_child_and_get_activity_count(tmpdir: str) -> int:
+  """
+  Runs a minimal JAX profile in a fresh process and returns the ROCm
+  total_activity_events count reported by the XLA backend via a file hook.
 
+  Requires XLA backend to honor env var:
+    XLA_ROCM_ACTIVITY_COUNT_FILE=<path>
+  and write a single integer line to that file.
+  """
+  activity_file = os.path.join(tmpdir, "rocm_activity_count.txt")
+  outdir = os.path.join(tmpdir, "profile")
 
-def _count_gpu_events_xspace(xplane_pb_path: str) -> int:
-  """Return total number of events across all /device:GPU* planes in XSpace."""
-  xplane_pb2 = _import_xplane_pb2()
-
-  xs = xplane_pb2.XSpace()
-  xs.ParseFromString(pathlib.Path(xplane_pb_path).read_bytes())
-
-  total = 0
-  for plane in xs.planes:
-    # On multi-GPU, plane names may be "/device:GPU:0", "/device:GPU:1", etc.
-    if plane.name.startswith("/device:GPU"):
-      for line in plane.lines:
-        total += len(line.events)
-  return total
-
-
-def _run_child_and_get_xplane(outdir: str, env_overrides: dict) -> str:
-  """Run a minimal JAX trace in a fresh process; return path to *.xplane.pb."""
   code = r"""
-import glob, json, os
-import jax, jax.numpy as jnp
-from jax import jit
-import jax.profiler
+    import os
+    import jax, jax.numpy as jnp
+    from jax import jit
+    import jax.profiler
 
-# Keep this minimal and avoid any eager device queries before tracing.
+    @jit
+    def f(a, b):
+      return jnp.dot(a, b)
 
-@jit
-def f(a, b):
-  return jnp.dot(a, b)
+    a = jnp.ones((1024, 1024), dtype=jnp.float16)
+    b = jnp.ones((1024, 1024), dtype=jnp.float16)
 
-a = jnp.ones((1024, 1024), dtype=jnp.float16)
-b = jnp.ones((1024, 1024), dtype=jnp.float16)
-
-# Warm-up compile OUTSIDE the trace so the trace mostly captures runtime work.
-f(a, b).block_until_ready()
-
-outdir = os.environ["OUTDIR"]
-with jax.profiler.trace(outdir):
-  # Run a few iterations to ensure we get recorded GPU activity.
-  for _ in range(3):
+    # Warm-up compile outside trace.
     f(a, b).block_until_ready()
 
-pbs = glob.glob(os.path.join(outdir, "**", "*.xplane.pb"), recursive=True)
-assert len(pbs) == 1, pbs
-print(json.dumps({"xplane": pbs[0]}))
-"""
+    outdir = os.environ["OUTDIR"]
+    with jax.profiler.trace(outdir):
+      for _ in range(5):
+        f(a, b).block_until_ready()
+    """
 
   env = os.environ.copy()
   env["OUTDIR"] = outdir
-  # You can use "gpu" if that's how your wheel is configured; "rocm" is safer
-  # for forcing ROCm specifically.
-  env.setdefault("JAX_PLATFORMS", "rocm")
-  env.update(env_overrides)
+  env["JAX_PLATFORMS"] = "rocm"
+  env["XLA_ROCM_ACTIVITY_COUNT_FILE"] = activity_file
 
-  r = subprocess.run([sys.executable, "-c", code], env=env,
-                     capture_output=True, text=True)
+  # Optional: make debugging easier when it fails
+  # env["ROCPROFILER_LOG_LEVEL"] = "trace"
+  # env["AMD_LOG_LEVEL"] = "5"
 
+  r = subprocess.run([sys.executable, "-c", code],
+                     env=env, capture_output=True, text=True)
   if r.returncode != 0:
     raise RuntimeError(
-        "Child process failed.\n"
-        f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
+      "Child process failed.\n"
+      f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
     )
 
-  info = json.loads(r.stdout.splitlines()[-1])
-  return info["xplane"]
+  if not os.path.exists(activity_file):
+    raise RuntimeError(
+      f"XLA_ROCM_ACTIVITY_COUNT_FILE was not written: {activity_file}\n"
+      "Make sure the XLA ROCm backend writes total_activity_events to this file."
+    )
 
+  txt = open(activity_file, "r", encoding="utf-8").read().strip()
+  return int(txt)
 
 @jtu.thread_unsafe_test_class()
 class RocmProfilerPositiveControlTest(unittest.TestCase):
 
   @jtu.run_on_devices("gpu")
-  def test_gpu_events_present_when_configure_happens_early(self):
-    # Skip if not ROCm. (On CUDA this test’s assumptions don’t apply.)
-    backend = jax.lib.xla_bridge.get_backend()
-    if "rocm" not in backend.platform_version.lower():
-      self.skipTest(f"Not ROCm backend: {backend.platform_version}")
-
-    force_configure_so = os.environ.get("FORCE_CONFIGURE_SO")
-    if not force_configure_so:
-      self.skipTest("FORCE_CONFIGURE_SO is not set (need a preload .so).")
-
-    # Ensure the .so exists (helps avoid confusing LD_PRELOAD failures).
-    if not os.path.exists(force_configure_so):
-      self.fail(f"FORCE_CONFIGURE_SO does not exist: {force_configure_so}")
+  def test_gpu_activity_events_present_by_default(self):
+    # ROCm-only gate using supported JAX API
+    from jax.extend import backend as jax_backend
+    be = jax_backend.get_backend()
+    platform_version = getattr(be, "platform_version", "") or ""
+    if "rocm" not in platform_version.lower():
+      self.skipTest(f"Not ROCm backend: {platform_version}")
 
     with tempfile.TemporaryDirectory() as td:
-      outdir = os.path.join(td, "profile")
+      count = _run_child_and_get_activity_count(td)
 
-      # Preload the configure-forcer. Preserve any existing LD_PRELOAD.
-      prev = os.environ.get("LD_PRELOAD", "")
-      ld_preload = force_configure_so if not prev else f"{force_configure_so}:{prev}"
-
-      xplane = _run_child_and_get_xplane(
-          outdir,
-          env_overrides={
-              "LD_PRELOAD": ld_preload,
-              # Optional diagnostics:
-              # "ROCPROFILER_LOG_LEVEL": "trace",
-              # "AMD_LOG_LEVEL": "5",
-          },
-      )
-
-      gpu_events = _count_gpu_events_xspace(xplane)
       self.assertGreater(
-          gpu_events, 0,
-          f"Expected >0 GPU events when configure happens early; got {gpu_events}. "
-          f"xplane={xplane}"
+        count, 0,
+        f"Expected >0 GPU activity events in normal profiling run; got {count}."
       )
+
 
 # We do not allow multiple concurrent profiler sessions.
 @jtu.thread_unsafe_test_class()

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -39,561 +39,671 @@ from jax import jit
 
 
 try:
-  import portpicker
+    import portpicker
 except ImportError:
-  portpicker = None
+    portpicker = None
 
 try:
-  from xprof.convert import _pywrap_profiler_plugin
-  import jax.collect_profile
+    from xprof.convert import _pywrap_profiler_plugin
+    import jax.collect_profile
 except ImportError:
-  _pywrap_profiler_plugin = None
+    _pywrap_profiler_plugin = None
 
 jax.config.parse_flags_with_absl()
 
 
-def _run_child_and_get_activity_count(tmpdir: str) -> int:
-  """
-  Runs a minimal JAX profile in a fresh process and returns the ROCm
-  total_activity_events count reported by the XLA backend via a file hook.
+def _trace_viewer_json_from_xplane(pb_path: str) -> dict:
+    """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin."""
+    try:
+        from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
+    except Exception:
+        from xprof.convert import raw_to_tool_data as convert
 
-  Requires XLA backend to honor env var:
-    XLA_ROCM_ACTIVITY_COUNT_FILE=<path>
-  and write a single integer line to that file.
-  """
-  activity_file = os.path.join(tmpdir, "rocm_activity_count.txt")
-  outdir = os.path.join(tmpdir, "profile")
+    result, _ = convert.xspace_to_tool_data([pb_path], "trace_viewer@^", {})
+    # result is bytes
+    return json.loads(result.decode("utf-8"))
 
-  code = r"""
-import os
+
+def _count_gpu_events_from_traceevents(traceevents: list) -> int:
+    """
+    Count GPU *kernel-stream* duration events in Trace Viewer traceEvents.
+
+    - GPU PIDs are discovered via process_name metadata that CONTAINS '/device:GPU'
+    - Kernel stream TIDs are discovered via thread_name metadata containing '(Kernel)'.
+    - We count only 'ph'=='X' events with 'dur' on those (pid, tid).
+    - Fallback: if we can't find kernel tids, count all 'X' events on GPU pids.
+    """
+    # 1) Find GPU pids (process_name contains '/device:GPU')
+    gpu_pids = set()
+    for ev in traceevents:
+        if ev.get("ph") == "M" and ev.get("name") == "process_name":
+            pname = (ev.get("args") or {}).get("name", "")
+            if isinstance(pname, str) and "/device:GPU" in pname:
+                pid = ev.get("pid")
+                if pid is not None:
+                    gpu_pids.add(pid)
+
+    if not gpu_pids:
+        return 0
+
+    # 2) For each GPU pid, find tids that correspond to kernel streams
+    kernel_tids_by_pid = {pid: set() for pid in gpu_pids}
+    for ev in traceevents:
+        if ev.get("ph") == "M" and ev.get("name") == "thread_name":
+            pid = ev.get("pid")
+            tid = ev.get("tid")
+            if pid in gpu_pids and tid is not None:
+                tname = (ev.get("args") or {}).get("name", "")
+                if isinstance(tname, str) and "(Kernel)" in tname:
+                    kernel_tids_by_pid[pid].add(
+                        tid
+                    )  # Flatten kernel tids; decide whether we have a kernel-tid signal
+    have_kernel_tids = any(kernel_tids_by_pid[pid] for pid in gpu_pids)
+
+    # 3) Count events
+    count = 0
+    if have_kernel_tids:
+        for ev in traceevents:
+            if ev.get("ph") != "X":
+                continue
+            if "dur" not in ev:
+                continue
+            pid = ev.get("pid")
+            tid = ev.get("tid")
+            if pid in gpu_pids and tid in kernel_tids_by_pid.get(pid, ()):
+                count += 1
+    else:  # Fallback: count all duration events on GPU pids
+        for ev in traceevents:
+            if ev.get("ph") == "X" and "dur" in ev and ev.get("pid") in gpu_pids:
+                count += 1
+
+    return count
+
+
+def _run_child_matmul_trace_and_get_xplane(outdir: str, m: int, k: int, n: int) -> str:
+    """
+    Run a minimal JAX matmul trace in a fresh process. Returns path to *.xplane.pb.
+
+    Uses (m, k) @ (k, n) -> (m, n).
+    Each shape is run in its own child process for clean isolation and simpler attribution.
+    """
+    code = r"""
+import glob, json, os
 import jax, jax.numpy as jnp
 from jax import jit
 import jax.profiler
+
+m = int(os.environ["MATMUL_M"])
+k = int(os.environ["MATMUL_K"])
+n = int(os.environ["MATMUL_N"])
 
 @jit
 def f(a, b):
   return jnp.dot(a, b)
 
-a = jnp.ones((1024, 1024), dtype=jnp.float16)
-b = jnp.ones((1024, 1024), dtype=jnp.float16)
+# (m, k) @ (k, n) -> (m, n)
+a = jnp.ones((m, k), dtype=jnp.float16)
+b = jnp.ones((k, n), dtype=jnp.float16)
 
-# Warm-up compile outside trace.
+# Compile/warm-up outside trace.
 f(a, b).block_until_ready()
 
 outdir = os.environ["OUTDIR"]
 with jax.profiler.trace(outdir):
   for _ in range(5):
     f(a, b).block_until_ready()
+
+pbs = glob.glob(os.path.join(outdir, "**", "*.xplane.pb"), recursive=True)
+assert len(pbs) == 1, pbs
+print(json.dumps({"xplane": pbs[0]}))
 """
 
-  env = os.environ.copy()
-  env["OUTDIR"] = outdir
-  env["JAX_PLATFORMS"] = "rocm"
-  env["XLA_ROCM_ACTIVITY_COUNT_FILE"] = activity_file
+    env = os.environ.copy()
+    env["OUTDIR"] = outdir
+    env["JAX_PLATFORMS"] = "rocm"
+    env["MATMUL_M"] = str(m)
+    env["MATMUL_K"] = str(k)
+    env["MATMUL_N"] = str(n)
 
-  # Optional: make debugging easier when it fails
-  # env["ROCPROFILER_LOG_LEVEL"] = "trace"
-  # env["AMD_LOG_LEVEL"] = "5"
+    # Optional diagnostics
+    # env["ROCPROFILER_LOG_LEVEL"] = "trace"
+    # env["AMD_LOG_LEVEL"] = "5"
 
-  r = subprocess.run([sys.executable, "-c", code],
-                     env=env, capture_output=True, text=True)
-  if r.returncode != 0:
-    raise RuntimeError(
-      "Child process failed.\n"
-      f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
+    r = subprocess.run(
+        [sys.executable, "-c", code], env=env, capture_output=True, text=True
     )
+    if r.returncode != 0:
+        raise RuntimeError(
+            f"Child failed for shape ({m},{k})x({k},{n}).\n"
+            f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
+        )
 
-  if not os.path.exists(activity_file):
-    raise RuntimeError(
-      f"XLA_ROCM_ACTIVITY_COUNT_FILE was not written: {activity_file}\n"
-      "Make sure the XLA ROCm backend writes total_activity_events to this file."
-    )
+    info = json.loads(r.stdout.splitlines()[-1])
+    return info["xplane"]
 
-  txt = open(activity_file, "r", encoding="utf-8").read().strip()
-  return int(txt)
 
 @jtu.thread_unsafe_test_class()
-class RocmProfilerPositiveControlTest(unittest.TestCase):
+class RocmProfilerMatmulGpuEventsTest(unittest.TestCase):
+    # these tests simply test if there are GPU events when doing matmul on ROCm
 
-  @jtu.run_on_devices("gpu")
-  def test_gpu_activity_events_present_by_default(self):
-    # ROCm-only gate using supported JAX API
-    from jax.extend import backend as jax_backend
-    be = jax_backend.get_backend()
-    platform_version = getattr(be, "platform_version", "") or ""
-    if "rocm" not in platform_version.lower():
-      self.skipTest(f"Not ROCm backend: {platform_version}")
+    @jtu.run_on_devices("gpu")
+    def test_gpu_events_present_for_many_matmul_shapes(self):
+        # ROCm-only gate using supported API
+        from jax.extend import backend as jax_backend
 
-    with tempfile.TemporaryDirectory() as td:
-      count = _run_child_and_get_activity_count(td)
+        be = jax_backend.get_backend()
+        platform_version = getattr(be, "platform_version", "") or ""
+        if "rocm" not in platform_version.lower():
+            self.skipTest(f"Not ROCm backend: {platform_version}")
 
-      self.assertGreater(
-        count, 0,
-        f"Expected >0 GPU activity events in normal profiling run; got {count}."
-      )
+        # test shapes:
+        shapes = [
+            (8, 8, 8),
+            (8, 32, 32),
+            (8, 128, 128),
+            (8, 256, 8),
+            (8, 512, 8),
+            (8, 1024, 256),
+            (512, 128, 512),
+            (1024, 128, 1024),
+            (1024, 1024, 1024),
+        ]
+
+        # NOTE: This is 15 subprocesses. If it’s too slow for CI, shrink the list
+        # or group some shapes per run.
+        for m, k, n in shapes:
+            with self.subTest(shape=f"{m}x{k}x{n}"):
+                with tempfile.TemporaryDirectory() as td:
+                    outdir = os.path.join(td, "profile")
+                    xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
+
+                    tv = _trace_viewer_json_from_xplane(xplane)
+                    traceevents = tv.get("traceEvents", [])
+                    gpu_events = _count_gpu_events_from_traceevents(traceevents)
+
+                    self.assertGreater(
+                        gpu_events,
+                        0,
+                        f"Expected >0 GPU events for matmul {m}x{n}; got {gpu_events}. xplane={xplane}",
+                    )
 
 
 # We do not allow multiple concurrent profiler sessions.
 @jtu.thread_unsafe_test_class()
 class ProfilerTest(unittest.TestCase):
-  # These tests simply test that the profiler API does not crash; they do not
-  # check functional correctness.
+    # These tests simply test that the profiler API does not crash; they do not
+    # check functional correctness.
 
-  def setUp(self):
-    if (
-        sys.version_info < (3, 14)
-        and hasattr(sys, "_is_gil_enabled")
-        and not sys._is_gil_enabled()
-    ):
-      self.skipTest(
-          "Profiler tests are not thread-safe under Python 3.13 free threading"
-      )
+    def setUp(self):
+        if (
+            sys.version_info < (3, 14)
+            and hasattr(sys, "_is_gil_enabled")
+            and not sys._is_gil_enabled()
+        ):
+            self.skipTest(
+                "Profiler tests are not thread-safe under Python 3.13 free threading"
+            )
 
-    super().setUp()
-    self.worker_start = threading.Event()
-    self.profile_done = False
+        super().setUp()
+        self.worker_start = threading.Event()
+        self.profile_done = False
 
-  @unittest.skipIf(not portpicker, "Test requires portpicker")
-  def testStartStopServer(self):
-    port = portpicker.pick_unused_port()
-    jax.profiler.start_server(port=port)
-    del port
-    jax.profiler.stop_server()
+    @unittest.skipIf(not portpicker, "Test requires portpicker")
+    def testStartStopServer(self):
+        port = portpicker.pick_unused_port()
+        jax.profiler.start_server(port=port)
+        del port
+        jax.profiler.stop_server()
 
-  @unittest.skipIf(not portpicker, "Test requires portpicker")
-  def testCantStartMultipleServers(self):
-    port = portpicker.pick_unused_port()
-    jax.profiler.start_server(port=port)
-    port = portpicker.pick_unused_port()
-    with self.assertRaisesRegex(
-        ValueError, "Only one profiler server can be active at a time."):
-      jax.profiler.start_server(port=port)
-    jax.profiler.stop_server()
-
-  def testCantStopServerBeforeStartingServer(self):
-    with self.assertRaisesRegex(ValueError, "No active profiler server."):
-      jax.profiler.stop_server()
-
-  def testProgrammaticProfiling(self):
-    with tempfile.TemporaryDirectory() as tmpdir:
-      try:
-        jax.profiler.start_trace(tmpdir)
-        jax.pmap(lambda x: jax.lax.psum(x + 1, 'i'), axis_name='i')(
-            jnp.ones(jax.local_device_count()))
-      finally:
-        jax.profiler.stop_trace()
-
-      proto_path = glob.glob(os.path.join(tmpdir, "**/*.xplane.pb"),
-                             recursive=True)
-      self.assertEqual(len(proto_path), 1)
-      with open(proto_path[0], "rb") as f:
-        proto = f.read()
-      # Sanity check that serialized proto contains host, device, and
-      # Python traces without deserializing.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-      self.assertIn(b"pxla.py", proto)
-
-  @unittest.skipIf(
-      jaxlib_extension_version < 379, "Requires jaxlib 0.8 or later."
-  )
-  def testProgrammaticProfilingConcurrency(self):
-    def work():
-      x = jax.pmap(lambda x: jax.lax.psum(x + 1, 'i'), axis_name='i')(
-          jnp.ones(jax.local_device_count()))
-      jax.block_until_ready(x)
-    with tempfile.TemporaryDirectory() as tmpdir:
-      try:
-        jax.profiler.start_trace(tmpdir)
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-          for _ in range(10):
-            executor.submit(work)
-      finally:
-        jax.profiler.stop_trace()
-
-      proto_path = glob.glob(os.path.join(tmpdir, "**/*.xplane.pb"),
-                             recursive=True)
-      self.assertEqual(len(proto_path), 1)
-      with open(proto_path[0], "rb") as f:
-        proto = f.read()
-      # Sanity check that serialized proto contains host, device, and
-      # Python traces without deserializing.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-      self.assertIn(b"pxla.py", proto)
-
-  def testProgrammaticProfilingWithOptions(self):
-    with tempfile.TemporaryDirectory() as tmpdir:
-      try:
-        options = jax.profiler.ProfileOptions()
-        options.python_tracer_level = 0
-        jax.profiler.start_trace(tmpdir, profiler_options=options)
-        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-            jnp.ones(jax.local_device_count())
-        )
-      finally:
-        jax.profiler.stop_trace()
-
-      proto_path = glob.glob(
-          os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
-      )
-      self.assertEqual(len(proto_path), 1)
-      with open(proto_path[0], "rb") as f:
-        proto = f.read()
-      # Verify that the serialized proto contains host and device traces, and
-      # does not contain Python traces.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-      self.assertNotIn(b"pxla.py", proto)
-
-  def testProgrammaticProfilingPathlib(self):
-    with tempfile.TemporaryDirectory() as tmpdir_string:
-      tmpdir = pathlib.Path(tmpdir_string)
-      try:
-        jax.profiler.start_trace(tmpdir)
-        jax.pmap(lambda x: jax.lax.psum(x + 1, 'i'), axis_name='i')(
-            jnp.ones(jax.local_device_count()))
-      finally:
-        jax.profiler.stop_trace()
-
-      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-      self.assertEqual(len(proto_path), 1)
-      proto = proto_path[0].read_bytes()
-      # Sanity check that serialized proto contains host, device, and
-      # Python traces without deserializing.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-      self.assertIn(b"pxla.py", proto)
-
-  def testProgrammaticProfilingWithOptionsPathlib(self):
-    with tempfile.TemporaryDirectory() as tmpdir_string:
-      tmpdir = pathlib.Path(tmpdir_string)
-      try:
-        options = jax.profiler.ProfileOptions()
-        options.advanced_configuration = {"tpu_trace_mode": "TRACE_ONLY_HOST"}
-        jax.profiler.start_trace(tmpdir, profiler_options=options)
-        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-            jnp.ones(jax.local_device_count())
-        )
-      finally:
-        jax.profiler.stop_trace()
-
-      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-      self.assertEqual(len(proto_path), 1)
-      proto = proto_path[0].read_bytes()
-      # Verify that the serialized proto contains host traces and does not
-      # contain TPU device traces.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertNotIn(b"/device:TPU", proto)
-      self.assertIn(b"pxla.py", proto)
-
-  def testProfilerGetFDOProfile(self):
-    # Tests stop_and_get_fod_profile could run.
-    try:
-      jax.profiler.start_trace("test")
-      jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-          jnp.ones(jax.local_device_count())
-      )
-    finally:
-      fdo_profile = profiler.stop_and_get_fdo_profile()
-    if jtu.test_device_matches(["gpu"]) and jtu.is_device_cuda():
-      self.assertIn(b"copy", fdo_profile)
-
-  def testProgrammaticProfilingErrors(self):
-    with self.assertRaisesRegex(RuntimeError, "No profile started"):
-      jax.profiler.stop_trace()
-
-    try:
-      with tempfile.TemporaryDirectory() as tmpdir:
-        jax.profiler.start_trace(tmpdir)
+    @unittest.skipIf(not portpicker, "Test requires portpicker")
+    def testCantStartMultipleServers(self):
+        port = portpicker.pick_unused_port()
+        jax.profiler.start_server(port=port)
+        port = portpicker.pick_unused_port()
         with self.assertRaisesRegex(
-          RuntimeError,
-          "Profile has already been started. Only one profile may be run at a "
-          "time."):
-          jax.profiler.start_trace(tmpdir)
-    finally:
-      jax.profiler.stop_trace()
+            ValueError, "Only one profiler server can be active at a time."
+        ):
+            jax.profiler.start_server(port=port)
+        jax.profiler.stop_server()
 
-  def testProgrammaticProfilingContextManager(self):
-    with tempfile.TemporaryDirectory() as tmpdir:
-      with jax.profiler.trace(tmpdir):
-        jax.pmap(lambda x: jax.lax.psum(x + 1, 'i'), axis_name='i')(
-            jnp.ones(jax.local_device_count()))
-
-      proto_path = glob.glob(os.path.join(tmpdir, "**/*.xplane.pb"),
-                             recursive=True)
-      self.assertEqual(len(proto_path), 1)
-      with open(proto_path[0], "rb") as f:
-        proto = f.read()
-      # Sanity check that serialized proto contains host and device traces
-      # without deserializing.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-
-  @jtu.run_on_devices("gpu")
-  @jtu.thread_unsafe_test()
-  def testProgrammaticGpuCuptiTracing(self):
-    @jit
-    def xy_plus_z(x, y, z):
-      return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-    k = jax.random.key(0)
-    s = 1, 16, 16
-    jax.devices()
-    x = jnp.int8(jax.random.normal(k, shape=s))
-    y = jnp.bfloat16(jax.random.normal(k, shape=s))
-    z = jnp.float32(jax.random.normal(k, shape=s))
-    with tempfile.TemporaryDirectory() as tmpdir_string:
-      tmpdir = pathlib.Path(tmpdir_string)
-      with jax.profiler.trace(tmpdir):
-        print(xy_plus_z(x, y, z))
-
-      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-      proto_bytes = proto_path[0].read_bytes()
-      self.assertIn(b"/device:GPU", proto_bytes)
-
-  @jtu.run_on_devices("gpu")
-  @jtu.thread_unsafe_test()
-  def testProgrammaticGpuCuptiTracingWithOptions(self):
-    @jit
-    def xy_plus_z(x, y, z):
-      return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-
-    k = jax.random.key(0)
-    s = 1, 16, 16
-    jax.devices()
-    x = jnp.int8(jax.random.normal(k, shape=s))
-    y = jnp.bfloat16(jax.random.normal(k, shape=s))
-    z = jnp.float32(jax.random.normal(k, shape=s))
-    with tempfile.TemporaryDirectory() as tmpdir_string:
-      tmpdir = pathlib.Path(tmpdir_string)
-      options = jax.profiler.ProfileOptions()
-      options.advanced_configuration = {
-          "gpu_max_callback_api_events": 1000000,
-          "gpu_enable_nvtx_tracking": True,
-      }
-      with jax.profiler.trace(tmpdir):
-        xy_plus_z(x, y, z).block_until_ready()
-
-      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-      proto_bytes = proto_path[0].read_bytes()
-      self.assertIn(b"/device:GPU", proto_bytes)
-
-  # TODO: b/443121646 - Enable PM sampling test on JAX OSS once the Github CI
-  # host machine has privileged access.
-  # @jtu.run_on_devices("gpu")
-  # @jtu.thread_unsafe_test()
-  # def testProgrammaticGpuCuptiTracingWithPmSampling(self):
-  #   if not (jtu.is_cuda_compute_capability_equal("9.0")):
-  #     self.skipTest("Only works on GPU with capability sm90")
-
-  #   @jit
-  #   def xy_plus_z(x, y, z):
-  #     return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-
-  #   k = jax.random.key(0)
-  #   s = 1, 16, 16
-  #   jax.devices()
-  #   x = jnp.int8(jax.random.normal(k, shape=s))
-  #   y = jnp.bfloat16(jax.random.normal(k, shape=s))
-  #   z = jnp.float32(jax.random.normal(k, shape=s))
-  #   with tempfile.TemporaryDirectory() as tmpdir_string:
-  #     tmpdir = pathlib.Path(tmpdir_string)
-  #     options = jax.profiler.ProfileOptions()
-  #     options.advanced_configuration = {
-  #         "gpu_pm_sample_counters": (
-  #             "sm__cycles_active.sum"
-  #         ),
-  #         "gpu_pm_sample_interval_us": 500,
-  #     }
-  #     with jax.profiler.trace(tmpdir, profiler_options=options):
-  #       xy_plus_z(x, y, z).block_until_ready()
-
-  #     proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-  #     proto_bytes = proto_path[0].read_bytes()
-  #     self.assertIn(b"/device:GPU", proto_bytes)
-  #     self.assertIn(
-  #         b"sm__cycles_active.sum", proto_bytes
-  #     )
-
-  def testProgrammaticProfilingContextManagerPathlib(self):
-    with tempfile.TemporaryDirectory() as tmpdir_string:
-      tmpdir = pathlib.Path(tmpdir_string)
-      with jax.profiler.trace(tmpdir):
-        jax.pmap(lambda x: jax.lax.psum(x + 1, 'i'), axis_name='i')(
-            jnp.ones(jax.local_device_count()))
-
-      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-      self.assertEqual(len(proto_path), 1)
-      proto = proto_path[0].read_bytes()
-      # Sanity check that serialized proto contains host and device traces
-      # without deserializing.
-      self.assertIn(b"/host:CPU", proto)
-      if jtu.test_device_matches(["tpu"]):
-        self.assertIn(b"/device:TPU", proto)
-
-  def testTraceAnnotation(self):
-    x = 3
-    with jax.profiler.TraceAnnotation("mycontext"):
-      x = x + 2
-
-  def testTraceFunction(self):
-    @jax.profiler.annotate_function
-    def f(x, *, y):
-      return x + 2 * y
-    self.assertEqual(f(7, y=3), 13)
-
-    @jax.profiler.annotate_function
-    def f(x, *, name):
-      return x + 2 * len(name)
-    self.assertEqual(f(7, name="abc"), 13)
-
-    @partial(jax.profiler.annotate_function, name="aname")
-    def g(x):
-      return x + 2
-    self.assertEqual(g(7), 9)
-
-    @partial(jax.profiler.annotate_function, name="aname", akwarg="hello")
-    def h(x):
-      return x + 2
-    self.assertEqual(h(7), 9)
-
-  def testDeviceMemoryProfile(self):
-    x = jnp.ones((20,)) + 7.
-    self.assertIsInstance(jax.profiler.device_memory_profile(), bytes)
-    del x
-
-  def _check_xspace_pb_exist(self, logdir):
-    path = os.path.join(logdir, 'plugins', 'profile', '*', '*.xplane.pb')
-    self.assertEqual(1, len(glob.glob(path)),
-                     'Expected one path match: ' + path)
-
-  @unittest.skip("Test causes OOMs")
-  @unittest.skipIf(not (portpicker and _pywrap_profiler_plugin),
-    "Test requires xprof and portpicker")
-  def testSingleWorkerSamplingMode(self, delay_ms=None):
-    def on_worker(port, worker_start):
-      jax.profiler.start_server(port)
-      worker_start.set()
-      x = jnp.ones((1000, 1000))
-      while True:
-        with jax.profiler.TraceAnnotation("atraceannotation"):
-          jnp.dot(x, x.T).block_until_ready()
-          if self.profile_done:
+    def testCantStopServerBeforeStartingServer(self):
+        with self.assertRaisesRegex(ValueError, "No active profiler server."):
             jax.profiler.stop_server()
-            break
 
-    def on_profile(port, logdir, worker_start):
-      worker_start.wait()
-      options = {
-          "host_tracer_level": 2,
-          "python_tracer_level": 2,
-          "device_tracer_level": 1,
-          "delay_ms": delay_ms,
-      }
+    def testProgrammaticProfiling(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                jax.profiler.start_trace(tmpdir)
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+            finally:
+                jax.profiler.stop_trace()
 
-      # Request for 1000 milliseconds of profile.
-      duration_ms = 1000
-      _pywrap_profiler_plugin.trace(
-          f'localhost:{port}',
-          logdir,
-          '',
-          True,
-          duration_ms,
-          3,
-          options
-      )
-      self.profile_done = True
+            proto_path = glob.glob(
+                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+            )
+            self.assertEqual(len(proto_path), 1)
+            with open(proto_path[0], "rb") as f:
+                proto = f.read()
+            # Sanity check that serialized proto contains host, device, and
+            # Python traces without deserializing.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+            self.assertIn(b"pxla.py", proto)
 
-    logdir = absltest.get_default_test_tmpdir()
-    # Remove any existing log files.
-    shutil.rmtree(logdir, ignore_errors=True)
-    port = portpicker.pick_unused_port()
-    thread_profiler = threading.Thread(
-        target=on_profile, args=(port, logdir, self.worker_start))
-    thread_worker = threading.Thread(
-        target=on_worker, args=(port, self.worker_start))
-    thread_worker.start()
-    thread_profiler.start()
-    thread_profiler.join()
-    thread_worker.join(120)
-    self._check_xspace_pb_exist(logdir)
+    @unittest.skipIf(jaxlib_extension_version < 379, "Requires jaxlib 0.8 or later.")
+    def testProgrammaticProfilingConcurrency(self):
+        def work():
+            x = jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                jnp.ones(jax.local_device_count())
+            )
+            jax.block_until_ready(x)
 
-  @unittest.skipIf(
-      not (portpicker and _pywrap_profiler_plugin),
-    "Test requires xprof and portpicker")
-  def test_remote_profiler(self):
-    port = portpicker.pick_unused_port()
-    jax.profiler.start_server(port)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                jax.profiler.start_trace(tmpdir)
+                with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+                    for _ in range(10):
+                        executor.submit(work)
+            finally:
+                jax.profiler.stop_trace()
 
-    profile_done = threading.Event()
-    logdir = absltest.get_default_test_tmpdir()
-    # Remove any existing log files.
-    shutil.rmtree(logdir, ignore_errors=True)
-    def on_profile():
-      os.system(
-          f"{sys.executable} -m jax.collect_profile {port} 500 "
-          f"--log_dir {logdir} --no_perfetto_link")
-      profile_done.set()
+            proto_path = glob.glob(
+                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+            )
+            self.assertEqual(len(proto_path), 1)
+            with open(proto_path[0], "rb") as f:
+                proto = f.read()
+            # Sanity check that serialized proto contains host, device, and
+            # Python traces without deserializing.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+            self.assertIn(b"pxla.py", proto)
 
-    thread_profiler = threading.Thread(
-        target=on_profile, args=())
-    thread_profiler.start()
-    start_time = time.time()
-    y = jnp.zeros((5, 5))
-    while not profile_done.is_set():
-      # The timeout here must be relatively high. The profiler takes a while to
-      # start up on Cloud TPUs.
-      if time.time() - start_time > 30:
-        raise RuntimeError("Profile did not complete in 30s")
-      y = jnp.dot(y, y)
-    jax.profiler.stop_server()
-    thread_profiler.join()
-    self._check_xspace_pb_exist(logdir)
+    def testProgrammaticProfilingWithOptions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            try:
+                options = jax.profiler.ProfileOptions()
+                options.python_tracer_level = 0
+                jax.profiler.start_trace(tmpdir, profiler_options=options)
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+            finally:
+                jax.profiler.stop_trace()
 
-  @unittest.skip("Profiler takes >30s on Cloud TPUs")
-  @unittest.skipIf(
-      not (portpicker and _pywrap_profiler_plugin),
-    "Test requires xprof and portpicker")
-  def test_remote_profiler_gcs_path(self):
-    port = portpicker.pick_unused_port()
-    jax.profiler.start_server(port)
+            proto_path = glob.glob(
+                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+            )
+            self.assertEqual(len(proto_path), 1)
+            with open(proto_path[0], "rb") as f:
+                proto = f.read()
+            # Verify that the serialized proto contains host and device traces, and
+            # does not contain Python traces.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+            self.assertNotIn(b"pxla.py", proto)
 
-    profile_done = threading.Event()
-    logdir = "gs://mock-test-bucket/test-dir"
-    # Mock XProf call in collect_profile.
-    _pywrap_profiler_plugin.trace = unittest.mock.MagicMock()
-    def on_profile():
-      jax.collect_profile(port, 500, logdir, no_perfetto_link=True)
-      profile_done.set()
+    def testProgrammaticProfilingPathlib(self):
+        with tempfile.TemporaryDirectory() as tmpdir_string:
+            tmpdir = pathlib.Path(tmpdir_string)
+            try:
+                jax.profiler.start_trace(tmpdir)
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+            finally:
+                jax.profiler.stop_trace()
 
-    thread_profiler = threading.Thread(
-        target=on_profile, args=())
-    thread_profiler.start()
-    start_time = time.time()
-    y = jnp.zeros((5, 5))
-    while not profile_done.is_set():
-      # The timeout here must be relatively high. The profiler takes a while to
-      # start up on Cloud TPUs.
-      if time.time() - start_time > 30:
-        raise RuntimeError("Profile did not complete in 30s")
-      y = jnp.dot(y, y)
-    jax.profiler.stop_server()
-    thread_profiler.join()
-    _pywrap_profiler_plugin.trace.assert_called_once_with(
-        unittest.mock.ANY,
-        logdir,
-        unittest.mock.ANY,
-        unittest.mock.ANY,
-        unittest.mock.ANY,
-        unittest.mock.ANY,
-        unittest.mock.ANY,
+            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+            self.assertEqual(len(proto_path), 1)
+            proto = proto_path[0].read_bytes()
+            # Sanity check that serialized proto contains host, device, and
+            # Python traces without deserializing.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+            self.assertIn(b"pxla.py", proto)
+
+    def testProgrammaticProfilingWithOptionsPathlib(self):
+        with tempfile.TemporaryDirectory() as tmpdir_string:
+            tmpdir = pathlib.Path(tmpdir_string)
+            try:
+                options = jax.profiler.ProfileOptions()
+                options.advanced_configuration = {"tpu_trace_mode": "TRACE_ONLY_HOST"}
+                jax.profiler.start_trace(tmpdir, profiler_options=options)
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+            finally:
+                jax.profiler.stop_trace()
+
+            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+            self.assertEqual(len(proto_path), 1)
+            proto = proto_path[0].read_bytes()
+            # Verify that the serialized proto contains host traces and does not
+            # contain TPU device traces.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertNotIn(b"/device:TPU", proto)
+            self.assertIn(b"pxla.py", proto)
+
+    def testProfilerGetFDOProfile(self):
+        # Tests stop_and_get_fod_profile could run.
+        try:
+            jax.profiler.start_trace("test")
+            jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                jnp.ones(jax.local_device_count())
+            )
+        finally:
+            fdo_profile = profiler.stop_and_get_fdo_profile()
+        if jtu.test_device_matches(["gpu"]) and jtu.is_device_cuda():
+            self.assertIn(b"copy", fdo_profile)
+
+    def testProgrammaticProfilingErrors(self):
+        with self.assertRaisesRegex(RuntimeError, "No profile started"):
+            jax.profiler.stop_trace()
+
+        try:
+            with tempfile.TemporaryDirectory() as tmpdir:
+                jax.profiler.start_trace(tmpdir)
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "Profile has already been started. Only one profile may be run at a "
+                    "time.",
+                ):
+                    jax.profiler.start_trace(tmpdir)
+        finally:
+            jax.profiler.stop_trace()
+
+    def testProgrammaticProfilingContextManager(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with jax.profiler.trace(tmpdir):
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+
+            proto_path = glob.glob(
+                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+            )
+            self.assertEqual(len(proto_path), 1)
+            with open(proto_path[0], "rb") as f:
+                proto = f.read()
+            # Sanity check that serialized proto contains host and device traces
+            # without deserializing.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+
+    @jtu.run_on_devices("gpu")
+    @jtu.thread_unsafe_test()
+    def testProgrammaticGpuCuptiTracing(self):
+        @jit
+        def xy_plus_z(x, y, z):
+            return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+        k = jax.random.key(0)
+        s = 1, 16, 16
+        jax.devices()
+        x = jnp.int8(jax.random.normal(k, shape=s))
+        y = jnp.bfloat16(jax.random.normal(k, shape=s))
+        z = jnp.float32(jax.random.normal(k, shape=s))
+        with tempfile.TemporaryDirectory() as tmpdir_string:
+            tmpdir = pathlib.Path(tmpdir_string)
+            with jax.profiler.trace(tmpdir):
+                print(xy_plus_z(x, y, z))
+
+            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+            proto_bytes = proto_path[0].read_bytes()
+            self.assertIn(b"/device:GPU", proto_bytes)
+
+    @jtu.run_on_devices("gpu")
+    @jtu.thread_unsafe_test()
+    def testProgrammaticGpuCuptiTracingWithOptions(self):
+        @jit
+        def xy_plus_z(x, y, z):
+            return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+        k = jax.random.key(0)
+        s = 1, 16, 16
+        jax.devices()
+        x = jnp.int8(jax.random.normal(k, shape=s))
+        y = jnp.bfloat16(jax.random.normal(k, shape=s))
+        z = jnp.float32(jax.random.normal(k, shape=s))
+        with tempfile.TemporaryDirectory() as tmpdir_string:
+            tmpdir = pathlib.Path(tmpdir_string)
+            options = jax.profiler.ProfileOptions()
+            options.advanced_configuration = {
+                "gpu_max_callback_api_events": 1000000,
+                "gpu_enable_nvtx_tracking": True,
+            }
+            with jax.profiler.trace(tmpdir):
+                xy_plus_z(x, y, z).block_until_ready()
+
+            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+            proto_bytes = proto_path[0].read_bytes()
+            self.assertIn(b"/device:GPU", proto_bytes)
+
+    # TODO: b/443121646 - Enable PM sampling test on JAX OSS once the Github CI
+    # host machine has privileged access.
+    # @jtu.run_on_devices("gpu")
+    # @jtu.thread_unsafe_test()
+    # def testProgrammaticGpuCuptiTracingWithPmSampling(self):
+    #   if not (jtu.is_cuda_compute_capability_equal("9.0")):
+    #     self.skipTest("Only works on GPU with capability sm90")
+
+    #   @jit
+    #   def xy_plus_z(x, y, z):
+    #     return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+    #   k = jax.random.key(0)
+    #   s = 1, 16, 16
+    #   jax.devices()
+    #   x = jnp.int8(jax.random.normal(k, shape=s))
+    #   y = jnp.bfloat16(jax.random.normal(k, shape=s))
+    #   z = jnp.float32(jax.random.normal(k, shape=s))
+    #   with tempfile.TemporaryDirectory() as tmpdir_string:
+    #     tmpdir = pathlib.Path(tmpdir_string)
+    #     options = jax.profiler.ProfileOptions()
+    #     options.advanced_configuration = {
+    #         "gpu_pm_sample_counters": (
+    #             "sm__cycles_active.sum"
+    #         ),
+    #         "gpu_pm_sample_interval_us": 500,
+    #     }
+    #     with jax.profiler.trace(tmpdir, profiler_options=options):
+    #       xy_plus_z(x, y, z).block_until_ready()
+
+    #     proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+    #     proto_bytes = proto_path[0].read_bytes()
+    #     self.assertIn(b"/device:GPU", proto_bytes)
+    #     self.assertIn(
+    #         b"sm__cycles_active.sum", proto_bytes
+    #     )
+
+    def testProgrammaticProfilingContextManagerPathlib(self):
+        with tempfile.TemporaryDirectory() as tmpdir_string:
+            tmpdir = pathlib.Path(tmpdir_string)
+            with jax.profiler.trace(tmpdir):
+                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+                    jnp.ones(jax.local_device_count())
+                )
+
+            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+            self.assertEqual(len(proto_path), 1)
+            proto = proto_path[0].read_bytes()
+            # Sanity check that serialized proto contains host and device traces
+            # without deserializing.
+            self.assertIn(b"/host:CPU", proto)
+            if jtu.test_device_matches(["tpu"]):
+                self.assertIn(b"/device:TPU", proto)
+
+    def testTraceAnnotation(self):
+        x = 3
+        with jax.profiler.TraceAnnotation("mycontext"):
+            x = x + 2
+
+    def testTraceFunction(self):
+        @jax.profiler.annotate_function
+        def f(x, *, y):
+            return x + 2 * y
+
+        self.assertEqual(f(7, y=3), 13)
+
+        @jax.profiler.annotate_function
+        def f(x, *, name):
+            return x + 2 * len(name)
+
+        self.assertEqual(f(7, name="abc"), 13)
+
+        @partial(jax.profiler.annotate_function, name="aname")
+        def g(x):
+            return x + 2
+
+        self.assertEqual(g(7), 9)
+
+        @partial(jax.profiler.annotate_function, name="aname", akwarg="hello")
+        def h(x):
+            return x + 2
+
+        self.assertEqual(h(7), 9)
+
+    def testDeviceMemoryProfile(self):
+        x = jnp.ones((20,)) + 7.0
+        self.assertIsInstance(jax.profiler.device_memory_profile(), bytes)
+        del x
+
+    def _check_xspace_pb_exist(self, logdir):
+        path = os.path.join(logdir, "plugins", "profile", "*", "*.xplane.pb")
+        self.assertEqual(1, len(glob.glob(path)), "Expected one path match: " + path)
+
+    @unittest.skip("Test causes OOMs")
+    @unittest.skipIf(
+        not (portpicker and _pywrap_profiler_plugin),
+        "Test requires xprof and portpicker",
     )
+    def testSingleWorkerSamplingMode(self, delay_ms=None):
+        def on_worker(port, worker_start):
+            jax.profiler.start_server(port)
+            worker_start.set()
+            x = jnp.ones((1000, 1000))
+            while True:
+                with jax.profiler.TraceAnnotation("atraceannotation"):
+                    jnp.dot(x, x.T).block_until_ready()
+                    if self.profile_done:
+                        jax.profiler.stop_server()
+                        break
+
+        def on_profile(port, logdir, worker_start):
+            worker_start.wait()
+            options = {
+                "host_tracer_level": 2,
+                "python_tracer_level": 2,
+                "device_tracer_level": 1,
+                "delay_ms": delay_ms,
+            }
+
+            # Request for 1000 milliseconds of profile.
+            duration_ms = 1000
+            _pywrap_profiler_plugin.trace(
+                f"localhost:{port}", logdir, "", True, duration_ms, 3, options
+            )
+            self.profile_done = True
+
+        logdir = absltest.get_default_test_tmpdir()
+        # Remove any existing log files.
+        shutil.rmtree(logdir, ignore_errors=True)
+        port = portpicker.pick_unused_port()
+        thread_profiler = threading.Thread(
+            target=on_profile, args=(port, logdir, self.worker_start)
+        )
+        thread_worker = threading.Thread(
+            target=on_worker, args=(port, self.worker_start)
+        )
+        thread_worker.start()
+        thread_profiler.start()
+        thread_profiler.join()
+        thread_worker.join(120)
+        self._check_xspace_pb_exist(logdir)
+
+    @unittest.skipIf(
+        not (portpicker and _pywrap_profiler_plugin),
+        "Test requires xprof and portpicker",
+    )
+    def test_remote_profiler(self):
+        port = portpicker.pick_unused_port()
+        jax.profiler.start_server(port)
+
+        profile_done = threading.Event()
+        logdir = absltest.get_default_test_tmpdir()
+        # Remove any existing log files.
+        shutil.rmtree(logdir, ignore_errors=True)
+
+        def on_profile():
+            os.system(
+                f"{sys.executable} -m jax.collect_profile {port} 500 "
+                f"--log_dir {logdir} --no_perfetto_link"
+            )
+            profile_done.set()
+
+        thread_profiler = threading.Thread(target=on_profile, args=())
+        thread_profiler.start()
+        start_time = time.time()
+        y = jnp.zeros((5, 5))
+        while not profile_done.is_set():
+            # The timeout here must be relatively high. The profiler takes a while to
+            # start up on Cloud TPUs.
+            if time.time() - start_time > 30:
+                raise RuntimeError("Profile did not complete in 30s")
+            y = jnp.dot(y, y)
+        jax.profiler.stop_server()
+        thread_profiler.join()
+        self._check_xspace_pb_exist(logdir)
+
+    @unittest.skip("Profiler takes >30s on Cloud TPUs")
+    @unittest.skipIf(
+        not (portpicker and _pywrap_profiler_plugin),
+        "Test requires xprof and portpicker",
+    )
+    def test_remote_profiler_gcs_path(self):
+        port = portpicker.pick_unused_port()
+        jax.profiler.start_server(port)
+
+        profile_done = threading.Event()
+        logdir = "gs://mock-test-bucket/test-dir"
+        # Mock XProf call in collect_profile.
+        _pywrap_profiler_plugin.trace = unittest.mock.MagicMock()
+
+        def on_profile():
+            jax.collect_profile(port, 500, logdir, no_perfetto_link=True)
+            profile_done.set()
+
+        thread_profiler = threading.Thread(target=on_profile, args=())
+        thread_profiler.start()
+        start_time = time.time()
+        y = jnp.zeros((5, 5))
+        while not profile_done.is_set():
+            # The timeout here must be relatively high. The profiler takes a while to
+            # start up on Cloud TPUs.
+            if time.time() - start_time > 30:
+                raise RuntimeError("Profile did not complete in 30s")
+            y = jnp.dot(y, y)
+        jax.profiler.stop_server()
+        thread_profiler.join()
+        _pywrap_profiler_plugin.trace.assert_called_once_with(
+            unittest.mock.ANY,
+            logdir,
+            unittest.mock.ANY,
+            unittest.mock.ANY,
+            unittest.mock.ANY,
+            unittest.mock.ANY,
+            unittest.mock.ANY,
+        )
+
 
 if __name__ == "__main__":
-  absltest.main(testLoader=jtu.JaxTestLoader())
+    absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -65,26 +65,26 @@ def _run_child_and_get_activity_count(tmpdir: str) -> int:
   outdir = os.path.join(tmpdir, "profile")
 
   code = r"""
-    import os
-    import jax, jax.numpy as jnp
-    from jax import jit
-    import jax.profiler
+import os
+import jax, jax.numpy as jnp
+from jax import jit
+import jax.profiler
 
-    @jit
-    def f(a, b):
-      return jnp.dot(a, b)
+@jit
+def f(a, b):
+  return jnp.dot(a, b)
 
-    a = jnp.ones((1024, 1024), dtype=jnp.float16)
-    b = jnp.ones((1024, 1024), dtype=jnp.float16)
+a = jnp.ones((1024, 1024), dtype=jnp.float16)
+b = jnp.ones((1024, 1024), dtype=jnp.float16)
 
-    # Warm-up compile outside trace.
+# Warm-up compile outside trace.
+f(a, b).block_until_ready()
+
+outdir = os.environ["OUTDIR"]
+with jax.profiler.trace(outdir):
+  for _ in range(5):
     f(a, b).block_until_ready()
-
-    outdir = os.environ["OUTDIR"]
-    with jax.profiler.trace(outdir):
-      for _ in range(5):
-        f(a, b).block_until_ready()
-    """
+"""
 
   env = os.environ.copy()
   env["OUTDIR"] = outdir

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -182,52 +182,6 @@ print(json.dumps({"xplane": pbs[0]}))
     return info["xplane"]
 
 
-@jtu.thread_unsafe_test_class()
-class RocmProfilerMatmulGpuEventsTest(unittest.TestCase):
-    # these tests simply test if there are GPU events when doing matmul on ROCm
-
-    @jtu.run_on_devices("gpu")
-    def test_gpu_events_present_for_many_matmul_shapes(self):
-        # ROCm-only gate using supported API
-        from jax.extend import backend as jax_backend
-
-        be = jax_backend.get_backend()
-        platform_version = getattr(be, "platform_version", "") or ""
-        if "rocm" not in platform_version.lower():
-            self.skipTest(f"Not ROCm backend: {platform_version}")
-
-        # test shapes:
-        shapes = [
-            (8, 8, 8),
-            (8, 32, 32),
-            (8, 128, 128),
-            (8, 256, 8),
-            (8, 512, 8),
-            (8, 1024, 256),
-            (512, 128, 512),
-            (1024, 128, 1024),
-            (1024, 1024, 1024),
-        ]
-
-        # NOTE: This is 15 subprocesses. If it’s too slow for CI, shrink the list
-        # or group some shapes per run.
-        for m, k, n in shapes:
-            with self.subTest(shape=f"{m}x{k}x{n}"):
-                with tempfile.TemporaryDirectory() as td:
-                    outdir = os.path.join(td, "profile")
-                    xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
-
-                    tv = _trace_viewer_json_from_xplane(xplane)
-                    traceevents = tv.get("traceEvents", [])
-                    gpu_events = _count_gpu_events_from_traceevents(traceevents)
-
-                    self.assertGreater(
-                        gpu_events,
-                        0,
-                        f"Expected >0 GPU events for matmul {m}x{n}; got {gpu_events}. xplane={xplane}",
-                    )
-
-
 # We do not allow multiple concurrent profiler sessions.
 @jtu.thread_unsafe_test_class()
 class ProfilerTest(unittest.TestCase):
@@ -703,6 +657,46 @@ class ProfilerTest(unittest.TestCase):
             unittest.mock.ANY,
             unittest.mock.ANY,
         )
+
+    # test if there are GPU events when doing profiling via matmul on ROCm
+    @jtu.run_on_devices("gpu")
+    def test_gpu_events_present_for_many_matmul_shapes(self):
+        # ROCm-only gate using supported API
+        from jax.extend import backend as jax_backend
+
+        be = jax_backend.get_backend()
+        platform_version = getattr(be, "platform_version", "") or ""
+        if "rocm" not in platform_version.lower():
+            self.skipTest(f"Not ROCm backend: {platform_version}")
+
+        # test shapes:
+        shapes = [
+            (8, 8, 8),
+            (8, 32, 32),
+            (8, 128, 128),
+            (8, 256, 8),
+            (8, 512, 8),
+            (8, 1024, 256),
+            (512, 128, 512),
+            (1024, 128, 1024),
+            (1024, 1024, 1024),
+        ]
+
+        for m, k, n in shapes:
+            with self.subTest(shape=f"{m}x{k}x{n}"):
+                with tempfile.TemporaryDirectory() as td:
+                    outdir = os.path.join(td, "profile")
+                    xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
+
+                    tv = _trace_viewer_json_from_xplane(xplane)
+                    traceevents = tv.get("traceEvents", [])
+                    gpu_events = _count_gpu_events_from_traceevents(traceevents)
+
+                    self.assertGreater(
+                        gpu_events,
+                        0,
+                        f"Expected >0 GPU events for matmul {m}x{n}; got {gpu_events}. xplane={xplane}",
+                    )
 
 
 if __name__ == "__main__":

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -15,14 +15,12 @@
 import concurrent.futures
 from functools import partial
 import glob
-import json
 import os
 import shutil
 import sys
 import tempfile
 import threading
 import time
-from typing import List, Dict, Set, Any, Tuple
 import unittest
 import unittest.mock
 from absl.testing import absltest
@@ -32,8 +30,9 @@ import jax
 import jax.numpy as jnp
 import jax.profiler
 import jax._src.test_util as jtu
-from jax._src.lib import jaxlib_extension_version
+
 from jax._src import profiler
+from jax._src.lib import jaxlib_extension_version
 from jax import jit
 
 
@@ -49,223 +48,6 @@ except ImportError:
   _pywrap_profiler_plugin = None
 
 jax.config.parse_flags_with_absl()
-
-# Constant for the trace viewer tool specification
-_TRACE_VIEWER_TOOL_SPEC = "trace_viewer@^"
-# Trace event constants
-_METADATA_EVENT = "M"
-_DURATION_EVENT = "X"
-_PROCESS_NAME_KEY = "process_name"
-_THREAD_NAME_KEY = "thread_name"
-_GPU_DEVICE_MARKER = "/device:GPU"
-_KERNEL_MARKER = "(Kernel)"
-
-
-def _trace_viewer_json_from_xplane(pb_path: str) -> Dict[str, Any]:
-  """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin.
-
-  Args:
-    pb_path: Path to the xplane.pb protobuf file.
-
-  Returns:
-    Dictionary containing trace viewer data parsed from the xplane protobuf.
-
-  Raises:
-    FileNotFoundError: If the pb_path does not exist.
-    ImportError: If neither tensorboard_plugin_profile nor xprof is available.
-    RuntimeError: If conversion or JSON decoding fails.
-  """
-  if not os.path.exists(pb_path):
-    raise FileNotFoundError(f"XPlane file not found: {pb_path}")
-
-  # Try xprof first (JAX's profiler tools), then tensorboard as fallback
-  convert = None
-  errors = []
-
-  try:
-    from xprof.convert import raw_to_tool_data as convert
-  except (ImportError, AttributeError) as e:
-    errors.append(f"xprof: {e}")
-
-  if convert is None:
-    try:
-      from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
-    except (ImportError, AttributeError) as e:
-      errors.append(f"tensorboard_plugin_profile: {e}")
-
-  if convert is None:
-    raise ImportError(
-      "Failed to import profiler conversion tools. " f"Tried: {', '.join(errors)}"
-    )
-
-  try:
-    result, _ = convert.xspace_to_tool_data([pb_path], _TRACE_VIEWER_TOOL_SPEC, {})
-  except Exception as e:
-    raise RuntimeError(f"Failed to convert xplane to trace viewer data: {e}") from e
-
-  # result is bytes in UTF-8 encoding
-  try:
-    return json.loads(result.decode("utf-8"))
-  except (UnicodeDecodeError, json.JSONDecodeError) as e:
-    # Show first 100 bytes of result for debugging
-    preview = str(result[:100]) if isinstance(result, bytes) else str(result)[:100]
-    raise RuntimeError(
-      f"Failed to decode trace viewer JSON: {e}. " f"Result preview: {preview}"
-    ) from e
-
-
-def _count_gpu_events_from_traceevents(traceevents: List[Dict[str, Any]]) -> int:
-  """
-  Count GPU *kernel-stream* duration events in Trace Viewer traceEvents.
-
-  Strategy:
-  - GPU PIDs are discovered via process_name metadata that CONTAINS '/device:GPU'
-  - Kernel stream TIDs are discovered via thread_name metadata containing '(Kernel)'.
-  - We count only 'ph'=='X' events with 'dur' on those (pid, tid).
-  - Fallback: if we can't find kernel tids, count all 'X' events on GPU pids.
-
-  Args:
-    traceevents: List of trace event dictionaries from Trace Viewer JSON.
-
-  Returns:
-    Count of GPU kernel duration events found.
-  """
-  gpu_pids, kernel_tids_by_pid = _extract_gpu_metadata(traceevents)
-
-  if not gpu_pids:
-    return 0
-
-  has_kernel_tids = any(kernel_tids_by_pid.values())
-  return _count_duration_events(
-    traceevents, gpu_pids, kernel_tids_by_pid, has_kernel_tids
-  )
-
-
-def _extract_gpu_metadata(
-  traceevents: List[Dict[str, Any]],
-) -> Tuple[Set[int], Dict[int, Set[int]]]:
-  """Extract GPU process IDs and kernel thread IDs from metadata events.
-
-  Args:
-    traceevents: List of trace event dictionaries.
-
-  Returns:
-    Tuple of (gpu_pids, kernel_tids_by_pid) where:
-    - gpu_pids: Set of process IDs corresponding to GPU devices
-    - kernel_tids_by_pid: Dict mapping each GPU PID to its kernel thread IDs
-  """
-  gpu_pids: Set[int] = set()
-  kernel_tids_by_pid: Dict[int, Set[int]] = {}
-
-  for event in traceevents:
-    if event.get("ph") != _METADATA_EVENT:
-      continue
-
-    event_name = event.get("name")
-
-    # Extract GPU process IDs
-    if event_name == _PROCESS_NAME_KEY:
-      process_name = event.get("args", {}).get("name", "")
-      if isinstance(process_name, str) and _GPU_DEVICE_MARKER in process_name:
-        pid = event.get("pid")
-        if pid is not None:
-          gpu_pids.add(pid)
-          kernel_tids_by_pid.setdefault(pid, set())
-
-    # Extract kernel thread IDs for GPU processes
-    elif event_name == _THREAD_NAME_KEY:
-      pid = event.get("pid")
-      tid = event.get("tid")
-      if pid in gpu_pids and tid is not None:
-        thread_name = event.get("args", {}).get("name", "")
-        if isinstance(thread_name, str) and _KERNEL_MARKER in thread_name:
-          kernel_tids_by_pid[pid].add(tid)
-
-  return gpu_pids, kernel_tids_by_pid
-
-
-def _count_duration_events(
-  traceevents: List[Dict[str, Any]],
-  gpu_pids: Set[int],
-  kernel_tids_by_pid: Dict[int, Set[int]],
-  has_kernel_tids: bool,
-) -> int:
-  """Count duration events on GPU processes/threads.
-
-  Args:
-    traceevents: List of trace event dictionaries.
-    gpu_pids: Set of GPU process IDs.
-    kernel_tids_by_pid: Mapping of GPU PIDs to kernel thread IDs.
-    has_kernel_tids: Whether any kernel TIDs were found.
-
-  Returns:
-    Count of matching duration events.
-  """
-  count = 0
-
-  for event in traceevents:
-    # Only count duration events with a 'dur' field
-    if event.get("ph") != _DURATION_EVENT or "dur" not in event:
-      continue
-
-    pid = event.get("pid")
-    if pid not in gpu_pids:
-      continue
-
-    # If we have kernel TID info, filter by those; otherwise count all GPU events
-    if has_kernel_tids:
-      tid = event.get("tid")
-      if tid in kernel_tids_by_pid.get(pid, set()):
-        count += 1
-    else:
-      count += 1
-
-  return count
-
-
-def _find_and_read_trace_json_gz(profile_dir: str) -> Dict[str, Any]:
-  """Find and read the trace.json.gz file from a profile directory.
-
-  Args:
-    profile_dir: Path to the profile directory.
-
-  Returns:
-    Parsed JSON data from the trace file.
-
-  Raises:
-    FileNotFoundError: If no trace.json.gz file is found.
-  """
-  import gzip
-
-  # Search for trace.json.gz files
-  trace_files = glob.glob(
-    os.path.join(profile_dir, "**", "*.trace.json.gz"), recursive=True
-  )
-  if not trace_files:
-    raise FileNotFoundError(f"No trace.json.gz found in {profile_dir}")
-
-  # Use the first trace file found
-  trace_file = trace_files[0]
-
-  with gzip.open(trace_file, "rt", encoding="utf-8") as f:
-    return json.load(f)
-
-
-def _count_events_with_kernel_details(traceevents: List[Dict[str, Any]]) -> int:
-  """Count trace events that contain kernel_details in their args.
-
-  Args:
-    traceevents: List of trace event dictionaries.
-
-  Returns:
-    Count of events with kernel_details.
-  """
-  count = 0
-  for event in traceevents:
-    args = event.get("args", {})
-    if "kernel_details" in args:
-      count += 1
-  return count
 
 
 # We do not allow multiple concurrent profiler sessions.
@@ -744,10 +526,10 @@ class ProfilerTest(unittest.TestCase):
       unittest.mock.ANY,
     )
 
-  # test if there are GPU events when doing profiling via matmul on ROCm
   @jtu.run_on_devices("gpu")
   @jtu.thread_unsafe_test()
-  def test_rocm_gpu_events_present_for_many_matmul_shapes(self):
+  def test_rocm_profiling(self):
+    """Test that ROCm profiling captures GPU kernel events."""
     # ROCm-only gate using supported API
     from jax.extend import backend as jax_backend
 
@@ -756,58 +538,28 @@ class ProfilerTest(unittest.TestCase):
     if "rocm" not in platform_version.lower():
       self.skipTest(f"Not ROCm backend: {platform_version}")
 
-    @jit
-    def matmul(x, y):
-      return jnp.dot(x, y)
+    with tempfile.TemporaryDirectory() as tmpdir:
+      with jax.profiler.trace(tmpdir):
+        # Test multiple matmul shapes
+        shapes = [(32, 32), (64, 128), (256, 256), (512, 128)]
+        for i, (m, n) in enumerate(shapes):
+          x = jax.random.normal(jax.random.key(i * 2), (m, n))
+          y = jax.random.normal(jax.random.key(i * 2 + 1), (n, m))
+          jnp.dot(x, y).block_until_ready()
 
-    # test shapes:
-    shapes = [
-      (8, 8, 8),
-      (8, 32, 32),
-      (8, 128, 128),
-      (8, 256, 8),
-      (8, 512, 8),
-      (8, 1024, 256),
-      (1024, 1024, 1024),
-    ]
+      proto_path = glob.glob(
+        os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+      )
+      self.assertEqual(len(proto_path), 1)
+      with open(proto_path[0], "rb") as f:
+        proto = f.read()
+      # Sanity check that serialized proto contains GPU traces
+      self.assertIn(b"/device:GPU", proto)
 
-    for m, k, n in shapes:
-      with self.subTest(shape=f"{m}x{k}x{n}"):
-        with tempfile.TemporaryDirectory() as tmpdir:
-          # Run profiling directly in the test process
-          with jax.profiler.trace(tmpdir):
-            x = jax.random.normal(jax.random.key(0), (m, k))
-            y = jax.random.normal(jax.random.key(1), (k, n))
-            result = matmul(x, y)
-            result.block_until_ready()
-
-          # Find and read the xplane.pb file
-          xplane_files = glob.glob(
-            os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True
-          )
-          self.assertEqual(len(xplane_files), 1, "Expected exactly one xplane.pb file")
-          xplane = xplane_files[0]
-
-          # Convert to trace viewer JSON and count GPU events
-          tv = _trace_viewer_json_from_xplane(xplane)
-          traceevents = tv.get("traceEvents", [])
-          gpu_events = _count_gpu_events_from_traceevents(traceevents)
-
-          self.assertGreater(
-            gpu_events,
-            0,
-            f"Expected >0 GPU events for matmul {m}x{k}x{n}; got {gpu_events}. xplane={xplane}",
-          )
-
-  # Test kernel_details are present in trace.json.gz for ROCm profiling
   @jtu.run_on_devices("gpu")
   @jtu.thread_unsafe_test()
   def test_rocm_kernel_details_in_trace_json(self):
-    """Test that kernel_details appear in the generated trace.json.gz file.
-
-    This test reads the actual trace.json.gz file (not the xplane.pb conversion)
-    to verify that kernel launch details (grid, block, memory) are captured.
-    """
+    """Test that ROCm profiling captures kernel_details in trace.json.gz."""
     # ROCm-only gate using supported API
     from jax.extend import backend as jax_backend
 
@@ -816,81 +568,25 @@ class ProfilerTest(unittest.TestCase):
     if "rocm" not in platform_version.lower():
       self.skipTest(f"Not ROCm backend: {platform_version}")
 
-    @jit
-    def matmul(x, y):
-      return jnp.dot(x, y)
-
-    # Use a large matmul that should definitely have kernel launches
-    m, k, n = 1024, 1024, 1024
-
     with tempfile.TemporaryDirectory() as tmpdir:
-      # Run profiling directly in the test process
       with jax.profiler.trace(tmpdir):
-        x = jax.random.normal(jax.random.key(0), (m, k))
-        y = jax.random.normal(jax.random.key(1), (k, n))
-        result = matmul(x, y)
-        result.block_until_ready()
+        # Test multiple matmul shapes
+        shapes = [(64, 64), (128, 256), (512, 512), (1024, 256)]
+        for i, (m, n) in enumerate(shapes):
+          x = jax.random.normal(jax.random.key(i * 2), (m, n))
+          y = jax.random.normal(jax.random.key(i * 2 + 1), (n, m))
+          jnp.dot(x, y).block_until_ready()
 
-      # Read the trace.json.gz file directly (not convert from xplane)
-      try:
-        trace_data = _find_and_read_trace_json_gz(tmpdir)
-      except FileNotFoundError as e:
-        self.fail(f"Could not find trace.json.gz file: {e}")
-
-      traceevents = trace_data.get("traceEvents", [])
-      self.assertGreater(len(traceevents), 0, "No trace events found")
-
-      # Count events with kernel_details
-      kernel_detail_count = _count_events_with_kernel_details(traceevents)
-
-      # For a 1024x1024x1024 matmul, we should have multiple kernel launches
-      # with kernel_details in their args
-      self.assertGreater(
-        kernel_detail_count,
-        0,
-        f"Expected kernel_details in trace.json.gz for matmul {m}x{k}x{n}; "
-        f"found {kernel_detail_count} events with kernel_details out of {len(traceevents)} total events. "
-        f"profile_dir={tmpdir}",
+      # Find and read trace.json.gz file
+      import gzip
+      trace_files = glob.glob(
+        os.path.join(tmpdir, "**/*.trace.json.gz"), recursive=True
       )
-
-      # Validate the format of kernel_details in the first few events
-      events_checked = 0
-      for event in traceevents:
-        args = event.get("args", {})
-        if "kernel_details" not in args:
-          continue
-
-        kernel_details = args["kernel_details"]
-
-        # Verify it's a string
-        self.assertIsInstance(
-          kernel_details,
-          str,
-          f"kernel_details should be string, got {type(kernel_details)}",
-        )
-
-        # Verify it contains expected fields
-        self.assertIn(
-          "grid:",
-          kernel_details,
-          f"kernel_details missing 'grid:' field: {kernel_details}",
-        )
-        self.assertIn(
-          "block:",
-          kernel_details,
-          f"kernel_details missing 'block:' field: {kernel_details}",
-        )
-
-        # Check at least 3 events with kernel_details
-        events_checked += 1
-        if events_checked >= 3:
-          break
-
-      self.assertGreaterEqual(
-        events_checked,
-        1,
-        "Could not find any events with kernel_details to validate",
-      )
+      self.assertEqual(len(trace_files), 1)
+      with gzip.open(trace_files[0], "rt") as f:
+        trace_content = f.read()
+      # Sanity check that trace contains kernel_details
+      self.assertIn("kernel_details", trace_content)
 
 
 if __name__ == "__main__":

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -23,6 +23,7 @@ import sys
 import tempfile
 import threading
 import time
+from typing import List, Dict, Set, Any, Tuple
 import unittest
 import unittest.mock
 from absl.testing import absltest
@@ -50,72 +51,221 @@ except ImportError:
 
 jax.config.parse_flags_with_absl()
 
+# Constant for the trace viewer tool specification
+_TRACE_VIEWER_TOOL_SPEC = "trace_viewer@^"
+# Trace event constants
+_METADATA_EVENT = "M"
+_DURATION_EVENT = "X"
+_PROCESS_NAME_KEY = "process_name"
+_THREAD_NAME_KEY = "thread_name"
+_GPU_DEVICE_MARKER = "/device:GPU"
+_KERNEL_MARKER = "(Kernel)"
 
-def _trace_viewer_json_from_xplane(pb_path: str) -> dict:
-    """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin."""
+
+def _trace_viewer_json_from_xplane(pb_path: str) -> Dict[str, Any]:
+    """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin.
+
+    Args:
+        pb_path: Path to the xplane.pb protobuf file.
+
+    Returns:
+        Dictionary containing trace viewer data parsed from the xplane protobuf.
+
+    Raises:
+        FileNotFoundError: If the pb_path does not exist.
+        ImportError: If neither tensorboard_plugin_profile nor xprof is available.
+        RuntimeError: If conversion or JSON decoding fails.
+    """
+    if not os.path.exists(pb_path):
+        raise FileNotFoundError(f"XPlane file not found: {pb_path}")
+
+    # Try xprof first (JAX's profiler tools), then tensorboard as fallback
+    convert = None
+    errors = []
+
     try:
-        from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
-    except Exception:
         from xprof.convert import raw_to_tool_data as convert
+    except (ImportError, AttributeError) as e:
+        errors.append(f"xprof: {e}")
 
-    result, _ = convert.xspace_to_tool_data([pb_path], "trace_viewer@^", {})
-    # result is bytes
-    return json.loads(result.decode("utf-8"))
+    if convert is None:
+        try:
+            from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
+        except (ImportError, AttributeError) as e:
+            errors.append(f"tensorboard_plugin_profile: {e}")
+
+    if convert is None:
+        raise ImportError(
+            "Failed to import profiler conversion tools. " f"Tried: {', '.join(errors)}"
+        )
+
+    try:
+        result, _ = convert.xspace_to_tool_data([pb_path], _TRACE_VIEWER_TOOL_SPEC, {})
+    except Exception as e:
+        raise RuntimeError(f"Failed to convert xplane to trace viewer data: {e}") from e
+
+    # result is bytes in UTF-8 encoding
+    try:
+        return json.loads(result.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as e:
+        # Show first 100 bytes of result for debugging
+        preview = str(result[:100]) if isinstance(result, bytes) else str(result)[:100]
+        raise RuntimeError(
+            f"Failed to decode trace viewer JSON: {e}. " f"Result preview: {preview}"
+        ) from e
 
 
-def _count_gpu_events_from_traceevents(traceevents: list) -> int:
+def _count_gpu_events_from_traceevents(traceevents: List[Dict[str, Any]]) -> int:
     """
     Count GPU *kernel-stream* duration events in Trace Viewer traceEvents.
 
+    Strategy:
     - GPU PIDs are discovered via process_name metadata that CONTAINS '/device:GPU'
     - Kernel stream TIDs are discovered via thread_name metadata containing '(Kernel)'.
     - We count only 'ph'=='X' events with 'dur' on those (pid, tid).
     - Fallback: if we can't find kernel tids, count all 'X' events on GPU pids.
+
+    Args:
+        traceevents: List of trace event dictionaries from Trace Viewer JSON.
+
+    Returns:
+        Count of GPU kernel duration events found.
     """
-    # 1) Find GPU pids (process_name contains '/device:GPU')
-    gpu_pids = set()
-    for ev in traceevents:
-        if ev.get("ph") == "M" and ev.get("name") == "process_name":
-            pname = (ev.get("args") or {}).get("name", "")
-            if isinstance(pname, str) and "/device:GPU" in pname:
-                pid = ev.get("pid")
-                if pid is not None:
-                    gpu_pids.add(pid)
+    gpu_pids, kernel_tids_by_pid = _extract_gpu_metadata(traceevents)
 
     if not gpu_pids:
         return 0
 
-    # 2) For each GPU pid, find tids that correspond to kernel streams
-    kernel_tids_by_pid = {pid: set() for pid in gpu_pids}
-    for ev in traceevents:
-        if ev.get("ph") == "M" and ev.get("name") == "thread_name":
-            pid = ev.get("pid")
-            tid = ev.get("tid")
+    has_kernel_tids = any(kernel_tids_by_pid.values())
+    return _count_duration_events(
+        traceevents, gpu_pids, kernel_tids_by_pid, has_kernel_tids
+    )
+
+
+def _extract_gpu_metadata(
+    traceevents: List[Dict[str, Any]],
+) -> Tuple[Set[int], Dict[int, Set[int]]]:
+    """Extract GPU process IDs and kernel thread IDs from metadata events.
+
+    Args:
+        traceevents: List of trace event dictionaries.
+
+    Returns:
+        Tuple of (gpu_pids, kernel_tids_by_pid) where:
+        - gpu_pids: Set of process IDs corresponding to GPU devices
+        - kernel_tids_by_pid: Dict mapping each GPU PID to its kernel thread IDs
+    """
+    gpu_pids: Set[int] = set()
+    kernel_tids_by_pid: Dict[int, Set[int]] = {}
+
+    for event in traceevents:
+        if event.get("ph") != _METADATA_EVENT:
+            continue
+
+        event_name = event.get("name")
+
+        # Extract GPU process IDs
+        if event_name == _PROCESS_NAME_KEY:
+            process_name = event.get("args", {}).get("name", "")
+            if isinstance(process_name, str) and _GPU_DEVICE_MARKER in process_name:
+                pid = event.get("pid")
+                if pid is not None:
+                    gpu_pids.add(pid)
+                    kernel_tids_by_pid.setdefault(pid, set())
+
+        # Extract kernel thread IDs for GPU processes
+        elif event_name == _THREAD_NAME_KEY:
+            pid = event.get("pid")
+            tid = event.get("tid")
             if pid in gpu_pids and tid is not None:
-                tname = (ev.get("args") or {}).get("name", "")
-                if isinstance(tname, str) and "(Kernel)" in tname:
-                    kernel_tids_by_pid[pid].add(
-                        tid
-                    )  # Flatten kernel tids; decide whether we have a kernel-tid signal
-    have_kernel_tids = any(kernel_tids_by_pid[pid] for pid in gpu_pids)
+                thread_name = event.get("args", {}).get("name", "")
+                if isinstance(thread_name, str) and _KERNEL_MARKER in thread_name:
+                    kernel_tids_by_pid[pid].add(tid)
 
-    # 3) Count events
+    return gpu_pids, kernel_tids_by_pid
+
+
+def _count_duration_events(
+    traceevents: List[Dict[str, Any]],
+    gpu_pids: Set[int],
+    kernel_tids_by_pid: Dict[int, Set[int]],
+    has_kernel_tids: bool,
+) -> int:
+    """Count duration events on GPU processes/threads.
+
+    Args:
+        traceevents: List of trace event dictionaries.
+        gpu_pids: Set of GPU process IDs.
+        kernel_tids_by_pid: Mapping of GPU PIDs to kernel thread IDs.
+        has_kernel_tids: Whether any kernel TIDs were found.
+
+    Returns:
+        Count of matching duration events.
+    """
     count = 0
-    if have_kernel_tids:
-        for ev in traceevents:
-            if ev.get("ph") != "X":
-                continue
-            if "dur" not in ev:
-                continue
-            pid = ev.get("pid")
-            tid = ev.get("tid")
-            if pid in gpu_pids and tid in kernel_tids_by_pid.get(pid, ()):
-                count += 1
-    else:  # Fallback: count all duration events on GPU pids
-        for ev in traceevents:
-            if ev.get("ph") == "X" and "dur" in ev and ev.get("pid") in gpu_pids:
-                count += 1
 
+    for event in traceevents:
+        # Only count duration events with a 'dur' field
+        if event.get("ph") != _DURATION_EVENT or "dur" not in event:
+            continue
+
+        pid = event.get("pid")
+        if pid not in gpu_pids:
+            continue
+
+        # If we have kernel TID info, filter by those; otherwise count all GPU events
+        if has_kernel_tids:
+            tid = event.get("tid")
+            if tid in kernel_tids_by_pid.get(pid, set()):
+                count += 1
+        else:
+            count += 1
+
+    return count
+
+
+def _find_and_read_trace_json_gz(profile_dir: str) -> Dict[str, Any]:
+    """Find and read the trace.json.gz file from a profile directory.
+
+    Args:
+        profile_dir: Path to the profile directory.
+
+    Returns:
+        Parsed JSON data from the trace file.
+
+    Raises:
+        FileNotFoundError: If no trace.json.gz file is found.
+    """
+    import gzip
+
+    # Search for trace.json.gz files
+    trace_files = glob.glob(
+        os.path.join(profile_dir, "**", "*.trace.json.gz"), recursive=True
+    )
+    if not trace_files:
+        raise FileNotFoundError(f"No trace.json.gz found in {profile_dir}")
+
+    # Use the first trace file found
+    trace_file = trace_files[0]
+
+    with gzip.open(trace_file, "rt", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _count_events_with_kernel_details(traceevents: List[Dict[str, Any]]) -> int:
+    """Count trace events that contain kernel_details in their args.
+
+    Args:
+        traceevents: List of trace event dictionaries.
+
+    Returns:
+        Count of events with kernel_details.
+    """
+    count = 0
+    for event in traceevents:
+        args = event.get("args", {})
+        if "kernel_details" in args:
+            count += 1
     return count
 
 
@@ -693,8 +843,93 @@ class ProfilerTest(unittest.TestCase):
                     self.assertGreater(
                         gpu_events,
                         0,
-                        f"Expected >0 GPU events for matmul {m}x{n}; got {gpu_events}. xplane={xplane}",
+                        f"Expected >0 GPU events for matmul {m}x{k}x{n}; got {gpu_events}. xplane={xplane}",
                     )
+
+    # Test kernel_details are present in trace.json.gz for ROCm profiling
+    @jtu.run_on_devices("gpu")
+    @jtu.thread_unsafe_test()
+    def test_rocm_kernel_details_in_trace_json(self):
+        """Test that kernel_details appear in the generated trace.json.gz file.
+
+        This test reads the actual trace.json.gz file (not the xplane.pb conversion)
+        to verify that kernel launch details (grid, block, memory) are captured.
+        """
+        # ROCm-only gate using supported API
+        from jax.extend import backend as jax_backend
+
+        be = jax_backend.get_backend()
+        platform_version = getattr(be, "platform_version", "") or ""
+        if "rocm" not in platform_version.lower():
+            self.skipTest(f"Not ROCm backend: {platform_version}")
+
+        # Use a large matmul that should definitely have kernel launches
+        m, k, n = 1024, 1024, 1024
+
+        with tempfile.TemporaryDirectory() as td:
+            outdir = os.path.join(td, "profile")
+            xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
+
+            # Read the trace.json.gz file directly (not convert from xplane)
+            try:
+                trace_data = _find_and_read_trace_json_gz(outdir)
+            except FileNotFoundError as e:
+                self.fail(f"Could not find trace.json.gz file: {e}")
+
+            traceevents = trace_data.get("traceEvents", [])
+            self.assertGreater(len(traceevents), 0, "No trace events found")
+
+            # Count events with kernel_details
+            kernel_detail_count = _count_events_with_kernel_details(traceevents)
+
+            # For a 1024x1024x1024 matmul, we should have multiple kernel launches
+            # with kernel_details in their args
+            self.assertGreater(
+                kernel_detail_count,
+                0,
+                f"Expected kernel_details in trace.json.gz for matmul {m}x{k}x{n}; "
+                f"found {kernel_detail_count} events with kernel_details out of {len(traceevents)} total events. "
+                f"profile_dir={outdir}",
+            )
+
+            # Validate the format of kernel_details in the first few events
+            events_checked = 0
+            for event in traceevents:
+                args = event.get("args", {})
+                if "kernel_details" not in args:
+                    continue
+
+                kernel_details = args["kernel_details"]
+
+                # Verify it's a string
+                self.assertIsInstance(
+                    kernel_details,
+                    str,
+                    f"kernel_details should be string, got {type(kernel_details)}",
+                )
+
+                # Verify it contains expected fields
+                self.assertIn(
+                    "grid:",
+                    kernel_details,
+                    f"kernel_details missing 'grid:' field: {kernel_details}",
+                )
+                self.assertIn(
+                    "block:",
+                    kernel_details,
+                    f"kernel_details missing 'block:' field: {kernel_details}",
+                )
+
+                # Check at least 3 events with kernel_details
+                events_checked += 1
+                if events_checked >= 3:
+                    break
+
+            self.assertGreaterEqual(
+                events_checked,
+                1,
+                "Could not find any events with kernel_details to validate",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -660,7 +660,8 @@ class ProfilerTest(unittest.TestCase):
 
     # test if there are GPU events when doing profiling via matmul on ROCm
     @jtu.run_on_devices("gpu")
-    def test_gpu_events_present_for_many_matmul_shapes(self):
+    @jtu.thread_unsafe_test()
+    def test_rocm_gpu_events_present_for_many_matmul_shapes(self):
         # ROCm-only gate using supported API
         from jax.extend import backend as jax_backend
 
@@ -677,8 +678,6 @@ class ProfilerTest(unittest.TestCase):
             (8, 256, 8),
             (8, 512, 8),
             (8, 1024, 256),
-            (512, 128, 512),
-            (1024, 128, 1024),
             (1024, 1024, 1024),
         ]
 

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -38,15 +38,15 @@ from jax import jit
 
 
 try:
-    import portpicker
+  import portpicker
 except ImportError:
-    portpicker = None
+  portpicker = None
 
 try:
-    from xprof.convert import _pywrap_profiler_plugin
-    import jax.collect_profile
+  from xprof.convert import _pywrap_profiler_plugin
+  import jax.collect_profile
 except ImportError:
-    _pywrap_profiler_plugin = None
+  _pywrap_profiler_plugin = None
 
 jax.config.parse_flags_with_absl()
 
@@ -62,836 +62,836 @@ _KERNEL_MARKER = "(Kernel)"
 
 
 def _trace_viewer_json_from_xplane(pb_path: str) -> Dict[str, Any]:
-    """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin.
+  """Convert an xplane.pb into Trace Viewer JSON dict using xprof/tensorboard plugin.
 
-    Args:
-        pb_path: Path to the xplane.pb protobuf file.
+  Args:
+    pb_path: Path to the xplane.pb protobuf file.
 
-    Returns:
-        Dictionary containing trace viewer data parsed from the xplane protobuf.
+  Returns:
+    Dictionary containing trace viewer data parsed from the xplane protobuf.
 
-    Raises:
-        FileNotFoundError: If the pb_path does not exist.
-        ImportError: If neither tensorboard_plugin_profile nor xprof is available.
-        RuntimeError: If conversion or JSON decoding fails.
-    """
-    if not os.path.exists(pb_path):
-        raise FileNotFoundError(f"XPlane file not found: {pb_path}")
+  Raises:
+    FileNotFoundError: If the pb_path does not exist.
+    ImportError: If neither tensorboard_plugin_profile nor xprof is available.
+    RuntimeError: If conversion or JSON decoding fails.
+  """
+  if not os.path.exists(pb_path):
+    raise FileNotFoundError(f"XPlane file not found: {pb_path}")
 
-    # Try xprof first (JAX's profiler tools), then tensorboard as fallback
-    convert = None
-    errors = []
+  # Try xprof first (JAX's profiler tools), then tensorboard as fallback
+  convert = None
+  errors = []
 
+  try:
+    from xprof.convert import raw_to_tool_data as convert
+  except (ImportError, AttributeError) as e:
+    errors.append(f"xprof: {e}")
+
+  if convert is None:
     try:
-        from xprof.convert import raw_to_tool_data as convert
+      from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
     except (ImportError, AttributeError) as e:
-        errors.append(f"xprof: {e}")
+      errors.append(f"tensorboard_plugin_profile: {e}")
 
-    if convert is None:
-        try:
-            from tensorboard_plugin_profile.convert import raw_to_tool_data as convert
-        except (ImportError, AttributeError) as e:
-            errors.append(f"tensorboard_plugin_profile: {e}")
+  if convert is None:
+    raise ImportError(
+      "Failed to import profiler conversion tools. " f"Tried: {', '.join(errors)}"
+    )
 
-    if convert is None:
-        raise ImportError(
-            "Failed to import profiler conversion tools. " f"Tried: {', '.join(errors)}"
-        )
+  try:
+    result, _ = convert.xspace_to_tool_data([pb_path], _TRACE_VIEWER_TOOL_SPEC, {})
+  except Exception as e:
+    raise RuntimeError(f"Failed to convert xplane to trace viewer data: {e}") from e
 
-    try:
-        result, _ = convert.xspace_to_tool_data([pb_path], _TRACE_VIEWER_TOOL_SPEC, {})
-    except Exception as e:
-        raise RuntimeError(f"Failed to convert xplane to trace viewer data: {e}") from e
-
-    # result is bytes in UTF-8 encoding
-    try:
-        return json.loads(result.decode("utf-8"))
-    except (UnicodeDecodeError, json.JSONDecodeError) as e:
-        # Show first 100 bytes of result for debugging
-        preview = str(result[:100]) if isinstance(result, bytes) else str(result)[:100]
-        raise RuntimeError(
-            f"Failed to decode trace viewer JSON: {e}. " f"Result preview: {preview}"
-        ) from e
+  # result is bytes in UTF-8 encoding
+  try:
+    return json.loads(result.decode("utf-8"))
+  except (UnicodeDecodeError, json.JSONDecodeError) as e:
+    # Show first 100 bytes of result for debugging
+    preview = str(result[:100]) if isinstance(result, bytes) else str(result)[:100]
+    raise RuntimeError(
+      f"Failed to decode trace viewer JSON: {e}. " f"Result preview: {preview}"
+    ) from e
 
 
 def _count_gpu_events_from_traceevents(traceevents: List[Dict[str, Any]]) -> int:
-    """
-    Count GPU *kernel-stream* duration events in Trace Viewer traceEvents.
+  """
+  Count GPU *kernel-stream* duration events in Trace Viewer traceEvents.
 
-    Strategy:
-    - GPU PIDs are discovered via process_name metadata that CONTAINS '/device:GPU'
-    - Kernel stream TIDs are discovered via thread_name metadata containing '(Kernel)'.
-    - We count only 'ph'=='X' events with 'dur' on those (pid, tid).
-    - Fallback: if we can't find kernel tids, count all 'X' events on GPU pids.
+  Strategy:
+  - GPU PIDs are discovered via process_name metadata that CONTAINS '/device:GPU'
+  - Kernel stream TIDs are discovered via thread_name metadata containing '(Kernel)'.
+  - We count only 'ph'=='X' events with 'dur' on those (pid, tid).
+  - Fallback: if we can't find kernel tids, count all 'X' events on GPU pids.
 
-    Args:
-        traceevents: List of trace event dictionaries from Trace Viewer JSON.
+  Args:
+    traceevents: List of trace event dictionaries from Trace Viewer JSON.
 
-    Returns:
-        Count of GPU kernel duration events found.
-    """
-    gpu_pids, kernel_tids_by_pid = _extract_gpu_metadata(traceevents)
+  Returns:
+    Count of GPU kernel duration events found.
+  """
+  gpu_pids, kernel_tids_by_pid = _extract_gpu_metadata(traceevents)
 
-    if not gpu_pids:
-        return 0
+  if not gpu_pids:
+    return 0
 
-    has_kernel_tids = any(kernel_tids_by_pid.values())
-    return _count_duration_events(
-        traceevents, gpu_pids, kernel_tids_by_pid, has_kernel_tids
-    )
+  has_kernel_tids = any(kernel_tids_by_pid.values())
+  return _count_duration_events(
+    traceevents, gpu_pids, kernel_tids_by_pid, has_kernel_tids
+  )
 
 
 def _extract_gpu_metadata(
-    traceevents: List[Dict[str, Any]],
+  traceevents: List[Dict[str, Any]],
 ) -> Tuple[Set[int], Dict[int, Set[int]]]:
-    """Extract GPU process IDs and kernel thread IDs from metadata events.
+  """Extract GPU process IDs and kernel thread IDs from metadata events.
 
-    Args:
-        traceevents: List of trace event dictionaries.
+  Args:
+    traceevents: List of trace event dictionaries.
 
-    Returns:
-        Tuple of (gpu_pids, kernel_tids_by_pid) where:
-        - gpu_pids: Set of process IDs corresponding to GPU devices
-        - kernel_tids_by_pid: Dict mapping each GPU PID to its kernel thread IDs
-    """
-    gpu_pids: Set[int] = set()
-    kernel_tids_by_pid: Dict[int, Set[int]] = {}
+  Returns:
+    Tuple of (gpu_pids, kernel_tids_by_pid) where:
+    - gpu_pids: Set of process IDs corresponding to GPU devices
+    - kernel_tids_by_pid: Dict mapping each GPU PID to its kernel thread IDs
+  """
+  gpu_pids: Set[int] = set()
+  kernel_tids_by_pid: Dict[int, Set[int]] = {}
 
-    for event in traceevents:
-        if event.get("ph") != _METADATA_EVENT:
-            continue
+  for event in traceevents:
+    if event.get("ph") != _METADATA_EVENT:
+      continue
 
-        event_name = event.get("name")
+    event_name = event.get("name")
 
-        # Extract GPU process IDs
-        if event_name == _PROCESS_NAME_KEY:
-            process_name = event.get("args", {}).get("name", "")
-            if isinstance(process_name, str) and _GPU_DEVICE_MARKER in process_name:
-                pid = event.get("pid")
-                if pid is not None:
-                    gpu_pids.add(pid)
-                    kernel_tids_by_pid.setdefault(pid, set())
+    # Extract GPU process IDs
+    if event_name == _PROCESS_NAME_KEY:
+      process_name = event.get("args", {}).get("name", "")
+      if isinstance(process_name, str) and _GPU_DEVICE_MARKER in process_name:
+        pid = event.get("pid")
+        if pid is not None:
+          gpu_pids.add(pid)
+          kernel_tids_by_pid.setdefault(pid, set())
 
-        # Extract kernel thread IDs for GPU processes
-        elif event_name == _THREAD_NAME_KEY:
-            pid = event.get("pid")
-            tid = event.get("tid")
-            if pid in gpu_pids and tid is not None:
-                thread_name = event.get("args", {}).get("name", "")
-                if isinstance(thread_name, str) and _KERNEL_MARKER in thread_name:
-                    kernel_tids_by_pid[pid].add(tid)
+    # Extract kernel thread IDs for GPU processes
+    elif event_name == _THREAD_NAME_KEY:
+      pid = event.get("pid")
+      tid = event.get("tid")
+      if pid in gpu_pids and tid is not None:
+        thread_name = event.get("args", {}).get("name", "")
+        if isinstance(thread_name, str) and _KERNEL_MARKER in thread_name:
+          kernel_tids_by_pid[pid].add(tid)
 
-    return gpu_pids, kernel_tids_by_pid
+  return gpu_pids, kernel_tids_by_pid
 
 
 def _count_duration_events(
-    traceevents: List[Dict[str, Any]],
-    gpu_pids: Set[int],
-    kernel_tids_by_pid: Dict[int, Set[int]],
-    has_kernel_tids: bool,
+  traceevents: List[Dict[str, Any]],
+  gpu_pids: Set[int],
+  kernel_tids_by_pid: Dict[int, Set[int]],
+  has_kernel_tids: bool,
 ) -> int:
-    """Count duration events on GPU processes/threads.
+  """Count duration events on GPU processes/threads.
 
-    Args:
-        traceevents: List of trace event dictionaries.
-        gpu_pids: Set of GPU process IDs.
-        kernel_tids_by_pid: Mapping of GPU PIDs to kernel thread IDs.
-        has_kernel_tids: Whether any kernel TIDs were found.
+  Args:
+    traceevents: List of trace event dictionaries.
+    gpu_pids: Set of GPU process IDs.
+    kernel_tids_by_pid: Mapping of GPU PIDs to kernel thread IDs.
+    has_kernel_tids: Whether any kernel TIDs were found.
 
-    Returns:
-        Count of matching duration events.
-    """
-    count = 0
+  Returns:
+    Count of matching duration events.
+  """
+  count = 0
 
-    for event in traceevents:
-        # Only count duration events with a 'dur' field
-        if event.get("ph") != _DURATION_EVENT or "dur" not in event:
-            continue
+  for event in traceevents:
+    # Only count duration events with a 'dur' field
+    if event.get("ph") != _DURATION_EVENT or "dur" not in event:
+      continue
 
-        pid = event.get("pid")
-        if pid not in gpu_pids:
-            continue
+    pid = event.get("pid")
+    if pid not in gpu_pids:
+      continue
 
-        # If we have kernel TID info, filter by those; otherwise count all GPU events
-        if has_kernel_tids:
-            tid = event.get("tid")
-            if tid in kernel_tids_by_pid.get(pid, set()):
-                count += 1
-        else:
-            count += 1
+    # If we have kernel TID info, filter by those; otherwise count all GPU events
+    if has_kernel_tids:
+      tid = event.get("tid")
+      if tid in kernel_tids_by_pid.get(pid, set()):
+        count += 1
+    else:
+      count += 1
 
-    return count
+  return count
 
 
 def _find_and_read_trace_json_gz(profile_dir: str) -> Dict[str, Any]:
-    """Find and read the trace.json.gz file from a profile directory.
+  """Find and read the trace.json.gz file from a profile directory.
 
-    Args:
-        profile_dir: Path to the profile directory.
+  Args:
+    profile_dir: Path to the profile directory.
 
-    Returns:
-        Parsed JSON data from the trace file.
+  Returns:
+    Parsed JSON data from the trace file.
 
-    Raises:
-        FileNotFoundError: If no trace.json.gz file is found.
-    """
-    import gzip
+  Raises:
+    FileNotFoundError: If no trace.json.gz file is found.
+  """
+  import gzip
 
-    # Search for trace.json.gz files
-    trace_files = glob.glob(
-        os.path.join(profile_dir, "**", "*.trace.json.gz"), recursive=True
-    )
-    if not trace_files:
-        raise FileNotFoundError(f"No trace.json.gz found in {profile_dir}")
+  # Search for trace.json.gz files
+  trace_files = glob.glob(
+    os.path.join(profile_dir, "**", "*.trace.json.gz"), recursive=True
+  )
+  if not trace_files:
+    raise FileNotFoundError(f"No trace.json.gz found in {profile_dir}")
 
-    # Use the first trace file found
-    trace_file = trace_files[0]
+  # Use the first trace file found
+  trace_file = trace_files[0]
 
-    with gzip.open(trace_file, "rt", encoding="utf-8") as f:
-        return json.load(f)
+  with gzip.open(trace_file, "rt", encoding="utf-8") as f:
+    return json.load(f)
 
 
 def _count_events_with_kernel_details(traceevents: List[Dict[str, Any]]) -> int:
-    """Count trace events that contain kernel_details in their args.
+  """Count trace events that contain kernel_details in their args.
 
-    Args:
-        traceevents: List of trace event dictionaries.
+  Args:
+    traceevents: List of trace event dictionaries.
 
-    Returns:
-        Count of events with kernel_details.
-    """
-    count = 0
-    for event in traceevents:
-        args = event.get("args", {})
-        if "kernel_details" in args:
-            count += 1
-    return count
+  Returns:
+    Count of events with kernel_details.
+  """
+  count = 0
+  for event in traceevents:
+    args = event.get("args", {})
+    if "kernel_details" in args:
+      count += 1
+  return count
 
 
 # We do not allow multiple concurrent profiler sessions.
 @jtu.thread_unsafe_test_class()
 class ProfilerTest(unittest.TestCase):
-    # These tests simply test that the profiler API does not crash; they do not
-    # check functional correctness.
+  # These tests simply test that the profiler API does not crash; they do not
+  # check functional correctness.
 
-    def setUp(self):
-        if (
-            sys.version_info < (3, 14)
-            and hasattr(sys, "_is_gil_enabled")
-            and not sys._is_gil_enabled()
-        ):
-            self.skipTest(
-                "Profiler tests are not thread-safe under Python 3.13 free threading"
-            )
+  def setUp(self):
+    if (
+      sys.version_info < (3, 14)
+      and hasattr(sys, "_is_gil_enabled")
+      and not sys._is_gil_enabled()
+    ):
+      self.skipTest(
+        "Profiler tests are not thread-safe under Python 3.13 free threading"
+      )
 
-        super().setUp()
-        self.worker_start = threading.Event()
-        self.profile_done = False
+    super().setUp()
+    self.worker_start = threading.Event()
+    self.profile_done = False
 
-    @unittest.skipIf(not portpicker, "Test requires portpicker")
-    def testStartStopServer(self):
-        port = portpicker.pick_unused_port()
-        jax.profiler.start_server(port=port)
-        del port
-        jax.profiler.stop_server()
+  @unittest.skipIf(not portpicker, "Test requires portpicker")
+  def testStartStopServer(self):
+    port = portpicker.pick_unused_port()
+    jax.profiler.start_server(port=port)
+    del port
+    jax.profiler.stop_server()
 
-    @unittest.skipIf(not portpicker, "Test requires portpicker")
-    def testCantStartMultipleServers(self):
-        port = portpicker.pick_unused_port()
-        jax.profiler.start_server(port=port)
-        port = portpicker.pick_unused_port()
+  @unittest.skipIf(not portpicker, "Test requires portpicker")
+  def testCantStartMultipleServers(self):
+    port = portpicker.pick_unused_port()
+    jax.profiler.start_server(port=port)
+    port = portpicker.pick_unused_port()
+    with self.assertRaisesRegex(
+      ValueError, "Only one profiler server can be active at a time."
+    ):
+      jax.profiler.start_server(port=port)
+    jax.profiler.stop_server()
+
+  def testCantStopServerBeforeStartingServer(self):
+    with self.assertRaisesRegex(ValueError, "No active profiler server."):
+      jax.profiler.stop_server()
+
+  def testProgrammaticProfiling(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      try:
+        jax.profiler.start_trace(tmpdir)
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+      finally:
+        jax.profiler.stop_trace()
+
+      proto_path = glob.glob(
+        os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+      )
+      self.assertEqual(len(proto_path), 1)
+      with open(proto_path[0], "rb") as f:
+        proto = f.read()
+      # Sanity check that serialized proto contains host, device, and
+      # Python traces without deserializing.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+      self.assertIn(b"pxla.py", proto)
+
+  @unittest.skipIf(jaxlib_extension_version < 379, "Requires jaxlib 0.8 or later.")
+  def testProgrammaticProfilingConcurrency(self):
+    def work():
+      x = jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+        jnp.ones(jax.local_device_count())
+      )
+      jax.block_until_ready(x)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      try:
+        jax.profiler.start_trace(tmpdir)
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+          for _ in range(10):
+            executor.submit(work)
+      finally:
+        jax.profiler.stop_trace()
+
+      proto_path = glob.glob(
+        os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+      )
+      self.assertEqual(len(proto_path), 1)
+      with open(proto_path[0], "rb") as f:
+        proto = f.read()
+      # Sanity check that serialized proto contains host, device, and
+      # Python traces without deserializing.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+      self.assertIn(b"pxla.py", proto)
+
+  def testProgrammaticProfilingWithOptions(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      try:
+        options = jax.profiler.ProfileOptions()
+        options.python_tracer_level = 0
+        jax.profiler.start_trace(tmpdir, profiler_options=options)
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+      finally:
+        jax.profiler.stop_trace()
+
+      proto_path = glob.glob(
+        os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+      )
+      self.assertEqual(len(proto_path), 1)
+      with open(proto_path[0], "rb") as f:
+        proto = f.read()
+      # Verify that the serialized proto contains host and device traces, and
+      # does not contain Python traces.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+      self.assertNotIn(b"pxla.py", proto)
+
+  def testProgrammaticProfilingPathlib(self):
+    with tempfile.TemporaryDirectory() as tmpdir_string:
+      tmpdir = pathlib.Path(tmpdir_string)
+      try:
+        jax.profiler.start_trace(tmpdir)
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+      finally:
+        jax.profiler.stop_trace()
+
+      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+      self.assertEqual(len(proto_path), 1)
+      proto = proto_path[0].read_bytes()
+      # Sanity check that serialized proto contains host, device, and
+      # Python traces without deserializing.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+      self.assertIn(b"pxla.py", proto)
+
+  def testProgrammaticProfilingWithOptionsPathlib(self):
+    with tempfile.TemporaryDirectory() as tmpdir_string:
+      tmpdir = pathlib.Path(tmpdir_string)
+      try:
+        options = jax.profiler.ProfileOptions()
+        options.advanced_configuration = {"tpu_trace_mode": "TRACE_ONLY_HOST"}
+        jax.profiler.start_trace(tmpdir, profiler_options=options)
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+      finally:
+        jax.profiler.stop_trace()
+
+      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+      self.assertEqual(len(proto_path), 1)
+      proto = proto_path[0].read_bytes()
+      # Verify that the serialized proto contains host traces and does not
+      # contain TPU device traces.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertNotIn(b"/device:TPU", proto)
+      self.assertIn(b"pxla.py", proto)
+
+  def testProfilerGetFDOProfile(self):
+    # Tests stop_and_get_fod_profile could run.
+    try:
+      jax.profiler.start_trace("test")
+      jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+        jnp.ones(jax.local_device_count())
+      )
+    finally:
+      fdo_profile = profiler.stop_and_get_fdo_profile()
+    if jtu.test_device_matches(["gpu"]) and jtu.is_device_cuda():
+      self.assertIn(b"copy", fdo_profile)
+
+  def testProgrammaticProfilingErrors(self):
+    with self.assertRaisesRegex(RuntimeError, "No profile started"):
+      jax.profiler.stop_trace()
+
+    try:
+      with tempfile.TemporaryDirectory() as tmpdir:
+        jax.profiler.start_trace(tmpdir)
         with self.assertRaisesRegex(
-            ValueError, "Only one profiler server can be active at a time."
+          RuntimeError,
+          "Profile has already been started. Only one profile may be run at a "
+          "time.",
         ):
-            jax.profiler.start_server(port=port)
-        jax.profiler.stop_server()
+          jax.profiler.start_trace(tmpdir)
+    finally:
+      jax.profiler.stop_trace()
 
-    def testCantStopServerBeforeStartingServer(self):
-        with self.assertRaisesRegex(ValueError, "No active profiler server."):
+  def testProgrammaticProfilingContextManager(self):
+    with tempfile.TemporaryDirectory() as tmpdir:
+      with jax.profiler.trace(tmpdir):
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+
+      proto_path = glob.glob(
+        os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
+      )
+      self.assertEqual(len(proto_path), 1)
+      with open(proto_path[0], "rb") as f:
+        proto = f.read()
+      # Sanity check that serialized proto contains host and device traces
+      # without deserializing.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+
+  @jtu.run_on_devices("gpu")
+  @jtu.thread_unsafe_test()
+  def testProgrammaticGpuCuptiTracing(self):
+    @jit
+    def xy_plus_z(x, y, z):
+      return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+    k = jax.random.key(0)
+    s = 1, 16, 16
+    jax.devices()
+    x = jnp.int8(jax.random.normal(k, shape=s))
+    y = jnp.bfloat16(jax.random.normal(k, shape=s))
+    z = jnp.float32(jax.random.normal(k, shape=s))
+    with tempfile.TemporaryDirectory() as tmpdir_string:
+      tmpdir = pathlib.Path(tmpdir_string)
+      with jax.profiler.trace(tmpdir):
+        print(xy_plus_z(x, y, z))
+
+      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+      proto_bytes = proto_path[0].read_bytes()
+      self.assertIn(b"/device:GPU", proto_bytes)
+
+  @jtu.run_on_devices("gpu")
+  @jtu.thread_unsafe_test()
+  def testProgrammaticGpuCuptiTracingWithOptions(self):
+    @jit
+    def xy_plus_z(x, y, z):
+      return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+    k = jax.random.key(0)
+    s = 1, 16, 16
+    jax.devices()
+    x = jnp.int8(jax.random.normal(k, shape=s))
+    y = jnp.bfloat16(jax.random.normal(k, shape=s))
+    z = jnp.float32(jax.random.normal(k, shape=s))
+    with tempfile.TemporaryDirectory() as tmpdir_string:
+      tmpdir = pathlib.Path(tmpdir_string)
+      options = jax.profiler.ProfileOptions()
+      options.advanced_configuration = {
+        "gpu_max_callback_api_events": 1000000,
+        "gpu_enable_nvtx_tracking": True,
+      }
+      with jax.profiler.trace(tmpdir):
+        xy_plus_z(x, y, z).block_until_ready()
+
+      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+      proto_bytes = proto_path[0].read_bytes()
+      self.assertIn(b"/device:GPU", proto_bytes)
+
+  # TODO: b/443121646 - Enable PM sampling test on JAX OSS once the Github CI
+  # host machine has privileged access.
+  # @jtu.run_on_devices("gpu")
+  # @jtu.thread_unsafe_test()
+  # def testProgrammaticGpuCuptiTracingWithPmSampling(self):
+  #   if not (jtu.is_cuda_compute_capability_equal("9.0")):
+  #     self.skipTest("Only works on GPU with capability sm90")
+
+  #   @jit
+  #   def xy_plus_z(x, y, z):
+  #     return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
+
+  #   k = jax.random.key(0)
+  #   s = 1, 16, 16
+  #   jax.devices()
+  #   x = jnp.int8(jax.random.normal(k, shape=s))
+  #   y = jnp.bfloat16(jax.random.normal(k, shape=s))
+  #   z = jnp.float32(jax.random.normal(k, shape=s))
+  #   with tempfile.TemporaryDirectory() as tmpdir_string:
+  #     tmpdir = pathlib.Path(tmpdir_string)
+  #     options = jax.profiler.ProfileOptions()
+  #     options.advanced_configuration = {
+  #         "gpu_pm_sample_counters": (
+  #             "sm__cycles_active.sum"
+  #         ),
+  #         "gpu_pm_sample_interval_us": 500,
+  #     }
+  #     with jax.profiler.trace(tmpdir, profiler_options=options):
+  #       xy_plus_z(x, y, z).block_until_ready()
+
+  #     proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+  #     proto_bytes = proto_path[0].read_bytes()
+  #     self.assertIn(b"/device:GPU", proto_bytes)
+  #     self.assertIn(
+  #         b"sm__cycles_active.sum", proto_bytes
+  #     )
+
+  def testProgrammaticProfilingContextManagerPathlib(self):
+    with tempfile.TemporaryDirectory() as tmpdir_string:
+      tmpdir = pathlib.Path(tmpdir_string)
+      with jax.profiler.trace(tmpdir):
+        jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
+          jnp.ones(jax.local_device_count())
+        )
+
+      proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
+      self.assertEqual(len(proto_path), 1)
+      proto = proto_path[0].read_bytes()
+      # Sanity check that serialized proto contains host and device traces
+      # without deserializing.
+      self.assertIn(b"/host:CPU", proto)
+      if jtu.test_device_matches(["tpu"]):
+        self.assertIn(b"/device:TPU", proto)
+
+  def testTraceAnnotation(self):
+    x = 3
+    with jax.profiler.TraceAnnotation("mycontext"):
+      x = x + 2
+
+  def testTraceFunction(self):
+    @jax.profiler.annotate_function
+    def f(x, *, y):
+      return x + 2 * y
+
+    self.assertEqual(f(7, y=3), 13)
+
+    @jax.profiler.annotate_function
+    def f(x, *, name):
+      return x + 2 * len(name)
+
+    self.assertEqual(f(7, name="abc"), 13)
+
+    @partial(jax.profiler.annotate_function, name="aname")
+    def g(x):
+      return x + 2
+
+    self.assertEqual(g(7), 9)
+
+    @partial(jax.profiler.annotate_function, name="aname", akwarg="hello")
+    def h(x):
+      return x + 2
+
+    self.assertEqual(h(7), 9)
+
+  def testDeviceMemoryProfile(self):
+    x = jnp.ones((20,)) + 7.0
+    self.assertIsInstance(jax.profiler.device_memory_profile(), bytes)
+    del x
+
+  def _check_xspace_pb_exist(self, logdir):
+    path = os.path.join(logdir, "plugins", "profile", "*", "*.xplane.pb")
+    self.assertEqual(1, len(glob.glob(path)), "Expected one path match: " + path)
+
+  @unittest.skip("Test causes OOMs")
+  @unittest.skipIf(
+    not (portpicker and _pywrap_profiler_plugin),
+    "Test requires xprof and portpicker",
+  )
+  def testSingleWorkerSamplingMode(self, delay_ms=None):
+    def on_worker(port, worker_start):
+      jax.profiler.start_server(port)
+      worker_start.set()
+      x = jnp.ones((1000, 1000))
+      while True:
+        with jax.profiler.TraceAnnotation("atraceannotation"):
+          jnp.dot(x, x.T).block_until_ready()
+          if self.profile_done:
             jax.profiler.stop_server()
+            break
 
-    def testProgrammaticProfiling(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                jax.profiler.start_trace(tmpdir)
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-            finally:
-                jax.profiler.stop_trace()
+    def on_profile(port, logdir, worker_start):
+      worker_start.wait()
+      options = {
+        "host_tracer_level": 2,
+        "python_tracer_level": 2,
+        "device_tracer_level": 1,
+        "delay_ms": delay_ms,
+      }
 
-            proto_path = glob.glob(
-                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
-            )
-            self.assertEqual(len(proto_path), 1)
-            with open(proto_path[0], "rb") as f:
-                proto = f.read()
-            # Sanity check that serialized proto contains host, device, and
-            # Python traces without deserializing.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-            self.assertIn(b"pxla.py", proto)
+      # Request for 1000 milliseconds of profile.
+      duration_ms = 1000
+      _pywrap_profiler_plugin.trace(
+        f"localhost:{port}", logdir, "", True, duration_ms, 3, options
+      )
+      self.profile_done = True
 
-    @unittest.skipIf(jaxlib_extension_version < 379, "Requires jaxlib 0.8 or later.")
-    def testProgrammaticProfilingConcurrency(self):
-        def work():
-            x = jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                jnp.ones(jax.local_device_count())
-            )
-            jax.block_until_ready(x)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                jax.profiler.start_trace(tmpdir)
-                with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-                    for _ in range(10):
-                        executor.submit(work)
-            finally:
-                jax.profiler.stop_trace()
-
-            proto_path = glob.glob(
-                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
-            )
-            self.assertEqual(len(proto_path), 1)
-            with open(proto_path[0], "rb") as f:
-                proto = f.read()
-            # Sanity check that serialized proto contains host, device, and
-            # Python traces without deserializing.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-            self.assertIn(b"pxla.py", proto)
-
-    def testProgrammaticProfilingWithOptions(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            try:
-                options = jax.profiler.ProfileOptions()
-                options.python_tracer_level = 0
-                jax.profiler.start_trace(tmpdir, profiler_options=options)
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-            finally:
-                jax.profiler.stop_trace()
-
-            proto_path = glob.glob(
-                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
-            )
-            self.assertEqual(len(proto_path), 1)
-            with open(proto_path[0], "rb") as f:
-                proto = f.read()
-            # Verify that the serialized proto contains host and device traces, and
-            # does not contain Python traces.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-            self.assertNotIn(b"pxla.py", proto)
-
-    def testProgrammaticProfilingPathlib(self):
-        with tempfile.TemporaryDirectory() as tmpdir_string:
-            tmpdir = pathlib.Path(tmpdir_string)
-            try:
-                jax.profiler.start_trace(tmpdir)
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-            finally:
-                jax.profiler.stop_trace()
-
-            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-            self.assertEqual(len(proto_path), 1)
-            proto = proto_path[0].read_bytes()
-            # Sanity check that serialized proto contains host, device, and
-            # Python traces without deserializing.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-            self.assertIn(b"pxla.py", proto)
-
-    def testProgrammaticProfilingWithOptionsPathlib(self):
-        with tempfile.TemporaryDirectory() as tmpdir_string:
-            tmpdir = pathlib.Path(tmpdir_string)
-            try:
-                options = jax.profiler.ProfileOptions()
-                options.advanced_configuration = {"tpu_trace_mode": "TRACE_ONLY_HOST"}
-                jax.profiler.start_trace(tmpdir, profiler_options=options)
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-            finally:
-                jax.profiler.stop_trace()
-
-            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-            self.assertEqual(len(proto_path), 1)
-            proto = proto_path[0].read_bytes()
-            # Verify that the serialized proto contains host traces and does not
-            # contain TPU device traces.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertNotIn(b"/device:TPU", proto)
-            self.assertIn(b"pxla.py", proto)
-
-    def testProfilerGetFDOProfile(self):
-        # Tests stop_and_get_fod_profile could run.
-        try:
-            jax.profiler.start_trace("test")
-            jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                jnp.ones(jax.local_device_count())
-            )
-        finally:
-            fdo_profile = profiler.stop_and_get_fdo_profile()
-        if jtu.test_device_matches(["gpu"]) and jtu.is_device_cuda():
-            self.assertIn(b"copy", fdo_profile)
-
-    def testProgrammaticProfilingErrors(self):
-        with self.assertRaisesRegex(RuntimeError, "No profile started"):
-            jax.profiler.stop_trace()
-
-        try:
-            with tempfile.TemporaryDirectory() as tmpdir:
-                jax.profiler.start_trace(tmpdir)
-                with self.assertRaisesRegex(
-                    RuntimeError,
-                    "Profile has already been started. Only one profile may be run at a "
-                    "time.",
-                ):
-                    jax.profiler.start_trace(tmpdir)
-        finally:
-            jax.profiler.stop_trace()
-
-    def testProgrammaticProfilingContextManager(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            with jax.profiler.trace(tmpdir):
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-
-            proto_path = glob.glob(
-                os.path.join(tmpdir, "**/*.xplane.pb"), recursive=True
-            )
-            self.assertEqual(len(proto_path), 1)
-            with open(proto_path[0], "rb") as f:
-                proto = f.read()
-            # Sanity check that serialized proto contains host and device traces
-            # without deserializing.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-
-    @jtu.run_on_devices("gpu")
-    @jtu.thread_unsafe_test()
-    def testProgrammaticGpuCuptiTracing(self):
-        @jit
-        def xy_plus_z(x, y, z):
-            return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-
-        k = jax.random.key(0)
-        s = 1, 16, 16
-        jax.devices()
-        x = jnp.int8(jax.random.normal(k, shape=s))
-        y = jnp.bfloat16(jax.random.normal(k, shape=s))
-        z = jnp.float32(jax.random.normal(k, shape=s))
-        with tempfile.TemporaryDirectory() as tmpdir_string:
-            tmpdir = pathlib.Path(tmpdir_string)
-            with jax.profiler.trace(tmpdir):
-                print(xy_plus_z(x, y, z))
-
-            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-            proto_bytes = proto_path[0].read_bytes()
-            self.assertIn(b"/device:GPU", proto_bytes)
-
-    @jtu.run_on_devices("gpu")
-    @jtu.thread_unsafe_test()
-    def testProgrammaticGpuCuptiTracingWithOptions(self):
-        @jit
-        def xy_plus_z(x, y, z):
-            return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-
-        k = jax.random.key(0)
-        s = 1, 16, 16
-        jax.devices()
-        x = jnp.int8(jax.random.normal(k, shape=s))
-        y = jnp.bfloat16(jax.random.normal(k, shape=s))
-        z = jnp.float32(jax.random.normal(k, shape=s))
-        with tempfile.TemporaryDirectory() as tmpdir_string:
-            tmpdir = pathlib.Path(tmpdir_string)
-            options = jax.profiler.ProfileOptions()
-            options.advanced_configuration = {
-                "gpu_max_callback_api_events": 1000000,
-                "gpu_enable_nvtx_tracking": True,
-            }
-            with jax.profiler.trace(tmpdir):
-                xy_plus_z(x, y, z).block_until_ready()
-
-            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-            proto_bytes = proto_path[0].read_bytes()
-            self.assertIn(b"/device:GPU", proto_bytes)
-
-    # TODO: b/443121646 - Enable PM sampling test on JAX OSS once the Github CI
-    # host machine has privileged access.
-    # @jtu.run_on_devices("gpu")
-    # @jtu.thread_unsafe_test()
-    # def testProgrammaticGpuCuptiTracingWithPmSampling(self):
-    #   if not (jtu.is_cuda_compute_capability_equal("9.0")):
-    #     self.skipTest("Only works on GPU with capability sm90")
-
-    #   @jit
-    #   def xy_plus_z(x, y, z):
-    #     return jnp.float32(jax.lax.batch_matmul(jnp.bfloat16(x), y)) + z
-
-    #   k = jax.random.key(0)
-    #   s = 1, 16, 16
-    #   jax.devices()
-    #   x = jnp.int8(jax.random.normal(k, shape=s))
-    #   y = jnp.bfloat16(jax.random.normal(k, shape=s))
-    #   z = jnp.float32(jax.random.normal(k, shape=s))
-    #   with tempfile.TemporaryDirectory() as tmpdir_string:
-    #     tmpdir = pathlib.Path(tmpdir_string)
-    #     options = jax.profiler.ProfileOptions()
-    #     options.advanced_configuration = {
-    #         "gpu_pm_sample_counters": (
-    #             "sm__cycles_active.sum"
-    #         ),
-    #         "gpu_pm_sample_interval_us": 500,
-    #     }
-    #     with jax.profiler.trace(tmpdir, profiler_options=options):
-    #       xy_plus_z(x, y, z).block_until_ready()
-
-    #     proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-    #     proto_bytes = proto_path[0].read_bytes()
-    #     self.assertIn(b"/device:GPU", proto_bytes)
-    #     self.assertIn(
-    #         b"sm__cycles_active.sum", proto_bytes
-    #     )
-
-    def testProgrammaticProfilingContextManagerPathlib(self):
-        with tempfile.TemporaryDirectory() as tmpdir_string:
-            tmpdir = pathlib.Path(tmpdir_string)
-            with jax.profiler.trace(tmpdir):
-                jax.pmap(lambda x: jax.lax.psum(x + 1, "i"), axis_name="i")(
-                    jnp.ones(jax.local_device_count())
-                )
-
-            proto_path = tuple(tmpdir.rglob("*.xplane.pb"))
-            self.assertEqual(len(proto_path), 1)
-            proto = proto_path[0].read_bytes()
-            # Sanity check that serialized proto contains host and device traces
-            # without deserializing.
-            self.assertIn(b"/host:CPU", proto)
-            if jtu.test_device_matches(["tpu"]):
-                self.assertIn(b"/device:TPU", proto)
-
-    def testTraceAnnotation(self):
-        x = 3
-        with jax.profiler.TraceAnnotation("mycontext"):
-            x = x + 2
-
-    def testTraceFunction(self):
-        @jax.profiler.annotate_function
-        def f(x, *, y):
-            return x + 2 * y
-
-        self.assertEqual(f(7, y=3), 13)
-
-        @jax.profiler.annotate_function
-        def f(x, *, name):
-            return x + 2 * len(name)
-
-        self.assertEqual(f(7, name="abc"), 13)
-
-        @partial(jax.profiler.annotate_function, name="aname")
-        def g(x):
-            return x + 2
-
-        self.assertEqual(g(7), 9)
-
-        @partial(jax.profiler.annotate_function, name="aname", akwarg="hello")
-        def h(x):
-            return x + 2
-
-        self.assertEqual(h(7), 9)
-
-    def testDeviceMemoryProfile(self):
-        x = jnp.ones((20,)) + 7.0
-        self.assertIsInstance(jax.profiler.device_memory_profile(), bytes)
-        del x
-
-    def _check_xspace_pb_exist(self, logdir):
-        path = os.path.join(logdir, "plugins", "profile", "*", "*.xplane.pb")
-        self.assertEqual(1, len(glob.glob(path)), "Expected one path match: " + path)
-
-    @unittest.skip("Test causes OOMs")
-    @unittest.skipIf(
-        not (portpicker and _pywrap_profiler_plugin),
-        "Test requires xprof and portpicker",
+    logdir = absltest.get_default_test_tmpdir()
+    # Remove any existing log files.
+    shutil.rmtree(logdir, ignore_errors=True)
+    port = portpicker.pick_unused_port()
+    thread_profiler = threading.Thread(
+      target=on_profile, args=(port, logdir, self.worker_start)
     )
-    def testSingleWorkerSamplingMode(self, delay_ms=None):
-        def on_worker(port, worker_start):
-            jax.profiler.start_server(port)
-            worker_start.set()
-            x = jnp.ones((1000, 1000))
-            while True:
-                with jax.profiler.TraceAnnotation("atraceannotation"):
-                    jnp.dot(x, x.T).block_until_ready()
-                    if self.profile_done:
-                        jax.profiler.stop_server()
-                        break
-
-        def on_profile(port, logdir, worker_start):
-            worker_start.wait()
-            options = {
-                "host_tracer_level": 2,
-                "python_tracer_level": 2,
-                "device_tracer_level": 1,
-                "delay_ms": delay_ms,
-            }
-
-            # Request for 1000 milliseconds of profile.
-            duration_ms = 1000
-            _pywrap_profiler_plugin.trace(
-                f"localhost:{port}", logdir, "", True, duration_ms, 3, options
-            )
-            self.profile_done = True
-
-        logdir = absltest.get_default_test_tmpdir()
-        # Remove any existing log files.
-        shutil.rmtree(logdir, ignore_errors=True)
-        port = portpicker.pick_unused_port()
-        thread_profiler = threading.Thread(
-            target=on_profile, args=(port, logdir, self.worker_start)
-        )
-        thread_worker = threading.Thread(
-            target=on_worker, args=(port, self.worker_start)
-        )
-        thread_worker.start()
-        thread_profiler.start()
-        thread_profiler.join()
-        thread_worker.join(120)
-        self._check_xspace_pb_exist(logdir)
-
-    @unittest.skipIf(
-        not (portpicker and _pywrap_profiler_plugin),
-        "Test requires xprof and portpicker",
+    thread_worker = threading.Thread(
+      target=on_worker, args=(port, self.worker_start)
     )
-    def test_remote_profiler(self):
-        port = portpicker.pick_unused_port()
-        jax.profiler.start_server(port)
+    thread_worker.start()
+    thread_profiler.start()
+    thread_profiler.join()
+    thread_worker.join(120)
+    self._check_xspace_pb_exist(logdir)
 
-        profile_done = threading.Event()
-        logdir = absltest.get_default_test_tmpdir()
-        # Remove any existing log files.
-        shutil.rmtree(logdir, ignore_errors=True)
+  @unittest.skipIf(
+    not (portpicker and _pywrap_profiler_plugin),
+    "Test requires xprof and portpicker",
+  )
+  def test_remote_profiler(self):
+    port = portpicker.pick_unused_port()
+    jax.profiler.start_server(port)
 
-        def on_profile():
-            os.system(
-                f"{sys.executable} -m jax.collect_profile {port} 500 "
-                f"--log_dir {logdir} --no_perfetto_link"
-            )
-            profile_done.set()
+    profile_done = threading.Event()
+    logdir = absltest.get_default_test_tmpdir()
+    # Remove any existing log files.
+    shutil.rmtree(logdir, ignore_errors=True)
 
-        thread_profiler = threading.Thread(target=on_profile, args=())
-        thread_profiler.start()
-        start_time = time.time()
-        y = jnp.zeros((5, 5))
-        while not profile_done.is_set():
-            # The timeout here must be relatively high. The profiler takes a while to
-            # start up on Cloud TPUs.
-            if time.time() - start_time > 30:
-                raise RuntimeError("Profile did not complete in 30s")
-            y = jnp.dot(y, y)
-        jax.profiler.stop_server()
-        thread_profiler.join()
-        self._check_xspace_pb_exist(logdir)
+    def on_profile():
+      os.system(
+        f"{sys.executable} -m jax.collect_profile {port} 500 "
+        f"--log_dir {logdir} --no_perfetto_link"
+      )
+      profile_done.set()
 
-    @unittest.skip("Profiler takes >30s on Cloud TPUs")
-    @unittest.skipIf(
-        not (portpicker and _pywrap_profiler_plugin),
-        "Test requires xprof and portpicker",
+    thread_profiler = threading.Thread(target=on_profile, args=())
+    thread_profiler.start()
+    start_time = time.time()
+    y = jnp.zeros((5, 5))
+    while not profile_done.is_set():
+      # The timeout here must be relatively high. The profiler takes a while to
+      # start up on Cloud TPUs.
+      if time.time() - start_time > 30:
+        raise RuntimeError("Profile did not complete in 30s")
+      y = jnp.dot(y, y)
+    jax.profiler.stop_server()
+    thread_profiler.join()
+    self._check_xspace_pb_exist(logdir)
+
+  @unittest.skip("Profiler takes >30s on Cloud TPUs")
+  @unittest.skipIf(
+    not (portpicker and _pywrap_profiler_plugin),
+    "Test requires xprof and portpicker",
+  )
+  def test_remote_profiler_gcs_path(self):
+    port = portpicker.pick_unused_port()
+    jax.profiler.start_server(port)
+
+    profile_done = threading.Event()
+    logdir = "gs://mock-test-bucket/test-dir"
+    # Mock XProf call in collect_profile.
+    _pywrap_profiler_plugin.trace = unittest.mock.MagicMock()
+
+    def on_profile():
+      jax.collect_profile(port, 500, logdir, no_perfetto_link=True)
+      profile_done.set()
+
+    thread_profiler = threading.Thread(target=on_profile, args=())
+    thread_profiler.start()
+    start_time = time.time()
+    y = jnp.zeros((5, 5))
+    while not profile_done.is_set():
+      # The timeout here must be relatively high. The profiler takes a while to
+      # start up on Cloud TPUs.
+      if time.time() - start_time > 30:
+        raise RuntimeError("Profile did not complete in 30s")
+      y = jnp.dot(y, y)
+    jax.profiler.stop_server()
+    thread_profiler.join()
+    _pywrap_profiler_plugin.trace.assert_called_once_with(
+      unittest.mock.ANY,
+      logdir,
+      unittest.mock.ANY,
+      unittest.mock.ANY,
+      unittest.mock.ANY,
+      unittest.mock.ANY,
+      unittest.mock.ANY,
     )
-    def test_remote_profiler_gcs_path(self):
-        port = portpicker.pick_unused_port()
-        jax.profiler.start_server(port)
 
-        profile_done = threading.Event()
-        logdir = "gs://mock-test-bucket/test-dir"
-        # Mock XProf call in collect_profile.
-        _pywrap_profiler_plugin.trace = unittest.mock.MagicMock()
+  # test if there are GPU events when doing profiling via matmul on ROCm
+  @jtu.run_on_devices("gpu")
+  @jtu.thread_unsafe_test()
+  def test_rocm_gpu_events_present_for_many_matmul_shapes(self):
+    # ROCm-only gate using supported API
+    from jax.extend import backend as jax_backend
 
-        def on_profile():
-            jax.collect_profile(port, 500, logdir, no_perfetto_link=True)
-            profile_done.set()
+    be = jax_backend.get_backend()
+    platform_version = getattr(be, "platform_version", "") or ""
+    if "rocm" not in platform_version.lower():
+      self.skipTest(f"Not ROCm backend: {platform_version}")
 
-        thread_profiler = threading.Thread(target=on_profile, args=())
-        thread_profiler.start()
-        start_time = time.time()
-        y = jnp.zeros((5, 5))
-        while not profile_done.is_set():
-            # The timeout here must be relatively high. The profiler takes a while to
-            # start up on Cloud TPUs.
-            if time.time() - start_time > 30:
-                raise RuntimeError("Profile did not complete in 30s")
-            y = jnp.dot(y, y)
-        jax.profiler.stop_server()
-        thread_profiler.join()
-        _pywrap_profiler_plugin.trace.assert_called_once_with(
-            unittest.mock.ANY,
-            logdir,
-            unittest.mock.ANY,
-            unittest.mock.ANY,
-            unittest.mock.ANY,
-            unittest.mock.ANY,
-            unittest.mock.ANY,
+    @jit
+    def matmul(x, y):
+      return jnp.dot(x, y)
+
+    # test shapes:
+    shapes = [
+      (8, 8, 8),
+      (8, 32, 32),
+      (8, 128, 128),
+      (8, 256, 8),
+      (8, 512, 8),
+      (8, 1024, 256),
+      (1024, 1024, 1024),
+    ]
+
+    for m, k, n in shapes:
+      with self.subTest(shape=f"{m}x{k}x{n}"):
+        with tempfile.TemporaryDirectory() as tmpdir:
+          # Run profiling directly in the test process
+          with jax.profiler.trace(tmpdir):
+            x = jax.random.normal(jax.random.key(0), (m, k))
+            y = jax.random.normal(jax.random.key(1), (k, n))
+            result = matmul(x, y)
+            result.block_until_ready()
+
+          # Find and read the xplane.pb file
+          xplane_files = glob.glob(
+            os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True
+          )
+          self.assertEqual(len(xplane_files), 1, "Expected exactly one xplane.pb file")
+          xplane = xplane_files[0]
+
+          # Convert to trace viewer JSON and count GPU events
+          tv = _trace_viewer_json_from_xplane(xplane)
+          traceevents = tv.get("traceEvents", [])
+          gpu_events = _count_gpu_events_from_traceevents(traceevents)
+
+          self.assertGreater(
+            gpu_events,
+            0,
+            f"Expected >0 GPU events for matmul {m}x{k}x{n}; got {gpu_events}. xplane={xplane}",
+          )
+
+  # Test kernel_details are present in trace.json.gz for ROCm profiling
+  @jtu.run_on_devices("gpu")
+  @jtu.thread_unsafe_test()
+  def test_rocm_kernel_details_in_trace_json(self):
+    """Test that kernel_details appear in the generated trace.json.gz file.
+
+    This test reads the actual trace.json.gz file (not the xplane.pb conversion)
+    to verify that kernel launch details (grid, block, memory) are captured.
+    """
+    # ROCm-only gate using supported API
+    from jax.extend import backend as jax_backend
+
+    be = jax_backend.get_backend()
+    platform_version = getattr(be, "platform_version", "") or ""
+    if "rocm" not in platform_version.lower():
+      self.skipTest(f"Not ROCm backend: {platform_version}")
+
+    @jit
+    def matmul(x, y):
+      return jnp.dot(x, y)
+
+    # Use a large matmul that should definitely have kernel launches
+    m, k, n = 1024, 1024, 1024
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+      # Run profiling directly in the test process
+      with jax.profiler.trace(tmpdir):
+        x = jax.random.normal(jax.random.key(0), (m, k))
+        y = jax.random.normal(jax.random.key(1), (k, n))
+        result = matmul(x, y)
+        result.block_until_ready()
+
+      # Read the trace.json.gz file directly (not convert from xplane)
+      try:
+        trace_data = _find_and_read_trace_json_gz(tmpdir)
+      except FileNotFoundError as e:
+        self.fail(f"Could not find trace.json.gz file: {e}")
+
+      traceevents = trace_data.get("traceEvents", [])
+      self.assertGreater(len(traceevents), 0, "No trace events found")
+
+      # Count events with kernel_details
+      kernel_detail_count = _count_events_with_kernel_details(traceevents)
+
+      # For a 1024x1024x1024 matmul, we should have multiple kernel launches
+      # with kernel_details in their args
+      self.assertGreater(
+        kernel_detail_count,
+        0,
+        f"Expected kernel_details in trace.json.gz for matmul {m}x{k}x{n}; "
+        f"found {kernel_detail_count} events with kernel_details out of {len(traceevents)} total events. "
+        f"profile_dir={tmpdir}",
+      )
+
+      # Validate the format of kernel_details in the first few events
+      events_checked = 0
+      for event in traceevents:
+        args = event.get("args", {})
+        if "kernel_details" not in args:
+          continue
+
+        kernel_details = args["kernel_details"]
+
+        # Verify it's a string
+        self.assertIsInstance(
+          kernel_details,
+          str,
+          f"kernel_details should be string, got {type(kernel_details)}",
         )
 
-    # test if there are GPU events when doing profiling via matmul on ROCm
-    @jtu.run_on_devices("gpu")
-    @jtu.thread_unsafe_test()
-    def test_rocm_gpu_events_present_for_many_matmul_shapes(self):
-        # ROCm-only gate using supported API
-        from jax.extend import backend as jax_backend
+        # Verify it contains expected fields
+        self.assertIn(
+          "grid:",
+          kernel_details,
+          f"kernel_details missing 'grid:' field: {kernel_details}",
+        )
+        self.assertIn(
+          "block:",
+          kernel_details,
+          f"kernel_details missing 'block:' field: {kernel_details}",
+        )
 
-        be = jax_backend.get_backend()
-        platform_version = getattr(be, "platform_version", "") or ""
-        if "rocm" not in platform_version.lower():
-            self.skipTest(f"Not ROCm backend: {platform_version}")
+        # Check at least 3 events with kernel_details
+        events_checked += 1
+        if events_checked >= 3:
+          break
 
-        @jit
-        def matmul(x, y):
-            return jnp.dot(x, y)
-
-        # test shapes:
-        shapes = [
-            (8, 8, 8),
-            (8, 32, 32),
-            (8, 128, 128),
-            (8, 256, 8),
-            (8, 512, 8),
-            (8, 1024, 256),
-            (1024, 1024, 1024),
-        ]
-
-        for m, k, n in shapes:
-            with self.subTest(shape=f"{m}x{k}x{n}"):
-                with tempfile.TemporaryDirectory() as tmpdir:
-                    # Run profiling directly in the test process
-                    with jax.profiler.trace(tmpdir):
-                        x = jax.random.normal(jax.random.key(0), (m, k))
-                        y = jax.random.normal(jax.random.key(1), (k, n))
-                        result = matmul(x, y)
-                        result.block_until_ready()
-
-                    # Find and read the xplane.pb file
-                    xplane_files = glob.glob(
-                        os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True
-                    )
-                    self.assertEqual(len(xplane_files), 1, "Expected exactly one xplane.pb file")
-                    xplane = xplane_files[0]
-
-                    # Convert to trace viewer JSON and count GPU events
-                    tv = _trace_viewer_json_from_xplane(xplane)
-                    traceevents = tv.get("traceEvents", [])
-                    gpu_events = _count_gpu_events_from_traceevents(traceevents)
-
-                    self.assertGreater(
-                        gpu_events,
-                        0,
-                        f"Expected >0 GPU events for matmul {m}x{k}x{n}; got {gpu_events}. xplane={xplane}",
-                    )
-
-    # Test kernel_details are present in trace.json.gz for ROCm profiling
-    @jtu.run_on_devices("gpu")
-    @jtu.thread_unsafe_test()
-    def test_rocm_kernel_details_in_trace_json(self):
-        """Test that kernel_details appear in the generated trace.json.gz file.
-
-        This test reads the actual trace.json.gz file (not the xplane.pb conversion)
-        to verify that kernel launch details (grid, block, memory) are captured.
-        """
-        # ROCm-only gate using supported API
-        from jax.extend import backend as jax_backend
-
-        be = jax_backend.get_backend()
-        platform_version = getattr(be, "platform_version", "") or ""
-        if "rocm" not in platform_version.lower():
-            self.skipTest(f"Not ROCm backend: {platform_version}")
-
-        @jit
-        def matmul(x, y):
-            return jnp.dot(x, y)
-
-        # Use a large matmul that should definitely have kernel launches
-        m, k, n = 1024, 1024, 1024
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Run profiling directly in the test process
-            with jax.profiler.trace(tmpdir):
-                x = jax.random.normal(jax.random.key(0), (m, k))
-                y = jax.random.normal(jax.random.key(1), (k, n))
-                result = matmul(x, y)
-                result.block_until_ready()
-
-            # Read the trace.json.gz file directly (not convert from xplane)
-            try:
-                trace_data = _find_and_read_trace_json_gz(tmpdir)
-            except FileNotFoundError as e:
-                self.fail(f"Could not find trace.json.gz file: {e}")
-
-            traceevents = trace_data.get("traceEvents", [])
-            self.assertGreater(len(traceevents), 0, "No trace events found")
-
-            # Count events with kernel_details
-            kernel_detail_count = _count_events_with_kernel_details(traceevents)
-
-            # For a 1024x1024x1024 matmul, we should have multiple kernel launches
-            # with kernel_details in their args
-            self.assertGreater(
-                kernel_detail_count,
-                0,
-                f"Expected kernel_details in trace.json.gz for matmul {m}x{k}x{n}; "
-                f"found {kernel_detail_count} events with kernel_details out of {len(traceevents)} total events. "
-                f"profile_dir={tmpdir}",
-            )
-
-            # Validate the format of kernel_details in the first few events
-            events_checked = 0
-            for event in traceevents:
-                args = event.get("args", {})
-                if "kernel_details" not in args:
-                    continue
-
-                kernel_details = args["kernel_details"]
-
-                # Verify it's a string
-                self.assertIsInstance(
-                    kernel_details,
-                    str,
-                    f"kernel_details should be string, got {type(kernel_details)}",
-                )
-
-                # Verify it contains expected fields
-                self.assertIn(
-                    "grid:",
-                    kernel_details,
-                    f"kernel_details missing 'grid:' field: {kernel_details}",
-                )
-                self.assertIn(
-                    "block:",
-                    kernel_details,
-                    f"kernel_details missing 'block:' field: {kernel_details}",
-                )
-
-                # Check at least 3 events with kernel_details
-                events_checked += 1
-                if events_checked >= 3:
-                    break
-
-            self.assertGreaterEqual(
-                events_checked,
-                1,
-                "Could not find any events with kernel_details to validate",
-            )
+      self.assertGreaterEqual(
+        events_checked,
+        1,
+        "Could not find any events with kernel_details to validate",
+      )
 
 
 if __name__ == "__main__":
-    absltest.main(testLoader=jtu.JaxTestLoader())
+  absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -18,7 +18,6 @@ import glob
 import json
 import os
 import shutil
-import subprocess
 import sys
 import tempfile
 import threading
@@ -267,68 +266,6 @@ def _count_events_with_kernel_details(traceevents: List[Dict[str, Any]]) -> int:
         if "kernel_details" in args:
             count += 1
     return count
-
-
-def _run_child_matmul_trace_and_get_xplane(outdir: str, m: int, k: int, n: int) -> str:
-    """
-    Run a minimal JAX matmul trace in a fresh process. Returns path to *.xplane.pb.
-
-    Uses (m, k) @ (k, n) -> (m, n).
-    Each shape is run in its own child process for clean isolation and simpler attribution.
-    """
-    code = r"""
-import glob, json, os
-import jax, jax.numpy as jnp
-from jax import jit
-import jax.profiler
-
-m = int(os.environ["MATMUL_M"])
-k = int(os.environ["MATMUL_K"])
-n = int(os.environ["MATMUL_N"])
-
-@jit
-def f(a, b):
-  return jnp.dot(a, b)
-
-# (m, k) @ (k, n) -> (m, n)
-a = jnp.ones((m, k), dtype=jnp.float16)
-b = jnp.ones((k, n), dtype=jnp.float16)
-
-# Compile/warm-up outside trace.
-f(a, b).block_until_ready()
-
-outdir = os.environ["OUTDIR"]
-with jax.profiler.trace(outdir):
-  for _ in range(5):
-    f(a, b).block_until_ready()
-
-pbs = glob.glob(os.path.join(outdir, "**", "*.xplane.pb"), recursive=True)
-assert len(pbs) == 1, pbs
-print(json.dumps({"xplane": pbs[0]}))
-"""
-
-    env = os.environ.copy()
-    env["OUTDIR"] = outdir
-    env["JAX_PLATFORMS"] = "rocm"
-    env["MATMUL_M"] = str(m)
-    env["MATMUL_K"] = str(k)
-    env["MATMUL_N"] = str(n)
-
-    # Optional diagnostics
-    # env["ROCPROFILER_LOG_LEVEL"] = "trace"
-    # env["AMD_LOG_LEVEL"] = "5"
-
-    r = subprocess.run(
-        [sys.executable, "-c", code], env=env, capture_output=True, text=True
-    )
-    if r.returncode != 0:
-        raise RuntimeError(
-            f"Child failed for shape ({m},{k})x({k},{n}).\n"
-            f"STDOUT:\n{r.stdout}\n\nSTDERR:\n{r.stderr}"
-        )
-
-    info = json.loads(r.stdout.splitlines()[-1])
-    return info["xplane"]
 
 
 # We do not allow multiple concurrent profiler sessions.
@@ -819,6 +756,10 @@ class ProfilerTest(unittest.TestCase):
         if "rocm" not in platform_version.lower():
             self.skipTest(f"Not ROCm backend: {platform_version}")
 
+        @jit
+        def matmul(x, y):
+            return jnp.dot(x, y)
+
         # test shapes:
         shapes = [
             (8, 8, 8),
@@ -832,10 +773,22 @@ class ProfilerTest(unittest.TestCase):
 
         for m, k, n in shapes:
             with self.subTest(shape=f"{m}x{k}x{n}"):
-                with tempfile.TemporaryDirectory() as td:
-                    outdir = os.path.join(td, "profile")
-                    xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    # Run profiling directly in the test process
+                    with jax.profiler.trace(tmpdir):
+                        x = jax.random.normal(jax.random.key(0), (m, k))
+                        y = jax.random.normal(jax.random.key(1), (k, n))
+                        result = matmul(x, y)
+                        result.block_until_ready()
 
+                    # Find and read the xplane.pb file
+                    xplane_files = glob.glob(
+                        os.path.join(tmpdir, "**", "*.xplane.pb"), recursive=True
+                    )
+                    self.assertEqual(len(xplane_files), 1, "Expected exactly one xplane.pb file")
+                    xplane = xplane_files[0]
+
+                    # Convert to trace viewer JSON and count GPU events
                     tv = _trace_viewer_json_from_xplane(xplane)
                     traceevents = tv.get("traceEvents", [])
                     gpu_events = _count_gpu_events_from_traceevents(traceevents)
@@ -863,16 +816,24 @@ class ProfilerTest(unittest.TestCase):
         if "rocm" not in platform_version.lower():
             self.skipTest(f"Not ROCm backend: {platform_version}")
 
+        @jit
+        def matmul(x, y):
+            return jnp.dot(x, y)
+
         # Use a large matmul that should definitely have kernel launches
         m, k, n = 1024, 1024, 1024
 
-        with tempfile.TemporaryDirectory() as td:
-            outdir = os.path.join(td, "profile")
-            xplane = _run_child_matmul_trace_and_get_xplane(outdir, m, k, n)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Run profiling directly in the test process
+            with jax.profiler.trace(tmpdir):
+                x = jax.random.normal(jax.random.key(0), (m, k))
+                y = jax.random.normal(jax.random.key(1), (k, n))
+                result = matmul(x, y)
+                result.block_until_ready()
 
             # Read the trace.json.gz file directly (not convert from xplane)
             try:
-                trace_data = _find_and_read_trace_json_gz(outdir)
+                trace_data = _find_and_read_trace_json_gz(tmpdir)
             except FileNotFoundError as e:
                 self.fail(f"Could not find trace.json.gz file: {e}")
 
@@ -889,7 +850,7 @@ class ProfilerTest(unittest.TestCase):
                 0,
                 f"Expected kernel_details in trace.json.gz for matmul {m}x{k}x{n}; "
                 f"found {kernel_detail_count} events with kernel_details out of {len(traceevents)} total events. "
-                f"profile_dir={outdir}",
+                f"profile_dir={tmpdir}",
             )
 
             # Validate the format of kernel_details in the first few events

--- a/tests/profiler_test.py
+++ b/tests/profiler_test.py
@@ -15,8 +15,10 @@
 import concurrent.futures
 from functools import partial
 import glob
+import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import threading
@@ -25,9 +27,6 @@ import unittest
 import unittest.mock
 from absl.testing import absltest
 import pathlib
-import importlib
-import json
-import subprocess
 
 import jax
 import jax.numpy as jnp


### PR DESCRIPTION
## Motivation

- update a test for checking zero ROCm GPU event 
- upstream PR https://github.com/jax-ml/jax/pull/34135

for kernel_details test, it requires to build `jaxlib` like the followings, otherwise trace file might miss kernel_details. 

```
python3 build/build.py build \
    --clang_path=/lib/llvm-18/bin/clang-18 \
    --wheels="jaxlib" \
    --target_cpu_features=native \
    --rocm_path=/opt/rocm \
    --rocm_version=7 \
    --rocm_amdgpu_targets=gfx942 \
    --verbose --bazel_options="--override_repository=xla=/your/xla"
```

## Run specific ROCm profiler test
```bash
cd jax &&  python tests/profiler_test.py 
```
- test evns
```
root@smc300x-clt-r4c6-18:/work/jax/dist# pip3 list | grep jax
jax                            0.8.0.dev20260127
jax-rocm7-pjrt                 0.8.0.dev20260127
jax-rocm7-plugin               0.8.0.dev20260127
jaxlib                         0.8.0.dev0+selfbuilt
```

```
[ RUN      ] ProfilerTest.test_rocm_kernel_details_in_trace_json
I0127 13:03:20.886666  883898 profiler_session.cc:103] Profiler session initializing.
I0127 13:03:20.886681  883898 profiler_session.cc:118] Profiler session started.
I0127 13:03:20.886698  883898 device_tracer_rocm.cc:51] GpuTracer created.
I0127 13:03:21.203999  883898 dot_search_space.cc:229] All configs were filtered out because none of them sufficiently match the hints. Maybe the hints set does not contain a good representative set of valid configs? Working around this by using the full hints set instead.
I0127 13:03:22.105101  883898 dot_search_space.cc:229] All configs were filtered out because none of them sufficiently match the hints. Maybe the hints set does not contain a good representative set of valid configs? Working around this by using the full hints set instead.
I0127 13:03:24.033801  883898 profiler_session.cc:68] Profiler session collecting data.
I0127 13:03:24.209389  883898 save_profile.cc:150] Collecting XSpace to repository: /tmp/tmpaasexs46/plugins/profile/2026_01_27_13_03_24/smc300x-clt-r4c6-18.xplane.pb
I0127 13:03:24.567035  883898 save_profile.cc:123] Creating directory: /tmp/tmpaasexs46/plugins/profile/2026_01_27_13_03_24

I0127 13:03:25.019298  883898 save_profile.cc:129] Dumped gzipped tool data for trace.json.gz to /tmp/tmpaasexs46/plugins/profile/2026_01_27_13_03_24/smc300x-clt-r4c6-18.trace.json.gz
I0127 13:03:25.077462  883898 profiler_session.cc:136] Profiler session tear down.
[       OK ] ProfilerTest.test_rocm_kernel_details_in_trace_json
[ RUN      ] ProfilerTest.test_rocm_profiling
I0127 13:03:25.167948  883898 profiler_session.cc:103] Profiler session initializing.
I0127 13:03:25.167988  883898 profiler_session.cc:118] Profiler session started.
I0127 13:03:25.168018  883898 device_tracer_rocm.cc:51] GpuTracer created.
I0127 13:03:26.219322  883898 dot_search_space.cc:229] All configs were filtered out because none of them sufficiently match the hints. Maybe the hints set does not contain a good representative set of valid configs? Working around this by using the full hints set instead.
I0127 13:03:26.792129  883898 dot_search_space.cc:229] All configs were filtered out because none of them sufficiently match the hints. Maybe the hints set does not contain a good representative set of valid configs? Working around this by using the full hints set instead.
I0127 13:03:27.985999  883898 dot_search_space.cc:229] All configs were filtered out because none of them sufficiently match the hints. Maybe the hints set does not contain a good representative set of valid configs? Working around this by using the full hints set instead.
I0127 13:03:28.260907  883898 profiler_session.cc:68] Profiler session collecting data.
I0127 13:03:28.451078  883898 save_profile.cc:150] Collecting XSpace to repository: /tmp/tmpcebxqk6h/plugins/profile/2026_01_27_13_03_28/smc300x-clt-r4c6-18.xplane.pb
I0127 13:03:28.805635  883898 save_profile.cc:123] Creating directory: /tmp/tmpcebxqk6h/plugins/profile/2026_01_27_13_03_28

I0127 13:03:29.257322  883898 save_profile.cc:129] Dumped gzipped tool data for trace.json.gz to /tmp/tmpcebxqk6h/plugins/profile/2026_01_27_13_03_28/smc300x-clt-r4c6-18.trace.json.gz
I0127 13:03:29.318556  883898 profiler_session.cc:136] Profiler session tear down.
[       OK ] ProfilerTest.test_rocm_profiling
----------------------------------------------------------------------
Ran 22 tests in 47.640s
```