### PR TITLE
Backport cuda_array_interface , testDotAlgorithm, Optimizer test fixes from rocm-jaxlib-v0.8.0

### DIFF
--- a/jaxlib/ffi.cc
+++ b/jaxlib/ffi.cc
@@ -325,9 +325,9 @@ absl::StatusOr<xla::nb_numpy_ndarray> PyFfiAnyBuffer::NumpyArray() const {
 }
 
 absl::StatusOr<nb::dict> PyFfiAnyBuffer::CudaArrayInterface() const {
-  if (device_type_ != kDLCUDA) {
+  if (device_type_ != kDLCUDA && device_type_ != kDLROCM) {
     return absl::UnimplementedError(
-        "Buffer.__cuda_array_interface__ is only supported on CUDA.");
+        "Buffer.__cuda_array_interface__ is only supported on CUDA and ROCm.");
   }
 
   nb::dict result;

--- a/tests/buffer_callback_test.py
+++ b/tests/buffer_callback_test.py
@@ -95,7 +95,7 @@ class BufferCallbackTest(jtu.JaxTestCase):
   @parameterized.product(
       dtype=jtu.dtypes.all, command_buffer_compatible=[True, False]
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def test_cuda_array_interface(self, dtype, command_buffer_compatible):
     if command_buffer_compatible:
       self.skipTest("Requires jaxlib extension version of at least 337.")

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1186,7 +1186,7 @@ class LaxTest(jtu.JaxTestCase):
           lax.DotAlgorithmPreset.BF16_BF16_F32_X6,
           lax.DotAlgorithmPreset.BF16_BF16_F32_X9,
       }:
-        if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        if jtu.test_device_matches(["cuda"]) and not jtu.is_cuda_compute_capability_at_least("8.0"):
           raise SkipTest(
               f"The dot algorithm '{algorithm}' requires CUDA compute "
               "capability >= 8.0.")

--- a/tests/optimizers_test.py
+++ b/tests/optimizers_test.py
@@ -41,7 +41,7 @@ class OptimizerTests(jtu.JaxTestCase):
     self.assertEqual(jax.tree.structure(opt_state),
                      jax.tree.structure(opt_state2))
 
-  @jtu.skip_on_devices('gpu')
+  @jtu.skip_on_devices('cuda')
   def _CheckRun(self, optimizer, loss, x0, num_steps, *args, **kwargs):
     init_fun, update_fun, get_params = optimizer(*args)
 


### PR DESCRIPTION
Cherry-pick important fixes from rocm-jaxlib-v0.8.0 to rocm-jaxlib-v0.8.2

## Cherry-picked commits:
- 38345cea5 Enable rocm cuda array interface for ROCm (#625)
- f6fd826ff Enable testDotAlgorithm BF16/TF32 tests on ROCm (#628)
- 23f28df81 Enable optimizer tests on ROCm (#631)

Upstream PR:
https://github.com/jax-ml/jax/pull/34534
https://github.com/jax-ml/jax/pull/34501
https://github.com/jax-ml/jax/pull/34560
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
