### PR TITLE
Skip tridiagonal solve tests on ROCm

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2289,6 +2289,7 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4), (3, 4, 5)],
                       dtype=float_types + complex_types)
+  @jtu.skip_on_devices("rocm")  # Numerical errors on ROCm
   def test_tridiagonal_solve(self, shape, dtype):
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")


### PR DESCRIPTION
## Motivation

Skip `test_tridiagonal_solve` on ROCm due to numerical precision errors in hipSPARSE's batched tridiagonal solver. Ticket raised with the hipSparse team.

## Technical Details

Added `@jtu.skip_on_devices("rocm")` decorator to `test_tridiagonal_solve` in `tests/linalg_test.py` 

## Test Result

<img width="1037" height="318" alt="test" src="https://github.com/user-attachments/assets/dd07bcc1-e0c4-4039-8c5f-e42c1bb2a714" />

Upstream PR - https://github.com/jax-ml/jax/pull/34568


## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
