### PR TITLE
Enabled testTridiagonal to run on ROCm devices

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1829,7 +1829,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
       dtype=float_types + complex_types,
       lower=[False, True],
   )
-  @jtu.skip_on_devices("tpu","rocm")
+  @jtu.skip_on_devices("tpu")
   def testTridiagonal(self, shape, dtype, lower):
     rng = jtu.rand_default(self.rng())
     def jax_func(a):


### PR DESCRIPTION
## Motivation

Enabled unit test `tests/linalg_test.py::ScipyLinalgTest::testTridiagonal` to run as all tests are passing.

## Test Result

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'xdist': '3.8.0', 'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 10 items

tests/linalg_test.py::ScipyLinalgTest::testTridiagonal0 PASSED                                                                                        [ 10%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal1 PASSED                                                                                        [ 20%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal2 PASSED                                                                                        [ 30%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal3 PASSED                                                                                        [ 40%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal4 PASSED                                                                                        [ 50%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal5 PASSED                                                                                        [ 60%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal6 PASSED                                                                                        [ 70%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal7 PASSED                                                                                        [ 80%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal8 PASSED                                                                                        [ 90%]
tests/linalg_test.py::ScipyLinalgTest::testTridiagonal9 PASSED                                                                                        [100%]

==================================================================== 10 passed in 5.17s =====================================================================
```