### PR TITLE
Enabled RNN unit test: test_no_workspace_overflow for ROCm devices

### DIFF
--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -216,7 +216,7 @@ class RnnTest(jtu.JaxTestCase):
     self.assertIn('"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\00@\\03\\80\\00\\00\\00\\00\\00@\\01\\00\\00\\00\\00\\00\\00"',
                     stablehlo)
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("cuda", "rocm")
   def test_no_workspace_overflow(self):
     # Problem sizes known to cause overflows on older versions.
     batch_size, max_seq_length, input_size = 256, 500, 512


### PR DESCRIPTION
## Motivation

The RNN unit test `test_no_workspace_overflow` was not enabled for ROCm devices but was passing. The test is now enabled.

## Technical Details

The `rocm` tag was added to the test decorator so that it will run on ROCm devices.

## Test Plan

The relevant unit test being enabled is `tests/experimental_rnn_test.py::RnnTest::test_no_workspace_overflow`

## Test Result

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-5.15.0-144-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'hypothesis': '6.148.2', 'html': '4.1.1', 'metadata': '3.1.1', 'rerunfailures': '16.1', 'reportlog': '1.0.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, hypothesis-6.148.2, html-4.1.1, metadata-3.1.1, rerunfailures-16.1, reportlog-1.0.0
collected 1 item

tests/experimental_rnn_test.py::RnnTest::test_no_workspace_overflow PASSED                                                                            [100%]

===================================================================== 1 passed in 3.36s =====================================================================
```