### PR TITLE
Fix psend test case failures

### DIFF
--- a/jax/_src/lax/parallel.py
+++ b/jax/_src/lax/parallel.py
@@ -1191,7 +1191,8 @@ single_side_collective_effect = SingleSideCollectiveEffect()
 core.effects.control_flow_allowed_effects.add_type(SingleSideCollectiveEffect)
 
 def _psend_lowering_gpu(ctx, x, *, axis_name, perm):
-  if ("cuda" not in ctx.module_context.platforms):
+  if ("cuda" not in ctx.module_context.platforms and
+      "rocm" not in ctx.module_context.platforms):
     raise NotImplementedError("psend is currently only implemented on GPUs")
 
   full_perm, other_args = _pcollectives_lowering_common(


### PR DESCRIPTION
Fixes the `_psend_lowering_gpu` function to support ROCm GPUs by adding ROCm platform check alongside the existing CUDA check.

Changes 
- Modified `jax/_src/lax/parallel.py` to check for both `cuda` and `rocm` platforms

Testing
- Failing psend tests are now passing

Upstream PR - https://github.com/jax-ml/jax/pull/34304