### PR TITLE
Implement approx_tanh for ROCm using OCML tanh function

### DIFF
--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -144,11 +144,13 @@ def _approx_tanh_rocm_lowering(
     ctx: lowering.LoweringRuleContext,
     *args,
 ):
-  """Lower approx_tanh for ROCm using OCML's tanh function.
+  """Lower approx_tanh for ROCm using Triton's fast_tanhf.
 
   AMD CDNA3 (MI300X/gfx942) does not have a hardware tanh instruction.
-  We use __ocml_tanh_f32 which Triton's AMD backend lowers using a numerically
-  stable fast exp-based formula: tanh(x) = sign(x) * (1 - 2/(e^(2|x|) + 1))
+  We use __triton_hip_fast_tanhf which Triton's AMD backend lowers using
+  fast_expf: tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
+
+  See: https://github.com/triton-lang/triton/pull/7780
   """
   from jax._src.lib.mlir import ir
   from jax._src.lib.mlir.dialects import arith as arith_dialect
@@ -162,7 +164,7 @@ def _approx_tanh_rocm_lowering(
     dtype = jnp.dtype(dtype)
     return mlir.dtype_to_ir_type(dtype)
 
-  # OCML only has f32 and f64 tanh. For f16/bf16, we cast to f32, compute, cast back.
+  # fast_tanhf only supports f32. For f16/bf16, cast to f32, compute, cast back.
   needs_cast = in_dtype in (jnp.float16, jnp.bfloat16)
 
   if needs_cast:
@@ -174,13 +176,13 @@ def _approx_tanh_rocm_lowering(
       f32_result_type = f32_type
     arg_f32 = arith_dialect.extf(f32_result_type, arg)
 
-    # Call __ocml_tanh_f32
+    # Call __triton_hip_fast_tanhf (fast exp-based implementation)
     tanh_result = tt_dialect.extern_elementwise(
         f32_result_type,
         [arg_f32],
-        libname="",
+        libname="libdevice",
         libpath="",
-        symbol="__ocml_tanh_f32",
+        symbol="__triton_hip_fast_tanhf",
         pure=True,
     )
 
@@ -188,14 +190,14 @@ def _approx_tanh_rocm_lowering(
     out_type = mlir.aval_to_ir_type(out_aval)
     result = arith_dialect.truncf(out_type, tanh_result)
   else:
-    # f32: call __ocml_tanh_f32 directly
+    # f32: call __triton_hip_fast_tanhf directly
     result_type = mlir.aval_to_ir_type(out_aval)
     result = tt_dialect.extern_elementwise(
         result_type,
         list(args),
-        libname="",
+        libname="libdevice",
         libpath="",
-        symbol="__ocml_tanh_f32",
+        symbol="__triton_hip_fast_tanhf",
         pure=True,
     )
 

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -121,12 +121,8 @@ def _elementwise_inline_asm_lowering(
   del result_shape_dtypes  # Unused.
 
   # For ROCm, PTX inline assembly is not supported. For tanh.approx, we use
-  # OCML's tanh function which Triton lowers via a fast exp-based formula.
-  # See:
-  # - Triton PR #7780: https://github.com/triton-lang/triton/pull/7780
-  # - Triton PR #8551: https://github.com/triton-lang/triton/pull/8551
-  # - NVIDIA PTX ISA: https://docs.nvidia.com/cuda/parallel-thread-execution/
-  # - AMD CDNA3 ISA: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf
+  # Triton's fast_tanhf which uses a fast exp-based formula.
+  # See: https://github.com/triton-lang/triton/pull/7780
   if ctx.context.platform == "rocm" and "tanh.approx" in asm:
     return _approx_tanh_rocm_lowering(ctx, *args)
 
@@ -150,6 +146,10 @@ def _approx_tanh_rocm_lowering(
   We use __triton_hip_fast_tanhf which Triton's AMD backend lowers using
   fast_expf: tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
 
+  Note: f64 is not currently supported by approx_tanh, but if JAX extends
+  support for f64 in the future, this lowering falls back to __ocml_tanh_f64
+  since fast_tanhf only supports f32.
+
   See: https://github.com/triton-lang/triton/pull/7780
   """
   from jax._src.lib.mlir import ir
