### PR TITLE
Fix shared memory limit check for ROCm in test_dot

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -76,6 +76,34 @@ def is_power_of_two(n: int) -> bool:
   return (n > 0) and (n & (n - 1) == 0)
 
 
+def get_rocm_shared_memory_limit() -> int:
+  """Get the shared memory (LDS) limit in bytes for ROCm devices.
+
+  Queries rocminfo to get the GROUP segment size dynamically.
+  Returns 64KB as default if rocminfo fails (MI100/MI200/MI300 all have 64KB LDS).
+  """
+  try:
+    result = subprocess.run(
+        ['rocminfo'], capture_output=True, text=True, timeout=10
+    )
+    if result.returncode != 0:
+      return 64 * 1024  # Default if rocminfo fails
+    lines = result.stdout.split('\n')
+    for i, line in enumerate(lines):
+      if 'Segment:' in line and 'GROUP' in line:
+        if i + 1 < len(lines):
+          size_line = lines[i + 1]
+          # Match "Size: <number>(<hex>) KB" with case-insensitive KB check
+          match = re.search(r'Size:\s+(\d+)\s*\([^)]+\)\s*KB', size_line, re.IGNORECASE)
+          if match:
+            size_kb = int(match.group(1))
+            return size_kb * 1024  # Convert KB to bytes
+  except Exception:
+    pass
+  # Default for AMD GPUs (MI100/MI200/MI300 all have 64KB LDS)
+  return 64 * 1024
+
+
 def smem_on_tpu():
   if jtu.test_device_matches(["tpu"]):
     return pltpu.SMEM
@@ -2207,11 +2235,21 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["gpu"]):
       if dtype == jnp.bfloat16:
         self.skipTest("bfloat16 type are not supported on GPU")
-      if (
-          math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape)
-          > (256 * 256) * 2
-      ):
-        self.skipTest("Shared memory size limit exceeded")
+      # Check shared memory limit: Triton loads lhs + rhs into shared memory
+      if jtu.is_device_rocm():
+        # ROCm: use correct formula with dynamic limit from rocminfo
+        dtype_size = jnp.dtype(dtype).itemsize
+        shared_mem_bytes = (math.prod(lhs_shape) + math.prod(rhs_shape)) * dtype_size
+        shared_mem_limit = get_rocm_shared_memory_limit()
+        if shared_mem_bytes > shared_mem_limit:
+          self.skipTest("Shared memory size limit exceeded")
+      else:
+        # NVIDIA: keep original check
+        if (
+            math.prod(lhs_shape) + math.prod(rhs_shape) + math.prod(out_shape)
+            > (256 * 256) * 2
+        ):
+          self.skipTest("Shared memory size limit exceeded")
       if (jax.local_devices()[0].device_kind == "NVIDIA L4" and
           dtype == jnp.float32 and
           lhs_and_rhs_shape in [


### PR DESCRIPTION
Add get_rocm_shared_memory_limit() helper function that queries rocminfo for the actual LDS (shared memory) limit, defaulting to 64KB.

Update the GPU shared memory check in test_dot to use the correct formula for ROCm: (lhs_elements + rhs_elements) * dtype_size in bytes, instead of the element count check that doesn't account for dtype size.
The affect test cases are skiped because it requires more than 64kb 

tests/pallas/ops_test.py::OpsTest::test_dot100
tests/pallas/ops_test.py::OpsTest::test_dot120
tests/pallas/ops_test.py::OpsTest::test_dot124
tests/pallas/ops_test.py::OpsTest::test_dot206
tests/pallas/ops_test.py::OpsTest::test_dot230
tests/pallas/ops_test.py::OpsTest::test_dot36
tests/pallas/ops_test.py::OpsTest::test_dot37
tests/pallas/ops_test.py::OpsTest::test_dot96


Test result 
```
cd /workspace/rocm-jax/jax && pytest tests/pallas/ops_test.py::OpsTest::test_dot100 tests/pallas/ops_test.py::OpsTest::test_dot120 tests/pallas/ops_test.py::OpsTest::test_dot124 tests/pallas/ops_test.py::OpsTest::test_dot206 tests/pallas/ops_test.py::OpsTest::test_dot230 tests/pallas/ops_test.py::OpsTest::test_dot36 tests/pallas/ops_test.py::OpsTest::test_dot37 tests/pallas/ops_test.py::OpsTest::test_dot96 -v -W ignore::DeprecationWarning 2>&1 | tail -15
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.150.0, rerunfailures-16.1, reportlog-1.0.0, metadata-3.1.1, json-report-1.5.0, html-4.1.1
collecting ... collected 8 items

tests/pallas/ops_test.py::OpsTest::test_dot100 SKIPPED (Shared memor...) [ 12%]
tests/pallas/ops_test.py::OpsTest::test_dot120 SKIPPED (Shared memor...) [ 25%]
tests/pallas/ops_test.py::OpsTest::test_dot124 SKIPPED (Shared memor...) [ 37%]
tests/pallas/ops_test.py::OpsTest::test_dot206 SKIPPED (Shared memor...) [ 50%]
tests/pallas/ops_test.py::OpsTest::test_dot230 SKIPPED (Shared memor...) [ 62%]
tests/pallas/ops_test.py::OpsTest::test_dot36 SKIPPED (Shared memory...) [ 75%]
tests/pallas/ops_test.py::OpsTest::test_dot37 SKIPPED (Shared memory...) [ 87%]
tests/pallas/ops_test.py::OpsTest::test_dot96 SKIPPED (Shared memory...) [100%]

============================= 8 skipped in 14.28s ==============================
```

