### PR TITLE
Enable test_dot_general_sharded for ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -713,7 +716,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
       self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
 
   @jtu.sample_product(in_shardings=sharding_configs)
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_dot_general_sharded(self, in_shardings):
     if len(jax.local_devices()) < 4:
       self.skipTest("Require at least 4 devices to run sharding tests.")


### PR DESCRIPTION
## Summary

XLA has a fallback path for scaled dot operations on ROCm (gfx942/MI300X) that dequantizes MXFP8 inputs and performs a standard dot product. This allows the sharded test to run on ROCm without requiring hipBLASLt (gfx950).

### Changes:
- Wrap cuDNN/Blackwell checks in setUp() with test_device_matches(["cuda"])
- Change test_dot_general_sharded from @run_on_devices("cuda") to "gpu"

## Test Result

```
 python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 -v 2>&1 | tail -40

tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 PASSED [ 12%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 PASSED [ 25%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 PASSED [ 37%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 PASSED [ 50%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 PASSED [ 62%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 PASSED [ 75%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 PASSED [ 87%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 PASSED [100%]

========================= 8 passed in 76.28s =========================

```
