### PR TITLE
Enable test_variadic_reduce_window on ROCm

### DIFF
--- a/tests/lax_vmap_test.py
+++ b/tests/lax_vmap_test.py
@@ -758,8 +758,8 @@ class LaxVmapTest(jtu.JaxTestCase):
   # TODO Collapse
   # TODO Scatter
 
-  # TODO(b/183233858): variadic reduce-window is not implemented on XLA:GPU
-  @jtu.skip_on_devices("gpu")
+  # b/183233858: variadic reduce-window not implemented on XLA:CUDA
+  @jtu.skip_on_devices("cuda")
   def test_variadic_reduce_window(self):
     # https://github.com/jax-ml/jax/discussions/9818 and
     # https://github.com/jax-ml/jax/issues/9837


### PR DESCRIPTION
Change skip decorator from 'gpu' to 'cuda' to allow test_variadic_reduce_window to run on ROCm GPUs.

## Motivation

This was initially disabled due to missing implementation XLA. Currently XLA supports this for ROCm hence enabling it for ROCm platform.


## Test Result

<img width="1801" height="242" alt="varidiac test" src="https://github.com/user-attachments/assets/142467b9-762e-467c-ab3c-ddcff082d025" />


upstream PR: https://github.com/jax-ml/jax/pull/34574
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
