### PR TITLE
Skip test_approx_tanh on ROCm: PTX inline assembly not supported

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1894,6 +1894,15 @@ class OpsTest(PallasBaseTest):
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpret mode")
 
+    # approx_tanh uses NVIDIA PTX inline assembly (tanh.approx.f32, etc.) which
+    # is not supported on ROCm. AMD CDNA3 (MI300X/gfx942) does not have a
+    # hardware tanh instruction - transcendentals are implemented via OCML
+    # library. See:
+    # - NVIDIA PTX ISA: https://docs.nvidia.com/cuda/parallel-thread-execution/
+    # - AMD CDNA3 ISA: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf
+    if jtu.is_device_rocm():
+      self.skipTest("approx_tanh uses PTX inline assembly not supported on ROCm")
+
     if (dtype == "bfloat16" and
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")


### PR DESCRIPTION
approx_tanh uses NVIDIA PTX inline assembly instructions (tanh.approx.f32, tanh.approx.f16, tanh.approx.bf16) which are not supported on AMD GPUs.

AMD CDNA3 (MI300X/gfx942) does not have a hardware approximate tanh instruction. Transcendental functions on ROCm are implemented via the OCML library (__ocml_tanh_f32, etc.) rather than dedicated hardware.

References:
- NVIDIA PTX ISA: https://docs.nvidia.com/cuda/parallel-thread-execution/
- AMD CDNA3 ISA: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf

Test result
```
python -m pytest tests/pallas/ops_test.py::OpsTest::test_approx_tanh0 tests/pallas/ops_test.py::OpsTest::test_approx_tanh1 tests/pallas/ops_test.py::OpsTest::test_approx_tanh2 -v 2>&1 
Test session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}, 'CI': '1'}
hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=(HealthCheck.too_slow,)
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collecting ... collected 3 items

tests/pallas/ops_test.py::OpsTest::test_approx_tanh0 SKIPPED (approx...) [ 33%]
tests/pallas/ops_test.py::OpsTest::test_approx_tanh1 SKIPPED (approx...) [ 66%]
tests/pallas/ops_test.py::OpsTest::test_approx_tanh2 SKIPPED (approx...) [100%]

```

