### PR TITLE
Enable test_nvfp4_gradient_clip tests on ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -515,7 +518,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
           ((30, 64), (100, 64), (([1], [1]), ([], []))),
       ]
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_nvfp4_gradient_clip(self, enable_grad_clip, configs):
     output_type = jnp.float32
     (a_raw, b_raw), (a_dq, b_dq), _, block_scale_configs = (


### PR DESCRIPTION
XLA has a fallback path for NVFP4 operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs a standard dot product. This allows the NVFP4 gradient clip tests to run and pass on ROCm.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_nvfp4_gradient_clip from @run_on_devices("cuda") to "gpu" to allow execution on both CUDA and ROCm

## Test Command

```bash
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 -v
```

## Test Results on MI300X

```
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 PASSED [ 25%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 PASSED [ 50%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 PASSED [ 75%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 PASSED [100%]

============================== 4 passed in 23.42s ==============================
```

