### PR TITLE
Enable test_comparison_scalar tests for ROCm GPUs

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1385,7 +1385,7 @@ class OpsTest(PallasBaseTest):
       self.skipTest("float16 is not supported on TPU")
 
     if (
-        jtu.test_device_matches(["gpu"])
+        jtu.test_device_matches(["cuda"])
         and not jtu.is_cuda_compute_capability_at_least("8.0")
     ):
       self.skipTest("Only works on GPUs with capability >= sm80")


### PR DESCRIPTION

All 30 test_comparison_scalar tests now pass on ROCm.
pytest tests/pallas/ops_test.py::OpsInterpretTest -k "test_comparison_scalar" -v
est session starting on GPU ?
Test result:
Testing...