### PR TITLE
Port commits for UT fixes from rocm-jaxlib-v0.8.0 to rocm-jaxlib-v0.8.2: condition number, rnn workspace, and Pallas Triton tests

### DIFF
--- a/tests/experimental_rnn_test.py
+++ b/tests/experimental_rnn_test.py
@@ -216,7 +216,7 @@ class RnnTest(jtu.JaxTestCase):
     self.assertIn('"\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\01\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\00\\01\\00\\00\\00@\\03\\80\\00\\00\\00\\00\\00@\\01\\00\\00\\00\\00\\00\\00"',
                     stablehlo)
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("cuda", "rocm")
   def test_no_workspace_overflow(self):
     # Problem sizes known to cause overflows on older versions.
     batch_size, max_seq_length, input_size = 256, 500, 512

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -1153,8 +1153,17 @@ class NumpyLinalgTest(jtu.JaxTestCase):
     pnorm=[jnp.inf, -jnp.inf, 1, -1, 2, -2, 'fro'],
     dtype=float_types + complex_types,
   )
-  @jtu.skip_on_devices("gpu")  # TODO(#2203): numerical errors
   def testCond(self, shape, pnorm, dtype):
+
+    if jtu.test_device_matches(['gpu']):
+      # Unskipping test for ROCm while leaving
+      # original skip in place for other GPUs as per
+      # commit: e81024f5053def119eddb7fb06ff6c4f7b5948a8
+      #
+      # Original note: TODO(#2203): numerical errors
+      if not jtu.is_device_rocm():
+        self.skipTest("Unsupported platform")
+
     def gen_mat():
       # arr_gen = jtu.rand_some_nan(self.rng())
       arr_gen = jtu.rand_default(self.rng())

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -47,7 +47,8 @@ class PallasBaseTest(jtu.JaxTestCase):
       if not self.INTERPRET:
         self.skipTest("On CPU the test works only in interpret mode")
     elif jtu.test_device_matches(["gpu"]):
-      if not jtu.is_cuda_compute_capability_at_least("9.0"):
+      if jtu.test_device_matches(["cuda"]) and \
+         not jtu.is_cuda_compute_capability_at_least("9.0"):
         self.skipTest("Only works on GPU with capability >= sm90")
     else:
       self.skipTest("Test only works on CPU and GPU")
@@ -116,11 +117,17 @@ class TritonPallasTest(PallasBaseTest):
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).min, value.dtype)
       else:
+        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
+        if jtu.test_device_matches(["rocm"]):
+            self.skipTest("Atomic fmin/fmax not currently supported on ROCm.")
         neutral = np.array(-float("inf"), value.dtype)
     elif op == plgpu.atomic_min:
       if np.issubdtype(value.dtype, np.integer):
         neutral = np.array(np.iinfo(value.dtype).max, value.dtype)
       else:
+        # JAX on ROCm does not currently handle atomic fmin/fmax correctly
+        if jtu.test_device_matches(["rocm"]):
+            self.skipTest("Atomic fmin/fmax not currently supported on ROCm.")
         neutral = np.array(float("inf"), value.dtype)
     elif op == plgpu.atomic_or:
       neutral = np.array(False, value.dtype)
@@ -316,6 +323,10 @@ class TritonPallasTest(PallasBaseTest):
       self.skipTest(
           "elementwise_inline_asm is not supported in interpret mode"
       )
+
+    if jtu.is_device_rocm():
+      self.skipTest("elementwise_inline_asm is not currently "
+                    "supported on ROCm")
 
     @functools.partial(
         self.pallas_call,


### PR DESCRIPTION
## Motivation
This ports several unit test fixes from `rocm-jaxlib-v0.8.0` to `rocm-jaxlib-v0.8.2`:
- Enable tests for condition number computation
    - v0.8.0 commit: https://github.com/ROCm/jax/commit/02cf07304208cf214b1bbb17eb3ec7f7485fae2b
    - Downstream PR: https://github.com/ROCm/jax/pull/613
    - Upstream PR: https://github.com/jax-ml/jax/pull/34561
- Enable RNN unit test: "test_no_workspace_overflow"
    - v0.8.0 commit: https://github.com/ROCm/jax/commit/abbb2ef8b55a22b1c759bc4f55d408181a631e09
    - Downstream PR: https://github.com/ROCm/jax/pull/624
    - Upstream PR: https://github.com/jax-ml/jax/pull/34577
- Enable Pallas Triton Tests. This involved two commits and fixes their merge conflicts from upstream changes
    - v0.8.0 commits: https://github.com/ROCm/jax/commit/61625381cc2f014972e9a67692f3249e6ca473d9 and https://github.com/ROCm/jax/commit/9344b2b2a0827236b1d11feb63a7c6dbc4286124
    - Downstream PR: https://github.com/ROCm/jax/pull/626 and https://github.com/ROCm/jax/pull/645
    - Upstream PR: https://github.com/jax-ml/jax/pull/34575
