### PR TITLE
Enable nn tests on ROCm

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -113,12 +113,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
       dtype=[jnp.float16, jnp.bfloat16, jnp.float32],
   )
   def testScaledMatmul(self, contract, lhs_non_contract, dtype):
-    # ROCm scaled_matmul is implemented in commit a2b972f28 ("register rocm
-    # platform to mx datatype lowering path") but JAX upstream has not merged
-    # this change yet. Skip until upstream JAX includes ROCm support.
-    if jtu.is_device_rocm():
-      raise unittest.SkipTest("ROCm scaled_matmul pending upstream JAX merge (a2b972f28).")
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
+    # ROCm: scaled_matmul works, skip only CUDA compute capability check
+    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
     # Check if float8_e8m0fnu is available
     configs = create_mxfp8_configs_if_available()
@@ -141,12 +137,8 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testScaledDotGeneral(
       self, is_training, output_type):
-    # ROCm scaled_matmul is implemented in commit a2b972f28 ("register rocm
-    # platform to mx datatype lowering path") but JAX upstream has not merged
-    # this change yet. Skip until upstream JAX includes ROCm support.
-    if jtu.is_device_rocm():
-      raise unittest.SkipTest("ROCm scaled_matmul pending upstream JAX merge (a2b972f28).")
-    if not jtu.is_cuda_compute_capability_at_least("10.0"):
+    # ROCm: scaled_dot_general works, skip only CUDA compute capability check
+    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
 
     configs = create_mxfp8_configs_if_available()
@@ -255,10 +247,13 @@ class NNFunctionsTest(jtu.JaxTestCase):
   def testDotProductAttentionMask(self, mask_mode):
     if isinstance(mask_mode, str):
       mask_mode = (mask_mode,)
-    if not jtu.is_cuda_compute_capability_at_least("8.0"):
-      raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
-    if jtu.is_cuda_version_at_least(13, 0):
-      raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
+    # ROCm: use XLA implementation instead of cuDNN
+    use_cudnn = not jtu.is_device_rocm()
+    if use_cudnn:
+      if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
+      if jtu.is_cuda_version_at_least(13, 0):
+        raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
     dtype = jnp.bfloat16
     B, S, T, N, H = 2, 128, 128, 4, 32
@@ -285,8 +280,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
       window_size = (3, 2) if is_causal else (3, 0)
 
     sdpa = nn.dot_product_attention
+    impl = 'cudnn' if use_cudnn else 'xla'
     sdpa_ref = partial(sdpa, is_causal=is_causal, implementation=None)
-    sdpa_ans = partial(sdpa, is_causal=is_causal, implementation='cudnn')
+    sdpa_ans = partial(sdpa, is_causal=is_causal, implementation=impl)
 
     args = (Q, K, V, bias, mask)
     kwargs = {'query_seq_lengths': q_seqlen, 'key_value_seq_lengths': kv_seqlen}
@@ -305,9 +301,10 @@ class NNFunctionsTest(jtu.JaxTestCase):
     dQ_ref, dK_ref, dV_ref, dbias_ref = sdpa_vjp_ref(grad)[:4]
     dQ_ans, dK_ans, dV_ans, dbias_ans = sdpa_vjp_ans(grad)[:4]
 
-    # Check if cudnn backend is called.
-    self.assertTrue(_check_cudnn_backend(sdpa_ans, *args, **kwargs))
-    self.assertTrue(_check_cudnn_backend(sdpa_vjp_ans, grad))
+    # Check if cudnn backend is called (only on CUDA).
+    if use_cudnn:
+      self.assertTrue(_check_cudnn_backend(sdpa_ans, *args, **kwargs))
+      self.assertTrue(_check_cudnn_backend(sdpa_vjp_ans, grad))
 
     self.assertAllClose(out_ref, out_ans, atol=.01, rtol=.01)
     self.assertAllClose(dQ_ref, dQ_ans, rtol=.02, atol=.02)
@@ -320,10 +317,13 @@ class NNFunctionsTest(jtu.JaxTestCase):
       use_vmap=[False, True],
   )
   def testDotProductAttentionBiasGradient(self, batch_size, use_vmap):
-    if not jtu.is_cuda_compute_capability_at_least("8.0"):
-      raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
-    if jtu.is_cuda_version_at_least(13, 0):
-      raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
+    # ROCm: use XLA implementation instead of cuDNN
+    use_cudnn = not jtu.is_device_rocm()
+    if use_cudnn:
+      if not jtu.is_cuda_compute_capability_at_least("8.0"):
+        raise unittest.SkipTest("Requires compute capability 8.0 or higher.")
+      if jtu.is_cuda_version_at_least(13, 0):
+        raise unittest.SkipTest("cuDNN creates no execution plans on CUDA 13.0.")
 
     dtype = jnp.bfloat16
     B, S, N, H = batch_size, 128, 4, 32
@@ -343,7 +343,7 @@ class NNFunctionsTest(jtu.JaxTestCase):
           implementation=impl,
       )
     attn_ref = partial(attention, impl=None)
-    attn_ans = partial(attention, impl='cudnn')
+    attn_ans = partial(attention, impl='cudnn' if use_cudnn else 'xla')
     if use_vmap:
       attn_batched_ref = jax.vmap(attn_ref, in_axes=(0, 0, None))
       attn_batched_ans = jax.vmap(attn_ans, in_axes=(0, 0, None))


### PR DESCRIPTION
- testScaledMatmul: works on ROCm, skip only CUDA compute capability check
- testScaledDotGeneral: works on ROCm, skip only CUDA compute capability check
- testDotProductAttentionMask: use XLA instead of cuDNN on ROCm
- testDotProductAttentionBiasGradient: use XLA instead of cuDNN on ROCm


## Test Result
```
python -m pytest tests/nn_test.py -k "testScaledMatmul or testScaledDotGeneral or testDotProductAttentionMask or testDotProductAttentionBiasGradient" -v 2>&1 | tail -45
Test session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.2.0-25-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'hypothesis': '6.150.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'metadata': '3.1.1', 'json-report': '1.5.0', 'html': '4.1.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.150.0, rerunfailures-16.1, reportlog-1.0.0, metadata-3.1.1, json-report-1.5.0, html-4.1.1
collecting ... collected 351 items / 321 deselected / 30 selected

tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 PASSED [  3%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 PASSED [  6%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 PASSED [ 10%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 PASSED [ 13%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 PASSED   [ 16%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 PASSED   [ 20%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 PASSED   [ 23%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 PASSED   [ 26%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask4 PASSED   [ 30%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask5 PASSED   [ 33%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask6 PASSED   [ 36%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask7 PASSED   [ 40%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 PASSED          [ 43%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 PASSED          [ 46%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 PASSED          [ 50%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 PASSED          [ 53%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 PASSED          [ 56%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 PASSED          [ 60%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 PASSED              [ 63%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 PASSED              [ 66%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 PASSED             [ 70%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 PASSED             [ 73%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 PASSED              [ 76%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 PASSED              [ 80%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 PASSED              [ 83%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 PASSED              [ 86%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 PASSED              [ 90%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 PASSED              [ 93%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 PASSED              [ 96%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 PASSED              [100%]

===================== 30 passed, 321 deselected in 49.70s ======================
```

Test | Backend Used
-- | --
testDotProductAttentionMask | XLA native (dot_general ops)
testDotProductAttentionBiasGradient | XLA native (dot_general ops)
testScaledMatmul | XLA native GPU kernels
testScaledDotGeneral | XLA native GPU kernels

