### PR TITLE
Enable test_dot_general tests on ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -664,7 +667,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
       ],
       output_type=[jnp.float16, jnp.bfloat16, jnp.float32],
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_dot_general(self, configs, output_type):
     cast_to_representable = partial(
         quantize_dequantize,


### PR DESCRIPTION
XLA has a fallback path for MXFP8 scaled dot operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs a standard dot product. This allows the dot general tests to run and pass on ROCm.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_dot_general from @run_on_devices("cuda") to "gpu" to allow execution on both CUDA and ROCm

## Test Command

```bash
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 -v
```

## Test Results on MI300X

```
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 PASSED [ 10%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 PASSED [ 20%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 PASSED [ 30%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 PASSED [ 40%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 PASSED [ 50%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 PASSED [ 60%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 PASSED [ 70%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 PASSED [ 80%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 PASSED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 PASSED [100%]

============================= 10 passed in 50.07s ==============================
```
