### PR TITLE
adding abort logic to rocm/jax

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -175,7 +175,12 @@ test_logger = ThreadSafeTestLogger()
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item, nextitem):
-    """Hook that runs around each test to track running tests"""
+    """Hook that runs around each test to track running tests for crash detection.
+    
+    This creates a "last_running" file before each test starts and deletes it
+    when the test completes successfully. If the test crashes, the file remains
+    and can be detected by the test runner.
+    """
     test_file = test_logger.get_test_file_name(item.session)
     test_name = item.name
     nodeid = item.nodeid
@@ -185,56 +190,61 @@ def pytest_runtest_protocol(item, nextitem):
     try:
         test_logger.log_running_test(test_file, test_name, nodeid, start_time)
     except Exception as e:
-        print(f"Warning: Could not log test start for {test_name}: {e}")
+        print(f"[TestLogger] WARNING: Failed to log running test: {e}")
+        # Continue anyway - not critical for test execution
 
+    test_completed = False
     try:
-        # Run the actual test
         outcome = yield
         # Test completed (successfully or with normal failure)
-        # Only clear if test completed normally (not aborted)
+        test_completed = True
+        
+        # Clear the crash detection file
         try:
-            if outcome.get_result():
-                test_logger.clear_running_test(test_file)
+            test_logger.clear_running_test(test_file)
         except Exception as e:
-            # If clearing fails, test might have been aborted - that's ok
-            print(f"Note: Could not clear running test log for {test_name}: {e}")
+            print(f"[TestLogger] WARNING: Failed to clear running test log: {e}")
+            
     except Exception as e:
-        # Test was interrupted/aborted - log it but don't raise in teardown
-        print(f"Test {test_name} in {test_file} was interrupted: {str(e)}")
-        # Re-raise to let pytest handle it properly
+        # Test raised exception (might be crash, might be normal exception)
+        print(f"[TestLogger] Test {test_name} exception: {e}")
+        if not test_completed:
+            # Don't clear the file - this might be a crash
+            print(f"[TestLogger] Leaving crash file for detection")
         raise
 
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session):
     """Called after the Session object has been created"""
-    print(
-        f"Starting test session on GPU {os.environ.get('HIP_VISIBLE_DEVICES', 'unknown')}"
-    )
+    gpu = os.environ.get('HIP_VISIBLE_DEVICES', '?')
+    print(f"Test session starting on GPU {gpu}")
 
 
 @pytest.hookimpl(trylast=True)
 def pytest_sessionfinish(session, exitstatus):
-    """Called after whole test run finished, just log any remaining aborts"""
+    """Called after test run finished.
+    
+    If a crash file still exists, it means a test crashed and the runner
+    will detect it. We just report it here for visibility.
+    """
     test_file = test_logger.get_test_file_name(session)
-
-    # Check if there's a remaining running test log (indicates abort)
     log_file = f"{test_logger.base_dir}/{test_file}_last_running.json"
-    try:
-        if os.path.exists(log_file):
-            try:
-                with open(log_file, "r") as f:
-                    abort_data = json.load(f)
+    
+    if os.path.exists(log_file):
+        try:
+            with open(log_file, "r") as f:
+                abort_data = json.load(f)
+            print(
+                f"\n[CRASH DETECTED] {abort_data.get('nodeid', abort_data.get('test_name', 'unknown'))} "
+                f"(GPU: {abort_data.get('gpu_id', '?')}, PID: {abort_data.get('pid', '?')})"
+            )
+            print(f"[CRASH DETECTED] Crash file will be processed by test runner")
+        except Exception as e:
+            print(f"[TestLogger] WARNING: Crash file exists but unreadable: {e}")
+    else:
+        # Normal completion - no crash
+        pass
 
-                print(f"Detected aborted test: {abort_data['test_name']} in {test_file}")
-                print(
-                    f"Last running file preserved for run_single_gpu.py to process: {log_file}"
-                )
-
-            except Exception as e:
-                print(f"Error reading abort detection file for {test_file}: {e}")
-    except Exception as e:
-        # Handle any unexpected errors gracefully
-        print(f"Warning: Could not check for aborted tests in {test_file}: {e}")
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -75,8 +75,8 @@ def pytest_collection() -> None:
         "CUDA_VISIBLE_DEVICES", str(xdist_worker_number % num_cuda_devices)
     )
 
