### PR TITLE
Skip is_finite tests on ROCm (not in Triton lowering for jax 0.8.0)

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1023,6 +1023,9 @@ class OpsTest(PallasBaseTest):
       self.skipTest("Not tested on CUDA") # set this b/c this how the test was
       # originally configured. Have no way to test cuda.
 
+    if jtu.is_device_rocm():
+      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
+
     size = len(self.IS_FINITE_TEST_VALUES)
 
     @functools.partial(
@@ -1050,6 +1053,9 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["cuda"]):
       self.skipTest("Not tested on CUDA") # set this b/c this how the test was
       # originally configured. Have no way to test cuda.
+
+    if jtu.is_device_rocm():
+      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 


### PR DESCRIPTION
The is_finite Triton lowering was added in commit 45e7dfce6 (Dec 18, 2025), after jax 0.8.0 was released (Oct 16, 2025). Skip these tests on ROCm until  updated jax 0.8.x+ is installed.

Tests skipped on ROCm:
- test_is_finite_bfloat16
- test_is_finite_float16
- test_is_finite_float32
- test_is_finite_scalar_bfloat16
- test_is_finite_scalar_float16
- test_is_finite_scalar_float32

