### PR TITLE
Add proper ROCm skip for cuDNN attention tests

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -193,6 +193,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
+    if impl == 'cudnn' and jtu.is_device_rocm():
+      raise unittest.SkipTest("cuDNN not available on ROCm.")
     if impl == 'cudnn' and not jtu.is_cuda_compute_capability_at_least("8.0"):
       raise unittest.SkipTest("Needs compute capability 8.0 or higher.")
     if impl == 'cudnn' and dtype == jnp.float32:


### PR DESCRIPTION
Add proper ROCm skip for cuDNN attention tests

Test Result
```
cd /workspace/rocm-jax/jax && pytest tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 tests/nn_test.py::NNFunctionsTest::testDotProductAttention1 tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 tests/nn_test.py::NNFunctionsTest::testDotProductAttention3 tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 tests/nn_test.py::NNFunctionsTest::testDotProductAttention5 tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 tests/nn_test.py::NNFunctionsTest::testDotProductAttention7 tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 tests/nn_test.py::NNFunctionsTest::testDotProductAttention9 tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 tests/nn_test.py::NNFunctionsTest::testDotProductAttention11 -v -rs 2>&1
Test session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collecting ... collected 12 items

tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 SKIPPED      [  8%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention1 PASSED       [ 16%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 SKIPPED      [ 25%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention3 PASSED       [ 33%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 SKIPPED      [ 41%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention5 PASSED       [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 SKIPPED      [ 58%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention7 PASSED       [ 66%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 SKIPPED      [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention9 PASSED       [ 83%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 SKIPPED     [ 91%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention11 PASSED      [100%]

=========================== short test summary info ============================
SKIPPED [6] tests/nn_test.py:189: cuDNN not available on ROCm.
=================== 6 passed, 6 skipped in 126.02s (0:02:06) ===================

```

and 
```
Skip the test that does not support by ROCM
- testDotProductAttentionMask: cuDNN not available on ROCm
- testDotProductAttentionBiasGradient: cuDNN not available on ROCm"
Test Result

 pytest tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 -v -rs 2>&1
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 SKIPPED  [ 12%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 SKIPPED  [ 25%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 SKIPPED  [ 37%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 SKIPPED  [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 SKIPPED [ 62%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 SKIPPED [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 SKIPPED [ 87%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 SKIPPED [100%]

=========================== short test summary info ============================
SKIPPED [4] tests/nn_test.py:240: cuDNN not available on ROCm.
SKIPPED [4] tests/nn_test.py:310: cuDNN not available on ROCm.
============================== 8 skipped in 6.04s ==============================
```

