### PR TITLE
Enable rocm cuda array interface for ROCm

### DIFF
--- a/jaxlib/ffi.cc
+++ b/jaxlib/ffi.cc
@@ -204,9 +204,9 @@ absl::StatusOr<xla::nb_numpy_ndarray> PyFfiAnyBuffer::NumpyArray() const {
 }
 
 absl::StatusOr<nb::dict> PyFfiAnyBuffer::CudaArrayInterface() const {
-  if (device_type_ != kDLCUDA) {
+  if (device_type_ != kDLCUDA && device_type_ != kDLROCM) {
     return absl::UnimplementedError(
-        "Buffer.__cuda_array_interface__ is only supported on CUDA.");
+        "Buffer.__cuda_array_interface__ is only supported on CUDA and ROCm.");
   }
 
   nb::dict result;

--- a/tests/buffer_callback_test.py
+++ b/tests/buffer_callback_test.py
@@ -95,7 +95,7 @@ class BufferCallbackTest(jtu.JaxTestCase):
   @parameterized.product(
       dtype=jtu.dtypes.all, command_buffer_compatible=[True, False]
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_cuda_array_interface(self, dtype, command_buffer_compatible):
     if command_buffer_compatible:
       self.skipTest("Requires jaxlib extension version of at least 337.")


### PR DESCRIPTION
## Motivation
test_cuda_array_interface is currently fully skipped on ROCm. This fix enables  support for cuda_array_interface on ROCm devices.
But it only runs half of array_interface tests due to known issue in where command_buffer_compatible=True could cause segfault.


Below is my test run result with the fix:
<img width="1803" height="810" alt="test_cuda_array_interface" src="https://github.com/user-attachments/assets/09e23963-4c8f-4551-810c-aa6bb6ed1c41" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
