### PR TITLE
Enabled test for condition number on ROCm devices.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1102,8 +1102,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     pnorm=[jnp.inf, -jnp.inf, 1, -1, 2, -2, 'fro'],
     dtype=float_types + complex_types,
   )
-  @jtu.skip_on_devices("gpu")  # TODO(#2203): numerical errors
   def testCond(self, shape, pnorm, dtype):
+
+    if jtu.test_device_matches(['gpu']):
+      # Unskipping test for ROCm while leaving
+      # original skip in place for other GPUs as per
+      # commit: e81024f5053def119eddb7fb06ff6c4f7b5948a8
+      #
+      # Original note: TODO(#2203): numerical errors
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+
     def gen_mat():
       # arr_gen = jtu.rand_some_nan(self.rng())
       arr_gen = jtu.rand_default(self.rng())


### PR DESCRIPTION
## Motivation

Enabled unit tests for computing the condition number of a matrix on ROCm devices.

## Technical Details

The unit tests in `linalg_test.py::NumpyLinalgTest::testCond` were skipped for GPUs but ROCm devices have the required support. The skip condition is left as close to the original as possible to preserve the intention and comments left by previous upstream commits. Only ROCm devices are re-enabled.

## Test Plan

The unit tests in question are `linalg_test.py::NumpyLinalgTest::testCond`.

## Test Result
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 415 items / 405 deselected / 10 selected
[TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond0 PASSED                                                                                                     [ 10%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond1 PASSED                                                                                                     [ 20%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond2 PASSED                                                                                                     [ 30%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond3 PASSED                                                                                                     [ 40%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond4 PASSED                                                                                                     [ 50%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond5 PASSED                                                                                                     [ 60%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond6 PASSED                                                                                                     [ 70%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond7 PASSED                                                                                                     [ 80%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond8 PASSED                                                                                                     [ 90%][TestLogger] Using invocation directory as test name: tests

linalg_test.py::NumpyLinalgTest::testCond9 PASSED                                                                                                     [100%][TestLogger] Using invocation directory as test name: tests


============================================================ 10 passed, 405 deselected in 7.67s =============================================================
```