### PR TITLE
Enable testDotProductAttentionBiasGradient on ROCm

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -320,10 +320,13 @@ class NNFunctionsTest(jtu.JaxTestCase):
       use_vmap=[False, True],
   )
   def testDotProductAttentionBiasGradient(self, batch_size, use_vmap):
-    if not jtu.is_cuda_compute_capability_at_least("8.0"):
-      raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
-    if jtu.is_cuda_version_at_least(13, 0):
-      raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
+    # ROCm: use XLA implementation instead of cuDNN
+    use_cudnn = not jtu.is_device_rocm()
+    if use_cudnn:
+      if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
+      if jtu.is_cuda_version_at_least(13, 0):
+        raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
     dtype = jnp.bfloat16
     B, S, N, H = batch_size, 128, 4, 32
@@ -343,7 +346,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
           implementation=impl,
       )
     attn_ref = partial(attention, impl=None)
-    attn_ans = partial(attention, impl='cudnn')
+    attn_ans = partial(attention, impl='cudnn' if use_cudnn else 'xla')
     if use_vmap:
       attn_batched_ref = jax.vmap(attn_ref, in_axes=(0, 0, None))
       attn_batched_ans = jax.vmap(attn_ans, in_axes=(0, 0, None))


### PR DESCRIPTION
Use XLA implementation instead of cuDNN on ROCm since cuDNN is NVIDIA-only.

## Test result
```
python -m pytest "tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0" "tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1" "tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2" "tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3" -v 
Test session starting on GPU ?
====================================================== test session starts =======================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.2.0-25-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'hypothesis': '6.150.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'metadata': '3.1.1', 'json-report': '1.5.0', 'html': '4.1.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.150.0, rerunfailures-16.1, reportlog-1.0.0, metadata-3.1.1, json-report-1.5.0, html-4.1.1
collected 4 items                                                                                                                

tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 PASSED                                             [ 25%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 PASSED                                             [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 PASSED                                             [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 PASSED                                             [100%]

======================================================= 4 passed in 17.12s =======================================================
root@493934c8ed3e:/workspace/rocm-jax/jax# 
```