### PR TITLE
Add proper ROCm skip for cuDNN attention tests

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -193,6 +193,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       impl=['cudnn', 'xla'],
   )
   def testDotProductAttention(self, dtype, group_num, use_vmap, impl):
+    if impl == 'cudnn' and jtu.is_device_rocm():
+      raise unittest.SkipTest("cuDNN not available on ROCm.")
     if impl == 'cudnn' and not jtu.is_cuda_compute_capability_at_least("8.0"):
       raise unittest.SkipTest("Needs compute capability 8.0 or higher.")
     if impl == 'cudnn' and dtype == jnp.float32:


### PR DESCRIPTION
Skip the test that does not support by ROCM
- testDotProductAttentionMask: cuDNN not available on ROCm
- testDotProductAttentionBiasGradient: cuDNN not available on ROCm"
Test Result

 pytest tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 -v -rs 2>&1
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 SKIPPED  [ 12%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 SKIPPED  [ 25%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 SKIPPED  [ 37%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 SKIPPED  [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 SKIPPED [ 62%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 SKIPPED [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 SKIPPED [ 87%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 SKIPPED [100%]

=========================== short test summary info ============================
SKIPPED [4] tests/nn_test.py:240: cuDNN not available on ROCm.
SKIPPED [4] tests/nn_test.py:310: cuDNN not available on ROCm.
============================== 8 skipped in 6.04s ==============================
