### PR TITLE
Cherry pick fix for unit test: "donate_argnames_signature_fail"

### DIFF
--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -409,12 +409,20 @@ class JitTest(jtu.BufferDonationTestCase):
   # Jit and Donate arguments
 
   def test_donate_argnames_signature_fail(self):
+    class NoSignature:
+      @property
+      def __signature__(self):
+        raise TypeError("no signature")
+      def __call__(self, *args, **kwargs):
+        return None
+    fun = NoSignature()
+
     inp = np.arange(4)
     with self.assertRaisesRegex(
         ValueError,
         "Getting the signature of function.*failed. Pass donate_argnums "
         "instead of donate_argnames."):
-      jax.jit(np.dot, donate_argnames='a')(inp, inp)
+      jax.jit(fun, donate_argnames='a')(inp, inp)
 
   @parameterized.named_parameters(
       ("argnums", "donate_argnums", (0, 1)),


### PR DESCRIPTION
## Motivation
The unit test `tests/api_test.py::JitTest::test_donate_argnames_signature_fail` was failing. The fix is available upstream in https://github.com/jax-ml/jax/commit/766f189919ecaa086b1899185c19e60452df7c07 so it has been cherry picked to allow the test to pass here.

## Technical Details
A custom class is added in the unit test to test signature failures.

## Test Plan
The relevant unit test is `tests/api_test.py::JitTest::test_donate_argnames_signature_fail`.

## Test Result

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 1 item
[TestLogger] Using invocation directory as test name: tests

api_test.py::JitTest::test_donate_argnames_signature_fail PASSED                                                                                      [100%][TestLogger] Using invocation directory as test name: tests


===================================================================== 1 passed in 3.39s =====================================================================
```