-# Thread-safe logging for parallel test execution and abort detection
 class ThreadSafeTestLogger:
+""Thread-safe logging for parallel test execution and abort detection"""
     def __init__(self):
         self.locks = {}
         self.global_lock = threading.Lock()
@@ -175,7 +175,7 @@ test_logger = ThreadSafeTestLogger()
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_protocol(item, nextitem):
-    """Hook that runs around each test to track running tests for crash detection.
+    """Hook that wraps around each test to track running tests for crash detection.
     
     This creates a "last_running" file before each test starts and deletes it
     when the test completes successfully. If the test crashes, the file remains

--- a/conftest.py
+++ b/conftest.py
@@ -84,12 +84,20 @@ class ThreadSafeTestLogger:
         self.base_dir = os.path.abspath("./logs")
         
         # Archive old logs if directory exists and is not empty
+        # Use a lock file to ensure only one process does the archiving
+        archive_lock_file = "./logs/.archive_in_progress"
+        
         if os.path.exists(self.base_dir) and os.path.isdir(self.base_dir):
-            if os.listdir(self.base_dir):
-                timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-                archived_logs_dir = f"{self.base_dir}_{timestamp}"
-                
+            if os.listdir(self.base_dir) and not os.path.exists(archive_lock_file):
                 try:
+                    # Create lock file to prevent other processes from archiving
+                    os.makedirs(os.path.dirname(archive_lock_file), exist_ok=True)
+                    with open(archive_lock_file, 'w') as f:
+                        f.write(str(os.getpid()))
+                    
+                    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+                    archived_logs_dir = f"{self.base_dir}_{timestamp}"
+                    
                     print(f"[TestLogger] Archiving old logs: {self.base_dir} -> {archived_logs_dir}")
                     shutil.move(self.base_dir, archived_logs_dir)
                     print(f"[TestLogger] Old logs archived successfully")

--- a/conftest.py
+++ b/conftest.py
@@ -83,29 +83,7 @@ class ThreadSafeTestLogger:
         self.global_lock = threading.Lock()
         self.base_dir = os.path.abspath("./logs")
         
-        # Archive old logs if directory exists and is not empty
-        # Use a lock file to ensure only one process does the archiving
-        archive_lock_file = "./logs/.archive_in_progress"
-        
-        if os.path.exists(self.base_dir) and os.path.isdir(self.base_dir):
-            if os.listdir(self.base_dir) and not os.path.exists(archive_lock_file):
-                try:
-                    # Create lock file to prevent other processes from archiving
-                    os.makedirs(os.path.dirname(archive_lock_file), exist_ok=True)
-                    with open(archive_lock_file, 'w') as f:
-                        f.write(str(os.getpid()))
-                    
-                    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-                    archived_logs_dir = f"{self.base_dir}_{timestamp}"
-                    
-                    print(f"[TestLogger] Archiving old logs: {self.base_dir} -> {archived_logs_dir}")
-                    shutil.move(self.base_dir, archived_logs_dir)
-                    print(f"[TestLogger] Old logs archived successfully")
-                except Exception as e:
-                    print(f"[TestLogger] WARNING: Failed to archive old logs: {e}")
-                    # Continue anyway - we'll try to use existing directory
-        
-        # Create fresh logs directory
+        # Create logs directory (archiving is handled by test runner scripts)
         try:
             os.makedirs(self.base_dir, exist_ok=True)
             print(f"[TestLogger] Initialized log directory: {self.base_dir}")

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ import os
 import pytest
 import json
 import threading
+import shutil
 from datetime import datetime
 
 @pytest.fixture(autouse=True)
@@ -76,12 +77,27 @@ def pytest_collection() -> None:
     )
 
 class ThreadSafeTestLogger:
-""Thread-safe logging for parallel test execution and abort detection"""
+    """Thread-safe logging for parallel test execution and abort detection"""
     def __init__(self):
         self.locks = {}
         self.global_lock = threading.Lock()
-        # Use absolute path to avoid working directory issues
         self.base_dir = os.path.abspath("./logs")
