### PR TITLE
Cherry pick fix for unit test: "test_issubdtype"

### DIFF
--- a/jax/_src/dtypes.py
+++ b/jax/_src/dtypes.py
@@ -977,7 +977,11 @@ def dtype(x: Any) -> DType:
     dt = x.dtype
   else:
     try:
-      dt = np.result_type(x)
+      with warnings.catch_warnings():
+        # Ignore warning associated with __numpy_dtype__ change in NumPy 2.4.
+        # TODO(jakevdp): remove this warning context after change is finalized.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        dt = np.result_type(x)
     except TypeError as err:
       raise TypeError(f"Cannot determine dtype of {x}") from err
   if dt not in _jax_dtype_set and not issubdtype(dt, extended):

--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -811,7 +811,7 @@ class NNInitializersTest(jtu.JaxTestCase):
     val = initializer(rng, shape, dtype)
 
     self.assertEqual(shape, jnp.shape(val))
-    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), jnp.dtype(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), val.dtype)
 
   @parameterized.parameters(itertools.chain.from_iterable(
     jtu.sample_product_testcases(
@@ -827,7 +827,7 @@ class NNInitializersTest(jtu.JaxTestCase):
     val = initializer(rng, shape)
 
     self.assertEqual(shape, jnp.shape(val))
-    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), jnp.dtype(val))
+    self.assertEqual(jax.dtypes.canonicalize_dtype(dtype), val.dtype)
 
   def testVarianceScalingMultiAxis(self):
     rng = random.PRNGKey(0)

--- a/tests/random_test.py
+++ b/tests/random_test.py
@@ -654,8 +654,14 @@ class KeyArrayTest(jtu.JaxTestCase):
 
     self.assertFalse(jnp.issubdtype(key.dtype, np.integer))
     self.assertFalse(jnp.issubdtype(key.dtype, np.number))
-    with self.assertRaisesRegex(TypeError, "Cannot interpret"):
-      jnp.issubdtype(key, dtypes.prng_key)
+    if jtu.numpy_version() < (2, 4, 0):
+      with self.assertRaisesRegex(TypeError, "Cannot interpret"):
+        jnp.issubdtype(key, dtypes.prng_key)
+    else:
+      with jtu.ignore_warning(category=DeprecationWarning,
+                              message="Implicit conversion of an array to a dtype"):
+        with self.assertRaisesRegex(ValueError, "Could not convert Array"):
+          jnp.issubdtype(key, dtypes.prng_key)
 
   @skipIf(not config.enable_custom_prng.value, 'relies on typed key upgrade flag')
   def test_construction_upgrade_flag(self):

--- a/tests/stax_test.py
+++ b/tests/stax_test.py
@@ -40,7 +40,7 @@ def _CheckShapeAgreement(test_case, init_fun, apply_fun, input_shape):
   result_shape, params = init_fun(init_key, input_shape)
   inputs = random_inputs(test_case.rng(), input_shape)
   if params:
-    inputs = inputs.astype(np.dtype(params[0]))
+    inputs = inputs.astype(dtypes.dtype(params[0]))
   result = apply_fun(params, inputs, rng=rng_key)
   test_case.assertEqual(result.shape, result_shape)
 


### PR DESCRIPTION
## Motivation
The unit test `tests/random_test.py::KeyArrayTest::test_issubdtype` was failing. The fix is available upstream in https://github.com/jax-ml/jax/commit/c37f3904c391829c15a3d5ce4f02c6c5c250dfa4 so it has been cherry picked to allow the test to pass here.

## Technical Details
This cherry pick fixes use of dtypes in `jax/_src/dtypes.py` and affects several different unit test files (`random_test.py`, `nn_test.py`, `stax_test.py`). Though the changes to `random_test.py` are the only ones needed for fixing the test, the entire commit is used to keep usage of dtypes consistent across unit tests.

## Test Plan
The relevant unit tests affected by these changes are:
- `tests/random_test.py::KeyArrayTest::test_issubdtype`
- `tests/nn_test.py::NNInitializersTest`
- `tests/stax_test.py`

## Test Result
All affected unit tests, test classes, or tests files have been retested here.
### Results for `tests/random_test.py::KeyArrayTest::test_issubdtype`
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 1 item
[TestLogger] Using invocation directory as test name: tests

random_test.py::KeyArrayTest::test_issubdtype PASSED                                                                                                  [100%][TestLogger] Using invocation directory as test name: tests


===================================================================== 1 passed in 4.49s =====================================================================
```

### Results for `tests/nn_test.py::NNInitializersTest`
```
=================================================================== 193 passed in 20.53s ====================================================================
```

### Results for `tests/stax_test.py`
```
==================================================================== 71 passed in 17.91s ====================================================================
```