### PR TITLE
enable nvfp4 tests rocm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -589,7 +589,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
       ],
       output_type=[jnp.float32, jnp.float16, jnp.bfloat16],
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_dot_general_nvfp4(self, configs, output_type):
     (a_raw, b_raw), (a_dq, b_dq), _, block_scale_configs = (
         generate_nvfp4_quantized_tensors(configs[:-1], output_type)


### PR DESCRIPTION
XLA has a fallback path for NVFP4 operations on ROCm that dequantizes inputs and performs standard matrix multiplication. This allows the NVFP4 dot general tests to run and pass on ROCm devices.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_dot_general_nvfp4 from @run_on_devices("cuda") to "gpu" to allow execution on both CUDA and ROCm

```
Test results
cd /workspace/rocm-jax/jax && python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 -v 2>&1 | tail -30

Test session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
metadata: {'Python': '3.11.13', 'Platform': 'Linux-5.15.0-70-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'metadata': '3.1.1', 'html': '4.1.1', 'json-report': '1.5.0', 'reportlog': '1.0.0', 'rerunfailures': '16.1', 'hypothesis': '6.150.0'}, 'CI': '1'}
hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=(HealthCheck.too_slow,)
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: metadata-3.1.1, html-4.1.1, json-report-1.5.0, reportlog-1.0.0, rerunfailures-16.1, hypothesis-6.150.0
collecting ... collected 10 items

tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 PASSED [ 10%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 PASSED [ 20%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 PASSED [ 30%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 PASSED [ 40%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 PASSED [ 50%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 PASSED [ 60%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 PASSED [ 70%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 PASSED [ 80%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 PASSED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 PASSED [100%]

```
======================== 10 passed in 85.92s (0:01:25) =========================