### PR TITLE
Enable test_dot_general_vmap tests on ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -784,7 +787,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
           ((2, 128, 128), (128, 2, 128), (0, 1, 2)),
       ]
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_dot_general_vmap(self, configs):
     cast_to_representable = partial(
         quantize_dequantize,


### PR DESCRIPTION
XLA has a fallback path for MXFP8 scaled dot operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs a standard dot product. This allows the vmap dot general tests to run and pass on ROCm devices.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_dot_general_vmap from @run_on_devices("cuda") to "gpu" to allow execution on both CUDA and ROCm

## Test Command

```bash
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 -v
```

## Test Results on MI300X

```
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 PASSED [ 33%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 PASSED [ 66%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 PASSED [100%]

========================= 3 passed in 19.08s =========================
```
