### PR TITLE
Enabled bicgstab and gmres tests with identity and random systems for ROCm

### DIFF
--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -261,8 +261,14 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     preconditioner=[None, 'identity', 'exact'],
   )
-  @jtu.skip_on_devices("gpu")
   def test_bicgstab_on_identity_system(self, shape, dtype, preconditioner):
+    
+    # Test works with ROCm so skip test only for other GPUs instead 
+    # of all GPUs
+    if jtu.test_device_matches(["gpu"]):
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+    
     A = jnp.eye(shape[1], dtype=dtype)
     solution = jnp.ones(shape[1], dtype=dtype)
     rng = jtu.rand_default(self.rng())
@@ -280,8 +286,14 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     preconditioner=[None, 'identity', 'exact'],
   )
-  @jtu.skip_on_devices("gpu")
   def test_bicgstab_on_random_system(self, shape, dtype, preconditioner):
+    
+    # Test works with ROCm so skip test only for other GPUs instead 
+    # of all GPUs
+    if jtu.test_device_matches(["gpu"]):
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+
     rng = jtu.rand_default(self.rng())
     A = rng(shape, dtype)
     solution = rng(shape[1:], dtype)
@@ -367,9 +379,15 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     preconditioner=[None, 'identity', 'exact'],
     solve_method=['batched', 'incremental'],
   )
-  @jtu.skip_on_devices("gpu")
   def test_gmres_on_identity_system(self, shape, dtype, preconditioner,
                                     solve_method):
+    
+    # Test works with ROCm so skip test only for other GPUs instead 
+    # of all GPUs
+    if jtu.test_device_matches(["gpu"]):
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+
     A = jnp.eye(shape[1], dtype=dtype)
 
     solution = jnp.ones(shape[1], dtype=dtype)
@@ -391,9 +409,15 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     preconditioner=[None, 'identity', 'exact'],
     solve_method=['incremental', 'batched'],
   )
-  @jtu.skip_on_devices("gpu")
   def test_gmres_on_random_system(self, shape, dtype, preconditioner,
                                   solve_method):
+    
+    # Test works with ROCm so skip test only for other GPUs instead 
+    # of all GPUs
+    if jtu.test_device_matches(["gpu"]):
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+
     rng = jtu.rand_default(self.rng())
     A = rng(shape, dtype)
 


### PR DESCRIPTION
## Motivation
Several unit tests in `tests/lax_scipy_sparse_test.py::LaxBackedScipyTests` were failing because they were disabled for all GPUs. These tests worked on ROCm though so they have been enabled for ROCm devices only.

## Test Plan
The tests that have been enabled are:
- `tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system`
- `tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system`
- `tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system`
- `tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system`

## Test Result
Running the four tests above they are all passing:
```
============================================================ 40 passed, 51 deselected in 26.88s =============================================================
```