### PR TITLE
Enable test_dot_general_sharded tests on ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -713,7 +716,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
       self.assertArraysAllClose(out, out_ref, rtol=1e-2, atol=1e-2)
 
   @jtu.sample_product(in_shardings=sharding_configs)
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_dot_general_sharded(self, in_shardings):
     if len(jax.local_devices()) < 4:
       self.skipTest("Require at least 4 devices to run sharding tests.")


### PR DESCRIPTION
XLA has a fallback path for MXFP8 scaled dot operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs a standard dot product. This allows the sharded dot general tests to run and pass on ROCm devices.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_dot_general_sharded from @run_on_devices("cuda") to "gpu" to allow execution on both CUDA and ROCm

Test command:
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 -v

Test results on MI300X:
test_dot_general_sharded0 PASSED
test_dot_general_sharded1 PASSED
test_dot_general_sharded2 PASSED
test_dot_general_sharded3 PASSED
test_dot_general_sharded4 PASSED
test_dot_general_sharded5 PASSED
test_dot_general_sharded6 PASSED
test_dot_general_sharded7 PASSED
========================= 8 passed in 77.60s =========================


