### PR TITLE
Enabled triton_pallas_test.py unit test file to run

### DIFF
--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -126,7 +126,7 @@ class TritonPallasTest(PallasBaseTest):
       else:
         # JAX on ROCm does not currently handle atomic fmin/fmax correctly
         if jtu.test_device_matches(["rocm"]):
-            self.skipTest("Unsupported platform")
+            self.skipTest("Atomic fmin/fmax not supported on ROCm.")
         neutral = np.array(float("inf"), value.dtype)
     elif op == plgpu.atomic_or:
       neutral = np.array(False, value.dtype)

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -46,7 +46,8 @@ class PallasBaseTest(jtu.JaxTestCase):
       if not self.INTERPRET:
         self.skipTest("On CPU the test works only in interpret mode")
     elif jtu.test_device_matches(["gpu"]):
-      if not jtu.is_cuda_compute_capability_at_least("9.0"):
+      if jtu.test_device_matches(["cuda"]) and \
+         not jtu.is_cuda_compute_capability_at_least("9.0"):
         self.skipTest("Only works on GPU with capability >= sm90")
     else:
       self.skipTest("Test only works on CPU and GPU")
@@ -115,11 +116,17 @@ class TritonPallasTest(PallasBaseTest):
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).min, value.dtype)
       else:
+        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
+        if jtu.test_device_matches(["rocm"]):
+            self.skipTest("Unsupported platform")
         neutral = np.array(-float("inf"), value.dtype)
     elif op == plgpu.atomic_min:
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).max, value.dtype)
       else:
+        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
+        if jtu.test_device_matches(["rocm"]):
+            self.skipTest("Unsupported platform")
         neutral = np.array(float("inf"), value.dtype)
     elif op == plgpu.atomic_or:
       neutral = np.array(False, value.dtype)

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -118,7 +118,7 @@ class TritonPallasTest(PallasBaseTest):
       else:
         # JAX on ROCm does not currently handle atomic fmin/fmax correctly
         if jtu.test_device_matches(["rocm"]):
-            self.skipTest("Unsupported platform")
+            self.skipTest("Atomic fmin/fmax not supported on ROCm.")
         neutral = np.array(-float("inf"), value.dtype)
     elif op == plgpu.atomic_min:
       if np.issubdtype(value.dtype, np.integer):


### PR DESCRIPTION
## Motivation

Enabled the `triton_pallas_test.py` unit test file to run. 

## Technical Details

The `triton_pallas_test.py` file was disabled for ROCm. The disabling condition was made more specific to allow ROCm devices to run the test file. Two tests have been added to the skips as they produce failures due to lack of support on JAX-ROCm:
- `pallas/triton_pallas_test.py::TritonPallasTest::test_scalar_atomic_max_f32`
- `pallas/triton_pallas_test.py::TritonPallasTest::test_scalar_atomic_max_f32`

## Test Plan

The file `tests/pallas/triton_pallas_test.py` is itself a unit test file.

## Test Result
The full output is omitted for brevity. Only the number of passing and skipped tests are included.

```
============================================================== 109 passed, 9 skipped in 21.66s ==============================================================
```