### PR TITLE
Enable test_comparison_scalar tests for ROCm GPUs

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1376,7 +1376,7 @@ class OpsTest(PallasBaseTest):
       self.skipTest("float16 is not supported on TPU")
 
     if (
-        jtu.test_device_matches(["gpu"])
+        jtu.test_device_matches(["cuda"])
         and not jtu.is_cuda_compute_capability_at_least("8.0")
     ):
       self.skipTest("Only works on GPUs with capability >= sm80")


### PR DESCRIPTION
Skip the test only for  CUDA-specific tests.
```

All 30 test_comparison_scalar tests now pass on ROCm.
pytest tests/pallas/ops_test.py::OpsInterpretTest -k "test_comparison_scalar" -v
est session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collecting ... collected 1931 items / 1901 deselected / 30 selected

tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_bool PASSED [  3%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float16 PASSED [  6%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float32 PASSED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_int32 PASSED [ 13%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_uint32 PASSED [ 16%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_bool PASSED [ 20%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_bool PASSED [ 23%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float16 PASSED [ 26%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float32 PASSED [ 30%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_int32 PASSED [ 33%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_uint32 PASSED [ 36%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float16 PASSED [ 40%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float32 PASSED [ 43%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_int32 PASSED [ 46%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_uint32 PASSED [ 50%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_bool PASSED [ 53%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_bool PASSED [ 56%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float16 PASSED [ 60%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float32 PASSED [ 63%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_int32 PASSED [ 66%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_uint32 PASSED [ 70%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float16 PASSED [ 73%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float32 PASSED [ 76%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_int32 PASSED [ 80%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_uint32 PASSED [ 83%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_bool PASSED [ 86%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float16 PASSED [ 90%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float32 PASSED [ 93%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_int32 PASSED [ 96%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_uint32 PASSED [100%]

================ 30 passed, 1901 deselected in 77.21s (0:01:17) ================
```