### PR TITLE
Skipping elementwise_inline_asm unit test on ROCm.

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1935,6 +1935,9 @@ class OpsTest(PallasBaseTest):
       self.skipTest(
           "elementwise_inline_asm is not supported in interpret mode"
       )
+    
+    if jtu.is_device_rocm():
+      self.skipTest("elementwise_inline_asm is not supported for ROCm")
 
     @functools.partial(
         self.pallas_call,

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1937,7 +1937,8 @@ class OpsTest(PallasBaseTest):
       )
     
     if jtu.is_device_rocm():
-      self.skipTest("elementwise_inline_asm is not supported for ROCm")
+      self.skipTest("elementwise_inline_asm is not currently "
+                    "supported on ROCm")
 
     @functools.partial(
         self.pallas_call,


### PR DESCRIPTION
## Motivation
The elementwise_inline_asm function is not properly supported for ROCm and produces incorrect results. As such, the relevant unit test is now skipped.

## Test Plan
The elementwise_inline_asm function is tested in: `tests/pallas/ops_test.py::OpsTest::test_elementwise_inline_asm`

## Test Result
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 1 item
[TestLogger] Using invocation directory as test name: tests

pallas/ops_test.py::OpsTest::test_elementwise_inline_asm SKIPPED (elementwise_inline_asm is not supported for ROCm)                                   [100%][TestLogger] Using invocation directory as test name: tests


==================================================================== 1 skipped in 3.73s =====================================================================
```