### PR TITLE
Enable test_remat_checkpoint_dots tests on ROCm

### DIFF
--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -456,7 +456,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
   def setUp(self):
     super().setUp()
     # cuDNN and Blackwell checks only apply to CUDA devices.
-    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8.
+    # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8/NVFP4.
     if jtu.test_device_matches(["cuda"]):
       try:
         check_cudnn_version()
@@ -833,7 +833,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
     self.assertArraysAllClose(x_grad, x_grad_ref, rtol=1e-2, atol=1e1)
     self.assertArraysAllClose(w_grad, w_grad_ref, rtol=1e-2, atol=1e1)
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_remat_checkpoint_dots(self):
     input = jnp.ones((1, 128, 128))
     config = create_nvfp4_configs([input])[0]
@@ -868,7 +868,7 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
     # Check that the custom backward for scaled_matmul is used.
     self.assertEqual(jaxpr.count('bwd=scaled_dot_bwd'), 1)
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_remat_checkpoint_dots_with_no_batch_dims(self):
     input = jnp.ones((1, 128, 128))
     batched_input = jnp.ones((16, 128, 128))


### PR DESCRIPTION
XLA has a fallback path for NVFP4 operations on ROCm (gfx942/MI300X) that dequantizes inputs and performs standard operations. This allows the remat checkpoint dots tests to run and pass on ROCm.

Changes:
- Wrap cuDNN/Blackwell checks in ScaledDotGeneralTest.setUp() with test_device_matches(["cuda"]) to skip only on CUDA without Blackwell
- Change test_remat_checkpoint_dots from @run_on_devices("cuda") to "gpu"
- Change test_remat_checkpoint_dots_with_no_batch_dims from @run_on_devices("cuda") to "gpu"

## Test Command

```bash
python -m pytest tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims -v
```

## Test Results on MI300X

```
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots PASSED [ 50%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims PASSED [100%]

============================== 2 passed in 15.71s ==============================
```
