### PR TITLE
Skip sparse tests on ROCm due to hipSPARSE issue

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -138,6 +138,8 @@ class cuSparseTest(sptu.SparseTestCase):
   )
   @jax.default_matmul_precision("float32")
   def test_csr_matmul_ad(self, shape, dtype, bshape):
+    if jtu.is_device_rocm():
+      self.skipTest("test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue")
     csr_matmul = sparse_csr._csr_matvec if len(bshape) == 1 else sparse_csr._csr_matmat
     tol = {np.float32: 2E-5, np.float64: 1E-12, np.complex64: 1E-5,
            np.complex128: 1E-12}
@@ -216,13 +218,8 @@ class cuSparseTest(sptu.SparseTestCase):
     transpose=[True, False],
   )
   def test_csr_matvec(self, shape, dtype, transpose):
-    if (
-        jtu.is_device_rocm() and
-        get_rocm_version() < (6, 4) and
-        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
-    ):
-      # TODO: Remove this check when ROCm 6.4+ is the minimum supported version
-      self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
+    if jtu.is_device_rocm():
+      self.skipTest("test_csr_matvec not supported on ROCm due to hipSPARSE issue")
 
     op = lambda M: M.T if transpose else M
 
@@ -592,6 +589,8 @@ class cuSparseTest(sptu.SparseTestCase):
   )
   @jtu.run_on_devices("gpu")
   def test_csr_spmv(self, shape, dtype, transpose):
+    if jtu.is_device_rocm():
+      self.skipTest("test_csr_spmv not supported on ROCm due to hipSPARSE issue")
     rng_sparse = sptu.rand_sparse(self.rng())
     rng_dense = jtu.rand_default(self.rng())
 
@@ -1041,6 +1040,8 @@ class SparseObjectTest(sptu.SparseTestCase):
     for Obj in [sparse.CSR, sparse.CSC, sparse.COO, sparse.BCOO]))
   @jax.default_matmul_precision("float32")
   def test_matmul(self, shape, dtype, Obj, bshape):
+    if jtu.is_device_rocm():
+      self.skipTest("test_matmul not supported on ROCm due to hipSPARSE issue")
     rng = sptu.rand_sparse(self.rng(), post=jnp.array)
     rng_b = jtu.rand_default(self.rng())
     M = rng(shape, dtype)


### PR DESCRIPTION
Skip test_csr_matmul_ad, test_csr_matvec, test_csr_spmv, and test_matmul on ROCm due to known issue in hipSPARSE.

## Motivation

issues in hipSPARSE library causing segfaults in these sparse tests, we will skip this on ROCm and re-enable it once the issue is fixed.

```bash
root@ab46678ff4c8:/workspace/rocm-jax/jax# cd /workspace/rocm-jax/jax && JAX_PLATFORMS=rocm pytest tests/sparse_test.py -k "test_csr_matmul_ad or test_csr_matvec or test_csr_spmv or test_matmul" -v
Test session starting on GPU ?
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 463 items / 393 deselected / 70 selected                                                                                                                                                   

tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad0 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  1%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad1 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  2%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad2 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  4%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad3 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  5%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad4 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  7%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad5 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [  8%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad6 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [ 10%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad7 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [ 11%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad8 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [ 12%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad9 SKIPPED (test_csr_matmul_ad not supported on ROCm due to hipSPARSE issue)                                                              [ 14%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec0 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 15%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec1 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 17%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec2 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 18%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec3 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 20%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec4 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 21%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec5 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 22%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec6 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 24%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec7 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 25%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec8 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 27%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec9 SKIPPED (test_csr_matvec not supported on ROCm due to hipSPARSE issue)                                                                    [ 28%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv0 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 30%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv1 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 31%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv2 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 32%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv3 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 34%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv4 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 35%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv5 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 37%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv6 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 38%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv7 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 40%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv8 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 41%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv9 SKIPPED (test_csr_spmv not supported on ROCm due to hipSPARSE issue)                                                                        [ 42%]
tests/sparse_test.py::SparseObjectTest::test_matmul0 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 44%]
tests/sparse_test.py::SparseObjectTest::test_matmul1 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 45%]
tests/sparse_test.py::SparseObjectTest::test_matmul10 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 47%]
tests/sparse_test.py::SparseObjectTest::test_matmul11 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 48%]
tests/sparse_test.py::SparseObjectTest::test_matmul12 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 50%]
tests/sparse_test.py::SparseObjectTest::test_matmul13 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 51%]
tests/sparse_test.py::SparseObjectTest::test_matmul14 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 52%]
tests/sparse_test.py::SparseObjectTest::test_matmul15 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 54%]
tests/sparse_test.py::SparseObjectTest::test_matmul16 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 55%]
tests/sparse_test.py::SparseObjectTest::test_matmul17 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 57%]
tests/sparse_test.py::SparseObjectTest::test_matmul18 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 58%]
tests/sparse_test.py::SparseObjectTest::test_matmul19 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 60%]
tests/sparse_test.py::SparseObjectTest::test_matmul2 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 61%]
tests/sparse_test.py::SparseObjectTest::test_matmul20 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 62%]
tests/sparse_test.py::SparseObjectTest::test_matmul21 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 64%]
tests/sparse_test.py::SparseObjectTest::test_matmul22 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 65%]
tests/sparse_test.py::SparseObjectTest::test_matmul23 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 67%]
tests/sparse_test.py::SparseObjectTest::test_matmul24 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 68%]
tests/sparse_test.py::SparseObjectTest::test_matmul25 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 70%]
tests/sparse_test.py::SparseObjectTest::test_matmul26 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 71%]
tests/sparse_test.py::SparseObjectTest::test_matmul27 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 72%]
tests/sparse_test.py::SparseObjectTest::test_matmul28 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 74%]
tests/sparse_test.py::SparseObjectTest::test_matmul29 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 75%]
tests/sparse_test.py::SparseObjectTest::test_matmul3 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 77%]
tests/sparse_test.py::SparseObjectTest::test_matmul30 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 78%]
tests/sparse_test.py::SparseObjectTest::test_matmul31 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 80%]
tests/sparse_test.py::SparseObjectTest::test_matmul32 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 81%]
tests/sparse_test.py::SparseObjectTest::test_matmul33 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 82%]
tests/sparse_test.py::SparseObjectTest::test_matmul34 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 84%]
tests/sparse_test.py::SparseObjectTest::test_matmul35 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 85%]
tests/sparse_test.py::SparseObjectTest::test_matmul36 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 87%]
tests/sparse_test.py::SparseObjectTest::test_matmul37 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 88%]
tests/sparse_test.py::SparseObjectTest::test_matmul38 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 90%]
tests/sparse_test.py::SparseObjectTest::test_matmul39 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                       [ 91%]
tests/sparse_test.py::SparseObjectTest::test_matmul4 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 92%]
tests/sparse_test.py::SparseObjectTest::test_matmul5 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 94%]
tests/sparse_test.py::SparseObjectTest::test_matmul6 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 95%]
tests/sparse_test.py::SparseObjectTest::test_matmul7 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 97%]
tests/sparse_test.py::SparseObjectTest::test_matmul8 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [ 98%]
tests/sparse_test.py::SparseObjectTest::test_matmul9 SKIPPED (test_matmul not supported on ROCm due to hipSPARSE issue)                                                                        [100%]

================================================================================ 70 skipped, 393 deselected in 3.39s =================================================================================
```

Upstream PR: https://github.com/jax-ml/jax/pull/34610
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
