### PR TITLE
Skip scaled_matmul tests on ROCm pending upstream JAX merge

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -113,6 +113,11 @@ class NNFunctionsTest(jtu.JaxTestCase):
       dtype=[jnp.float16, jnp.bfloat16, jnp.float32],
   )
   def testScaledMatmul(self, contract, lhs_non_contract, dtype):
+    # ROCm scaled_matmul is implemented in commit a2b972f28 ("register rocm
+    # platform to mx datatype lowering path") but JAX upstream has not merged
+    # this change yet. Skip until upstream JAX includes ROCm support.
+    if jtu.is_device_rocm():
+      raise unittest.SkipTest("ROCm scaled_matmul pending upstream JAX merge (a2b972f28).")
     if not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
     # Check if float8_e8m0fnu is available
@@ -136,6 +141,11 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testScaledDotGeneral(
       self, is_training, output_type):
+    # ROCm scaled_matmul is implemented in commit a2b972f28 ("register rocm
+    # platform to mx datatype lowering path") but JAX upstream has not merged
+    # this change yet. Skip until upstream JAX includes ROCm support.
+    if jtu.is_device_rocm():
+      raise unittest.SkipTest("ROCm scaled_matmul pending upstream JAX merge (a2b972f28).")
     if not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
 


### PR DESCRIPTION
ROCm scaled_matmul support is implemented in commit a2b972f28 ('register rocm platform to mx datatype lowering path') which changes platform='cuda' to platform='gpu' in scaled_matmul_stablehlo.py. However, JAX upstream has not merged this change yet. That why I skip these tests for version 0.8.0. 

Test status
 ```
pytest tests/nn_test.py -k "testScaledMatmul or testScaledDotGeneral" -v
Test session starting on GPU ?
================================================================================== test session starts ==================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collected 351 items / 333 deselected / 18 selected                                                                                                                                      

tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [  5%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [ 11%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [ 16%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [ 22%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [ 27%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                     [ 33%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 38%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 44%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                        [ 50%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                        [ 55%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 61%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 66%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 72%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 77%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 83%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 88%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [ 94%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 SKIPPED (ROCm scaled_matmul pending upstream JAX merge (a2b972f28).)                                                         [100%]
```