### PR TITLE
Fix GPU lowering rule for SVD on ROCm devices

### DIFF
--- a/jax/_src/lax/linalg.py
+++ b/jax/_src/lax/linalg.py
@@ -2233,7 +2233,9 @@ def _svd_gpu_sub_lowering(ctx, operand, *, full_matrices, compute_uv,
   # removing this condition.
   if algorithm is None or algorithm == SvdAlgorithm.DEFAULT:
     try:
-      use_jacobi = target_name_prefix == "cu" and m <= 1024 and n <= 1024
+      gpu_available = target_name_prefix == "cu" or \
+                      target_name_prefix == "hip"
+      use_jacobi = gpu_available and m <= 1024 and n <= 1024
     except core.InconclusiveDimensionOperation:
       use_jacobi = False
   else:


### PR DESCRIPTION
## Motivation
ShapePolyHarness SVD unit tests were expecting SVD on smaller matrices to default to the Jacobi version. This was not enabled for ROCm devices and was causing certain unit tests to fail.

## Technical Details

The relevant SVD GPU lowering rule has been fixed. It now defaults to Jacobi SVD for smaller matrices on ROCm devices.

## Test Plan

This is tested in the ShapePolyHarnessesTest class in tests/shape_poly_test.py. Some SVD tests were failing and are now passing.

## Test Result

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 6 items

tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_complex64_2_3_4_5_poly_b1_b2_m_n_full_matrices_False_compute_uv_True PASSED  [ 16%]
tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_complex64_2_3_4_5_poly_b1_b2_m_n_full_matrices_True_compute_uv_False PASSED  [ 33%]
tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_complex64_2_3_4_5_poly_b1_b2_m_n_full_matrices_True_compute_uv_True PASSED   [ 50%]
tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_float32_2_3_4_5_poly_b1_b2_m_n_full_matrices_False_compute_uv_True PASSED    [ 66%]
tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_float32_2_3_4_5_poly_b1_b2_m_n_full_matrices_True_compute_uv_False PASSED    [ 83%]
tests/shape_poly_test.py::ShapePolyHarnessesTest::test_harness_svd_shape_float32_2_3_4_5_poly_b1_b2_m_n_full_matrices_True_compute_uv_True PASSED     [100%]

==================================================================== 6 passed in 10.31s =====================================================================
```