+        
+        # Archive old logs if directory exists and is not empty
+        if os.path.exists(self.base_dir) and os.path.isdir(self.base_dir):
+            if os.listdir(self.base_dir):
+                timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+                archived_logs_dir = f"{self.base_dir}_{timestamp}"
+                
+                try:
+                    print(f"[TestLogger] Archiving old logs: {self.base_dir} -> {archived_logs_dir}")
+                    shutil.move(self.base_dir, archived_logs_dir)
+                    print(f"[TestLogger] Old logs archived successfully")
+                except Exception as e:
+                    print(f"[TestLogger] WARNING: Failed to archive old logs: {e}")
+                    # Continue anyway - we'll try to use existing directory
+        
+        # Create fresh logs directory
         try:
             os.makedirs(self.base_dir, exist_ok=True)
             print(f"[TestLogger] Initialized log directory: {self.base_dir}")
@@ -245,6 +261,3 @@ def pytest_sessionfinish(session, exitstatus):
     else:
         # Normal completion - no crash
         pass
-
-
-

--- a/conftest.py
+++ b/conftest.py
@@ -15,7 +15,9 @@
 
 import os
 import pytest
-
+import json
+import threading
+from datetime import datetime
 
 @pytest.fixture(autouse=True)
 def add_imports(doctest_namespace):
@@ -72,3 +74,167 @@ def pytest_collection() -> None:
     os.environ.setdefault(
         "CUDA_VISIBLE_DEVICES", str(xdist_worker_number % num_cuda_devices)
     )
