### PR TITLE
Enable RngShardingTests

### DIFF
--- a/tests/array_test.py
+++ b/tests/array_test.py
@@ -1593,7 +1593,7 @@ class RngShardingTest(jtu.JaxTestCase):
   # tests that the PRNGs are automatically sharded as expected
 
   @parameterized.named_parameters(("3", 3), ("4", 4), ("5", 5))
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_random_bits_is_pure_map_1d(self, num_devices):
     @jax.jit
     def f(x):
@@ -1627,7 +1627,7 @@ class RngShardingTest(jtu.JaxTestCase):
        "mesh_shape": mesh_shape, "pspec": pspec}
       for mesh_shape in [(3, 2), (4, 2), (2, 3)]
       for pspec in [P('x', None), P(None, 'y'), P('x', 'y')])
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_random_bits_is_pure_map_2d(self, mesh_shape, pspec):
     @jax.jit
     def f(x):


### PR DESCRIPTION
## Motivation

enable tests/array_test.py::RngShardingTest::test_random_bits_is_pure_map_{1,2}d

## Technical Details

Constrained the skip to CUDA only as ROCm has the RNG Sharding Lowering. 
Confirmed this with executing a reproducer which forces GPU execution, creates a multi-GPU mesh of multiple GPUs, builds a sharded input that is truly distributed across devices,  defines a jitted function that generates RNG bits. Emits and inspects HLO to find out if the optimized HLO contains global_shape, which means that it is partitioned and asserts if there are no collectives in the optimized HLO. Finally, checks the devices of addressable_shards, and confirms if they are all ROCm GPUs. 

## Test Plan

Test all  tests/array_test.py::RngShardingTest

## Test Result

Tests  are passing:

```
root@smci355-ccs-aus-m12-05:/jax080/rocm-jax/jax# pytest tests/array_test.py::RngShardingTest                                      [121/1868]
Test session starting on GPU ?                                                                                                               
============================================================ test session starts ============================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0                                                                                 
rootdir: /jax080/rocm-jax/jax                                                                                                                
configfile: pyproject.toml                                                                                                                   
plugins: html-4.1.1, hypothesis-6.150.2, metadata-3.1.1, json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0                              
collected 13 items                                                                                                                           
                                                                                                                                             
tests/array_test.py .............                                                                                                     [100%] 
                                                                                                                                             
============================================================ 13 passed in 9.38s =============================================================

```
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
