### PR TITLE
Skip sparse tests on ROCm due to hipSPARSE issue

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -137,6 +137,7 @@ class cuSparseTest(sptu.SparseTestCase):
     dtype=jtu.dtypes.floating + jtu.dtypes.complex,
   )
   @jax.default_matmul_precision("float32")
+  @jtu.skip_on_devices("rocm")  # skipping on ROCm due to known issue in hipSPARSE
   def test_csr_matmul_ad(self, shape, dtype, bshape):
     csr_matmul = sparse_csr._csr_matvec if len(bshape) == 1 else sparse_csr._csr_matmat
     tol = {np.float32: 2E-5, np.float64: 1E-12, np.complex64: 1E-5,
@@ -215,6 +216,7 @@ class cuSparseTest(sptu.SparseTestCase):
     dtype=all_dtypes,
     transpose=[True, False],
   )
+  @jtu.skip_on_devices("rocm")  # skipping on ROCm due to known issue in hipSPARSE
   def test_csr_matvec(self, shape, dtype, transpose):
     if (
         jtu.is_device_rocm() and
@@ -591,6 +593,7 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   @jtu.run_on_devices("gpu")
+  @jtu.skip_on_devices("rocm")  # skipping on ROCm due to known issue in hipSPARSE
   def test_csr_spmv(self, shape, dtype, transpose):
     tol = {np.float32: 2E-5, np.float64: 2E-14}
 
@@ -1042,6 +1045,7 @@ class SparseObjectTest(sptu.SparseTestCase):
     )
     for Obj in [sparse.CSR, sparse.CSC, sparse.COO, sparse.BCOO]))
   @jax.default_matmul_precision("float32")
+  @jtu.skip_on_devices("rocm")  # skipping on ROCm due to known issue in hipSPARSE
   def test_matmul(self, shape, dtype, Obj, bshape):
     rng = sptu.rand_sparse(self.rng(), post=jnp.array)
     rng_b = jtu.rand_default(self.rng())


### PR DESCRIPTION
## Motivation

Skip test_csr_matmul_ad, test_csr_matvec, test_csr_spmv, and test_matmul on ROCm due to known issue in hipSPARSE.

## Technical Details

issues in hipSPARSE library causing segfaults in these sparse tests, we will skip this on ROCm and re-enable it once the issue is fixed.

##Test Result:
```bash
root@ab46678ff4c8:/workspace/rocm-jax/jax# cd /workspace/rocm-jax/jax && JAX_PLATFORMS=rocm pytest tests/sparse_test.py -k "test_csr_matmul_ad or test_csr_matvec or test_csr_spmv or test_matmul" -v
Test session starting on GPU ?
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 463 items / 393 deselected / 70 selected                                                                                                                                                   

tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad0 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  1%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad1 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  2%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad2 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  4%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad3 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  5%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad4 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  7%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad5 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [  8%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad6 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [ 10%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad7 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [ 11%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad8 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [ 12%]
tests/sparse_test.py::cuSparseTest::test_csr_matmul_ad9 SKIPPED (test_csr_matmul_ad not supported on device with tags {'rocm', 'gpu'}.)                                                        [ 14%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec0 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 15%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec1 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 17%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec2 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 18%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec3 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 20%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec4 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 21%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec5 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 22%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec6 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 24%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec7 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 25%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec8 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 27%]
tests/sparse_test.py::cuSparseTest::test_csr_matvec9 SKIPPED (test_csr_matvec not supported on device with tags {'rocm', 'gpu'}.)                                                              [ 28%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv0 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 30%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv1 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 31%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv2 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 32%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv3 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 34%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv4 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 35%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv5 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 37%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv6 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 38%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv7 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 40%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv8 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 41%]
tests/sparse_test.py::cuSparseTest::test_csr_spmv9 SKIPPED (test_csr_spmv not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 42%]
tests/sparse_test.py::SparseObjectTest::test_matmul0 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 44%]
tests/sparse_test.py::SparseObjectTest::test_matmul1 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 45%]
tests/sparse_test.py::SparseObjectTest::test_matmul10 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 47%]
tests/sparse_test.py::SparseObjectTest::test_matmul11 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 48%]
tests/sparse_test.py::SparseObjectTest::test_matmul12 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 50%]
tests/sparse_test.py::SparseObjectTest::test_matmul13 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 51%]
tests/sparse_test.py::SparseObjectTest::test_matmul14 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 52%]
tests/sparse_test.py::SparseObjectTest::test_matmul15 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 54%]
tests/sparse_test.py::SparseObjectTest::test_matmul16 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 55%]
tests/sparse_test.py::SparseObjectTest::test_matmul17 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 57%]
tests/sparse_test.py::SparseObjectTest::test_matmul18 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 58%]
tests/sparse_test.py::SparseObjectTest::test_matmul19 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 60%]
tests/sparse_test.py::SparseObjectTest::test_matmul2 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 61%]
tests/sparse_test.py::SparseObjectTest::test_matmul20 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 62%]
tests/sparse_test.py::SparseObjectTest::test_matmul21 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 64%]
tests/sparse_test.py::SparseObjectTest::test_matmul22 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 65%]
tests/sparse_test.py::SparseObjectTest::test_matmul23 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 67%]
tests/sparse_test.py::SparseObjectTest::test_matmul24 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 68%]
tests/sparse_test.py::SparseObjectTest::test_matmul25 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 70%]
tests/sparse_test.py::SparseObjectTest::test_matmul26 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 71%]
tests/sparse_test.py::SparseObjectTest::test_matmul27 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 72%]
tests/sparse_test.py::SparseObjectTest::test_matmul28 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 74%]
tests/sparse_test.py::SparseObjectTest::test_matmul29 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 75%]
tests/sparse_test.py::SparseObjectTest::test_matmul3 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 77%]
tests/sparse_test.py::SparseObjectTest::test_matmul30 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 78%]
tests/sparse_test.py::SparseObjectTest::test_matmul31 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 80%]
tests/sparse_test.py::SparseObjectTest::test_matmul32 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 81%]
tests/sparse_test.py::SparseObjectTest::test_matmul33 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 82%]
tests/sparse_test.py::SparseObjectTest::test_matmul34 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 84%]
tests/sparse_test.py::SparseObjectTest::test_matmul35 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 85%]
tests/sparse_test.py::SparseObjectTest::test_matmul36 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 87%]
tests/sparse_test.py::SparseObjectTest::test_matmul37 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 88%]
tests/sparse_test.py::SparseObjectTest::test_matmul38 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 90%]
tests/sparse_test.py::SparseObjectTest::test_matmul39 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                 [ 91%]
tests/sparse_test.py::SparseObjectTest::test_matmul4 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 92%]
tests/sparse_test.py::SparseObjectTest::test_matmul5 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 94%]
tests/sparse_test.py::SparseObjectTest::test_matmul6 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 95%]
tests/sparse_test.py::SparseObjectTest::test_matmul7 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 97%]
tests/sparse_test.py::SparseObjectTest::test_matmul8 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [ 98%]
tests/sparse_test.py::SparseObjectTest::test_matmul9 SKIPPED (test_matmul not supported on device with tags {'rocm', 'gpu'}.)                                                                  [100%]

================================================================================ 70 skipped, 393 deselected in 4.76s =================================================================================
```
Upstream PR: https://github.com/jax-ml/jax/pull/34610

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
