### PR TITLE
Enabled ToeplitzSymmetricConstruction unit tests for ROCm devices

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2098,7 +2098,6 @@ class ScipyLinalgTest(jtu.JaxTestCase):
   @jtu.sample_product(
     shape=[(), (3,), (1, 4), (1, 5, 9), (11, 0, 13)],
     dtype=float_types + complex_types + int_types)
-  @jtu.skip_on_devices("rocm")
   def testToeplitzSymmetricConstruction(self, shape, dtype):
     if (dtype in [np.float64, np.complex128]
         and not config.enable_x64.value):


### PR DESCRIPTION
## Motivation
Enabled ToeplitzSymmetricConstruction unit tests for ROCm devices as certain data types are supported. All relevant tests either pass or skip.

## Technical Details

The unit tests tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction were disabled for ROCm and are now enabled. Certain tests are still skipped for all GPUs due to data type support but the remaining tests pass.

## Test Result

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'xdist': '3.8.0', 'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: xdist-3.8.0, rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 10 items

tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction0 PASSED                                                                      [ 10%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction1 SKIPPED (Integer (except int8) toeplitz is not supported on GPU yet.)       [ 20%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction2 PASSED                                                                      [ 30%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction3 SKIPPED (Integer (except int8) toeplitz is not supported on GPU yet.)       [ 40%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction4 PASSED                                                                      [ 50%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction5 PASSED                                                                      [ 60%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction6 PASSED                                                                      [ 70%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction7 PASSED                                                                      [ 80%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction8 SKIPPED (Integer (except int8) toeplitz is not supported on GPU yet.)       [ 90%]
tests/linalg_test.py::ScipyLinalgTest::testToeplitzSymmetricConstruction9 PASSED                                                                      [100%]

=============================================================== 7 passed, 3 skipped in 10.78s ===============================================================
```