### PR TITLE
Enable testDotAlgorithm BF16/TF32 tests on ROCm

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1177,7 +1177,7 @@ class LaxTest(jtu.JaxTestCase):
           lax.DotAlgorithmPreset.BF16_BF16_F32_X6,
           lax.DotAlgorithmPreset.BF16_BF16_F32_X9,
       }:
-        if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        if jtu.test_device_matches(["cuda"]) and not jtu.is_cuda_compute_capability_at_least("8.0"):
           raise SkipTest(
               f"The dot algorithm '{algorithm}' requires CUDA compute "
               "capability >= 8.0.")


### PR DESCRIPTION
Modify testDotAlgorithm to only check CUDA compute capability on CUDA devices, allowing ROCm to run these algorithm tests.

## Motivation
Currently testDotAlgorithm  checks CUDA compute compatibility for all GPU devices , with this fix we can enable algorithm tests on ROCm

## Test Result
<img width="1817" height="351" alt="testAlgorithm" src="https://github.com/user-attachments/assets/fb4fe2e1-ffd3-4925-b090-55a1856dc863" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
