### PR TITLE
Enabled Rsf2csf unit tests for ROCm devices.

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1978,7 +1978,7 @@ class ScipyLinalgTest(jtu.JaxTestCase):
     shape=[(1, 1), (4, 4), (15, 15), (50, 50), (100, 100)],
     dtype=float_types + complex_types,
   )
-  @jtu.run_on_devices("cpu")
+  @jtu.run_on_devices("cpu", "rocm")
   def testRsf2csf(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     args_maker = lambda: [rng(shape, dtype), rng(shape, dtype)]


### PR DESCRIPTION
## Motivation

The Rsf2csf unit tests were not enabled for ROCm devices but are able to pass. They have now been enabled.

## Technical Details

`rocm` was added to the unit test decorator for `tests/linalg_test.py::ScipyLinalgTest::testRsf2csf` to allow for ROCm devices to run the test.

## Test Plan
The relevant unit tests fall under `tests/linalg_test.py::ScipyLinalgTest::testRsf2csf`.

## Test Result
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.15.0-144-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'hypothesis': '6.148.2', 'html': '4.1.1', 'metadata': '3.1.1', 'rerunfailures': '16.1', 'reportlog': '1.0.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, hypothesis-6.148.2, html-4.1.1, metadata-3.1.1, rerunfailures-16.1, reportlog-1.0.0
collected 264 items / 254 deselected / 10 selected

tests/linalg_test.py::ScipyLinalgTest::testRsf2csf0 PASSED                                                                                            [ 10%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf1 PASSED                                                                                            [ 20%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf2 PASSED                                                                                            [ 30%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf3 PASSED                                                                                            [ 40%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf4 PASSED                                                                                            [ 50%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf5 PASSED                                                                                            [ 60%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf6 PASSED                                                                                            [ 70%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf7 PASSED                                                                                            [ 80%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf8 PASSED                                                                                            [ 90%]
tests/linalg_test.py::ScipyLinalgTest::testRsf2csf9 PASSED                                                                                            [100%]

============================================================ 10 passed, 254 deselected in 15.41s ============================================================
```