### PR TITLE
Enable optimizer tests on ROCm

### DIFF
--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -41,7 +41,7 @@ class OptimizerTests(jtu.JaxTestCase):
     self.assertEqual(jax.tree.structure(opt_state),
                      jax.tree.structure(opt_state2))
 
-  @jtu.skip_on_devices('gpu')
+  @jtu.skip_on_devices('cuda')
   def _CheckRun(self, optimizer, loss, x0, num_steps, *args, **kwargs):
     init_fun, update_fun, get_params = optimizer(*args)
 


### PR DESCRIPTION
Change skip decorator from 'gpu' to 'cuda' to allow optimizer tests to run on ROCm GPUs while still skipping on CUDA devices.

## Test Result
with the fix 
<img width="1807" height="258" alt="optimizers_test_pass" src="https://github.com/user-attachments/assets/48c2df8a-939a-4456-9bb8-30cfd0f481d8" />


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