+
+# Thread-safe logging for parallel test execution and abort detection
+class ThreadSafeTestLogger:
+    def __init__(self):
+        self.locks = {}
+        self.global_lock = threading.Lock()
+        # Use absolute path to avoid working directory issues
+        self.base_dir = os.path.abspath("./logs")
+        try:
+            os.makedirs(self.base_dir, exist_ok=True)
+            print(f"[TestLogger] Initialized log directory: {self.base_dir}")
+        except Exception as e:
+            print(f"[TestLogger] ERROR: Failed to create log directory {self.base_dir}: {e}")
+            # Fallback to temp directory if logs dir creation fails
+            import tempfile
+            self.base_dir = os.path.join(tempfile.gettempdir(), "jax_test_logs")
+            os.makedirs(self.base_dir, exist_ok=True)
+            print(f"[TestLogger] Using fallback directory: {self.base_dir}")
+
+    def get_file_lock(self, test_file):
+        """Get or create a lock for a specific test file"""
+        with self.global_lock:
+            if test_file not in self.locks:
+                self.locks[test_file] = threading.Lock()
+            return self.locks[test_file]
+
+    def get_test_file_name(self, session):
+        """Extract the test file name from the session"""
+        # Try to get from session config args
+        if hasattr(session, "config") and hasattr(session.config, "args"):
+            for arg in session.config.args:
+                # Handle full nodeid like "jax/tests/foo_test.py::TestClass::test_method"
+                if "tests/" in arg:
+                    # Split on :: to get just the file path
+                    file_path = arg.split("::")[0]
+                    if file_path.endswith(".py"):
+                        return os.path.basename(file_path).replace(".py", "")
+        
+        # Try to get from invocation params
+        if hasattr(session, "config") and hasattr(session.config, "invocation_params"):
+            invocation_dir = getattr(session.config.invocation_params, "dir", None)
+            if invocation_dir:
+                dir_name = os.path.basename(str(invocation_dir))
+                if dir_name:
+                    print(f"[TestLogger] Using invocation directory as test name: {dir_name}")
+                    return dir_name
+        
+        # Last resort: try to get from session items
+        if hasattr(session, "items") and session.items:
+            first_item = session.items[0]
+            if hasattr(first_item, "fspath"):
+                fspath = str(first_item.fspath)
+                if ".py" in fspath:
+                    return os.path.basename(fspath).replace(".py", "")
+        
+        print(f"[TestLogger] WARNING: Could not determine test file name, using 'unknown_test'")
+        print(f"[TestLogger] Session config args: {getattr(session.config, 'args', 'N/A')}")
+        return "unknown_test"
+
+    def log_running_test(self, test_file, test_name, nodeid, start_time):
+        """Log the currently running test for abort detection"""
+        lock = self.get_file_lock(test_file)
+        with lock:
+            log_data = {
+                "test_file": test_file,
+                "test_name": test_name,
+                "nodeid": nodeid,
+                "start_time": start_time,
+                "status": "running",
+                "pid": os.getpid(),
+                "gpu_id": os.environ.get("HIP_VISIBLE_DEVICES", "unknown"),
+            }
+
+            log_file = f"{self.base_dir}/{test_file}_last_running.json"
+            try:
+                # Ensure directory still exists (might have been deleted)
+                os.makedirs(self.base_dir, exist_ok=True)
+                with open(log_file, "w") as f:
+                    json.dump(log_data, f, indent=2)
+            except Exception as e:
+                print(f"[TestLogger] ERROR: Failed to write running test log to {log_file}: {e}")
+                print(f"[TestLogger] Current working directory: {os.getcwd()}")
+                print(f"[TestLogger] Base directory: {self.base_dir}")
+                print(f"[TestLogger] Base directory exists: {os.path.exists(self.base_dir)}")
+                raise
+
+    def clear_running_test(self, test_file):
+        """Clear the running test log when test completes successfully"""
+        lock = self.get_file_lock(test_file)
+        with lock:
+            log_file = f"{self.base_dir}/{test_file}_last_running.json"
+            if os.path.exists(log_file):
+                os.remove(log_file)
+
+
+# Global logger instance
+test_logger = ThreadSafeTestLogger()
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Hook that runs around each test to track running tests"""
+    test_file = test_logger.get_test_file_name(item.session)
+    test_name = item.name
+    nodeid = item.nodeid
+    start_time = datetime.now().isoformat()
+
+    # Log that this test is starting
+    try:
+        test_logger.log_running_test(test_file, test_name, nodeid, start_time)
+    except Exception as e:
+        print(f"Warning: Could not log test start for {test_name}: {e}")
+
+    try:
+        # Run the actual test
+        outcome = yield
+        # Test completed (successfully or with normal failure)
+        # Only clear if test completed normally (not aborted)
+        try:
+            if outcome.get_result():
+                test_logger.clear_running_test(test_file)
+        except Exception as e:
+            # If clearing fails, test might have been aborted - that's ok
+            print(f"Note: Could not clear running test log for {test_name}: {e}")
+    except Exception as e:
+        # Test was interrupted/aborted - log it but don't raise in teardown
+        print(f"Test {test_name} in {test_file} was interrupted: {str(e)}")
+        # Re-raise to let pytest handle it properly
+        raise
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_sessionstart(session):
+    """Called after the Session object has been created"""
+    print(
+        f"Starting test session on GPU {os.environ.get('HIP_VISIBLE_DEVICES', 'unknown')}"
+    )
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    """Called after whole test run finished, just log any remaining aborts"""
+    test_file = test_logger.get_test_file_name(session)
+
+    # Check if there's a remaining running test log (indicates abort)
+    log_file = f"{test_logger.base_dir}/{test_file}_last_running.json"
+    try:
+        if os.path.exists(log_file):
+            try:
+                with open(log_file, "r") as f:
+                    abort_data = json.load(f)
+
+                print(f"Detected aborted test: {abort_data['test_name']} in {test_file}")
+                print(
+                    f"Last running file preserved for run_single_gpu.py to process: {log_file}"
+                )
+
+            except Exception as e:
+                print(f"Error reading abort detection file for {test_file}: {e}")
+    except Exception as e:
+        # Handle any unexpected errors gracefully
+        print(f"Warning: Could not check for aborted tests in {test_file}: {e}")
+
+


### PR DESCRIPTION
## Motivation

The  conftest edit is required for abort logic to work that resides in the rocm-jax run_single_gpu.py and run_multi_gpu.py scripts.

## Technical Details

This PR adds specific test collection and logging logic that is necessary to catch the aborted file info and process it later. 

## Test Plan
Run:
```
python3 jax_rocm_plugin/build/rocm/run_single_gpu.py -c 2>&1 | tee JAX_SG_0.8.0_ut.log
python3 jax_rocm_plugin/build/rocm/run_multi_gpu.py -c 2>&1 | tee JAX_MG_0.8.0_ut.log
```

## Test Result

```
======================================================================
FINAL TEST SUMMARY
======================================================================
Total Tests:   51341
Passed:        30187
Failed:        65
Skipped:       20922
Errors:        6
Crashed:       1

----------------------------------------------------------------------
CRASHED TESTS (1):
----------------------------------------------------------------------
  - tests/crash_abort_test.py::test_crash_with_segfault (0.1s)
======================================================================
```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