@@ -163,6 +163,19 @@ def _approx_tanh_rocm_lowering(
   def dtype_to_ir_type(dtype):
     dtype = jnp.dtype(dtype)
     return mlir.dtype_to_ir_type(dtype)
+
+  # f64: fallback to __ocml_tanh_f64 if JAX extends approx_tanh to support f64
+  if in_dtype == jnp.float64:
+    result_type = mlir.aval_to_ir_type(out_aval)
+    result = tt_dialect.extern_elementwise(
+        result_type,
+        list(args),
+        libname="",
+        libpath="",
+        symbol="__ocml_tanh_f64",
+        pure=True,
+    )
+    return [result]
 
   # fast_tanhf only supports f32. For f16/bf16, cast to f32, compute, cast back.
   needs_cast = in_dtype in (jnp.float16, jnp.bfloat16)

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -48,6 +48,11 @@ def approx_tanh(x: jax.Array) -> jax.Array:
   elif x.dtype == jnp.float32:
     asm = "tanh.approx.f32 $0, $1;"
     constraint = "f"
+  elif x.dtype == jnp.float64:
+    # f64 tanh.approx is only supported on ROCm (uses __ocml_tanh_f64)
+    # CUDA does not have a PTX instruction for f64 approximate tanh
+    asm = "tanh.approx.f64 $0, $1;"
+    constraint = "d"
   else:
     raise TypeError(f"approx_tanh does not accept {x.dtype} arrays")
 
@@ -121,8 +126,8 @@ def _elementwise_inline_asm_lowering(
   del result_shape_dtypes  # Unused.
 
   # For ROCm, PTX inline assembly is not supported. For tanh.approx, we use
-  # Triton's fast_tanhf which uses a fast exp-based formula.
-  # See: https://github.com/triton-lang/triton/pull/7780
+  # Triton's __triton_hip_fast_tanhf (fast exp-based formula) for f32, and
+  # OCML's __ocml_tanh_f64 for f64. See: https://github.com/triton-lang/triton/pull/7780
   if ctx.context.platform == "rocm" and "tanh.approx" in asm:
     return _approx_tanh_rocm_lowering(ctx, *args)
 
@@ -140,17 +145,16 @@ def _approx_tanh_rocm_lowering(
     ctx: lowering.LoweringRuleContext,
     *args,
 ):
-  """Lower approx_tanh for ROCm using Triton's fast_tanhf.
+  """Lower approx_tanh for ROCm.
 
   AMD CDNA3 (MI300X/gfx942) does not have a hardware tanh instruction.
-  We use __triton_hip_fast_tanhf which Triton's AMD backend lowers using
-  fast_expf: tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
 
-  Note: f64 is not currently supported by approx_tanh, but if JAX extends
-  support for f64 in the future, this lowering falls back to __ocml_tanh_f64
-  since fast_tanhf only supports f32.
-
+  For f32 (and f16/bf16 via casting): We use Triton's __triton_hip_fast_tanhf
+  which implements a fast exp-based formula: tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
   See: https://github.com/triton-lang/triton/pull/7780
+
+  For f64: We use OCML's __ocml_tanh_f64 (AMD's Open Compute Math Library)
+  since fast_tanhf only supports f32.
   """
   from jax._src.lib.mlir import ir
   from jax._src.lib.mlir.dialects import arith as arith_dialect
@@ -164,7 +168,7 @@ def _approx_tanh_rocm_lowering(
     dtype = jnp.dtype(dtype)
     return mlir.dtype_to_ir_type(dtype)
 
-  # f64: fallback to __ocml_tanh_f64 if JAX extends approx_tanh to support f64
+  # f64: use __ocml_tanh_f64 (fast_tanhf only supports f32)
   if in_dtype == jnp.float64:
     result_type = mlir.aval_to_ir_type(out_aval)
     result = tt_dialect.extern_elementwise(

--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -119,6 +119,17 @@ def _elementwise_inline_asm_lowering(
     result_shape_dtypes,
 ):
   del result_shape_dtypes  # Unused.
+
+  # For ROCm, PTX inline assembly is not supported. For tanh.approx, we use
+  # OCML's tanh function which Triton lowers via a fast exp-based formula.
+  # See:
+  # - Triton PR #7780: https://github.com/triton-lang/triton/pull/7780
+  # - Triton PR #8551: https://github.com/triton-lang/triton/pull/8551
+  # - NVIDIA PTX ISA: https://docs.nvidia.com/cuda/parallel-thread-execution/
+  # - AMD CDNA3 ISA: https://www.amd.com/content/dam/amd/en/documents/instinct-tech-docs/instruction-set-architectures/amd-instinct-mi300-cdna3-instruction-set-architecture.pdf
+  if ctx.context.platform == "rocm" and "tanh.approx" in asm:
+    return _approx_tanh_rocm_lowering(ctx, *args)
+
   return tt_dialect.ElementwiseInlineAsmOp(
       [*map(mlir.aval_to_ir_type, ctx.avals_out)],
       asm,
@@ -127,6 +138,68 @@ def _elementwise_inline_asm_lowering(
       packed_element=pack,
       args=args,
   ).result
+
+
+def _approx_tanh_rocm_lowering(
+    ctx: lowering.LoweringRuleContext,
+    *args,
+):
+  """Lower approx_tanh for ROCm using OCML's tanh function.
+
+  AMD CDNA3 (MI300X/gfx942) does not have a hardware tanh instruction.
+  We use __ocml_tanh_f32 which Triton's AMD backend lowers using a numerically
+  stable fast exp-based formula: tanh(x) = sign(x) * (1 - 2/(e^(2|x|) + 1))
+  """
+  from jax._src.lib.mlir import ir
+  from jax._src.lib.mlir.dialects import arith as arith_dialect
+
+  [arg] = args
+  [out_aval] = ctx.avals_out
+  in_dtype = ctx.avals_in[0].dtype
+
+  # Helper to get IR type for a dtype
+  def dtype_to_ir_type(dtype):
+    dtype = jnp.dtype(dtype)
+    return mlir.dtype_to_ir_type(dtype)
+
+  # OCML only has f32 and f64 tanh. For f16/bf16, we cast to f32, compute, cast back.
+  needs_cast = in_dtype in (jnp.float16, jnp.bfloat16)
+
+  if needs_cast:
+    # Cast input to f32 (extend)
+    f32_type = dtype_to_ir_type(jnp.float32)
+    if out_aval.shape:
+      f32_result_type = ir.RankedTensorType.get(out_aval.shape, f32_type)
+    else:
+      f32_result_type = f32_type
+    arg_f32 = arith_dialect.extf(f32_result_type, arg)
+
+    # Call __ocml_tanh_f32
+    tanh_result = tt_dialect.extern_elementwise(
+        f32_result_type,
+        [arg_f32],
+        libname="",
+        libpath="",
+        symbol="__ocml_tanh_f32",
+        pure=True,
+    )
+
+    # Cast result back to original dtype (truncate)
+    out_type = mlir.aval_to_ir_type(out_aval)
+    result = arith_dialect.truncf(out_type, tanh_result)
+  else:
+    # f32: call __ocml_tanh_f32 directly
+    result_type = mlir.aval_to_ir_type(out_aval)
+    result = tt_dialect.extern_elementwise(
+        result_type,
+        list(args),
+        libname="",
+        libpath="",
+        symbol="__ocml_tanh_f32",
+        pure=True,
+    )
+
+  return [result]
 
 
 def debug_barrier() -> None:

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1884,7 +1884,7 @@ class OpsTest(PallasBaseTest):
 
     np.testing.assert_allclose(f(), kernel())
 
-  @parameterized.parameters("float16", "bfloat16", "float32")
+  @parameterized.parameters("float16", "bfloat16", "float32", "float64")
   def test_approx_tanh(self, dtype):
     self.skip_if_mosaic_gpu()
 
@@ -1898,6 +1898,16 @@ class OpsTest(PallasBaseTest):
         jtu.test_device_matches(["cuda"]) and
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
+
+    if dtype == "float64":
+      if jtu.test_device_matches(["cuda"]):
+        self.skipTest("f64 approx_tanh is only supported on ROCm")
+
+    # Enable x64 for f64 test if not already enabled, restore after test
+    original_x64 = jax.config.x64_enabled
+    if dtype == "float64" and not original_x64:
+      jax.config.update("jax_enable_x64", True)
+      self.addCleanup(lambda: jax.config.update("jax_enable_x64", False))
 
     @functools.partial(
         self.pallas_call, out_shape=jax.ShapeDtypeStruct((4,), dtype),

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1895,6 +1895,7 @@ class OpsTest(PallasBaseTest):
       self.skipTest("approx_tanh is not supported in interpret mode")
 
     if (dtype == "bfloat16" and
+        jtu.test_device_matches(["cuda"]) and
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
 


### PR DESCRIPTION
## Summary

AMD CDNA3 (MI300X/gfx942) does not have a hardware tanh instruction like NVIDIA's PTX `tanh.approx`. This PR implements `approx_tanh` for ROCm using Triton's `__triton_hip_fast_tanhf` function.

Triton's AMD backend lowers this using a fast exp-based formula:
```
tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
```

### Changes:
- For ROCm + tanh.approx: uses Triton's `__triton_hip_fast_tanhf` via `extern_elementwise`
- For f16/bf16: extends to f32 → compute → truncate back
- For f64: uses OCML's `__ocml_tanh_f64` (AMD's Open Compute Math Library) since fast_tanhf only supports f32
- Fixed bf16 skip condition to only apply to CUDA (not ROCm)
- Added f64 test with x64 mode auto-enable

### Test Results
```
tests/pallas/ops_test.py::OpsTest::test_approx_tanh0 (float16)  PASSED
tests/pallas/ops_test.py::OpsTest::test_approx_tanh1 (bfloat16) PASSED
tests/pallas/ops_test.py::OpsTest::test_approx_tanh2 (float32)  PASSED
tests/pallas/ops_test.py::OpsTest::test_approx_tanh3 (float64)  PASSED
```

## Links
- Triton PR #7780: https://github.com/triton-lang/triton/pull/7780
