### PR TITLE
Enable testSvdSubsetByIndex for ROCm with subset_by_index skip

### DIFF
--- a/tests/svd_test.py
+++ b/tests/svd_test.py
@@ -274,13 +274,16 @@ class SvdTest(jtu.JaxTestCase):
       start=[0, 1, 64, 126, 127],
       end=[1, 2, 65, 127, 128],
   )
-  @jtu.run_on_devices('tpu')  # TODO(rmlarsen: enable on other devices)
+  @jtu.run_on_devices('tpu', 'rocm')
   def testSvdSubsetByIndex(self, start, end):
     if start >= end:
       return
     dtype = np.float32
     m = 256
     n = 128
+    # subset_by_index is only implemented for TPU; on ROCm only full range works
+    if jtu.is_device_rocm() and not (start == 0 and end == min(m, n)):
+      self.skipTest("subset_by_index not implemented for ROCm")
     rng = jtu.rand_default(self.rng())
     tol = np.maximum(n, 80) * np.finfo(dtype).eps
     args_maker = lambda: [rng((m, n), dtype)]


### PR DESCRIPTION
Enable the case  where start=0 and end=128 (full range, no actual subsetting)
Skipped the case with actual subsetting (correctly skipped on ROCm with message "subset_by_index not implemented for ROCm"), figure out it does not support [GPU here ](https://github.com/ROCm/jax/blob/7134b1f4e7d363542f66c58fc692076ec444b104/jax/_src/lax/linalg.py#L2148
)

Test Result

```
pytest tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 -v 2>&1
Test session starting on GPU ?
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collected 10 items                                                                                                                                                                      

tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 PASSED                                                                                                                          [ 10%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [ 20%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [ 30%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [ 40%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [ 50%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 PASSED                                                                                                                          [ 60%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 PASSED                                                                                                                          [ 70%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 PASSED                                                                                                                          [ 80%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [ 90%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 SKIPPED (subset_by_index not implemented for ROCm)                                                                              [100%]


============================================================================= 4 passed, 6 skipped in 8.09s ==============================================================================
```
