### PR TITLE
Enable test_quantize_nvfp4 and test_quantize_requires_global_scale te…

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,12 +455,15 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
-    try:
-      check_cudnn_version()
-    except RuntimeError as e:
-      self.skipTest(str(e))
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
-      self.skipTest("Requires at least Blackwell arch")
+    # cuDNN and Blackwell checks only apply to CUDA devices.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8/NVFP4.
+    if jtu.test_device_matches(["cuda"]):
+      try:
+        check_cudnn_version()
+      except RuntimeError as e:
+        self.skipTest(str(e))
+      if not jtu.is_cuda_compute_capability_at_least("10.0"):
+        self.skipTest("Requires at least Blackwell arch")
 
   block_scale_configs = create_mxfp8_configs()
 
@@ -471,7 +474,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
           (1024, 2048),
       ],
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_quantize_nvfp4(self, shape):
     # To test the q-dq logic is valid with XLA
     output_type = jnp.float32
@@ -495,7 +498,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
                               a, rtol=0.2, atol=0.5)
 
   @jtu.sample_product(value=[1e6, 1/4096])
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_quantize_requires_global_scale(self, value):
     output_type = jnp.float32
     k1, k2 = jax.random.split(jax.random.key(0), 2)


### PR DESCRIPTION
…sts on ROCm

XLA has a fallback path for NVFP4 operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs standard operations. This allows the NVFP4 quantization tests to run and pass on ROCm.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_quantize_nvfp4 from @run_on_devices("cuda") to "gpu"
- Change test_quantize_requires_global_scale from @run_on_devices("cuda") to "gpu"
## Test Command

```bash
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 -v
```

## Test Results on MI300X

```
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 PASSED [ 20%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 PASSED [ 40%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 PASSED [ 60%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 PASSED [ 80%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 PASSED [100%]

============================== 5 passed in 24.53s ==============================
```

