### PR TITLE
Added skip for "test_prim_tridiagonal_solve" tests on ROCm

### DIFF
--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -75,7 +75,9 @@ class PrimitiveTest(jtu.JaxTestCase):
                     "decompositions for equality.")
 
     # Tridiagonal Solve (gtsv2) on ROCm is implemented but produces
-    # numerical errors so gtsv2 cannot be marked as stable yet.
+    # numerical errors as of at least ROCm 7.2 so gtsv2 cannot be marked
+    # as stable yet.
+    # TODO Re-enable this test when ROCm numerical errors in gtsv2 are fixed.
     if "tridiagonal_solve" in harness.fullname and jtu.is_device_rocm():
         self.skipTest("Tridiagonal Solve (gtsv2) is currently"
                       "unsupported on ROCm")

--- a/tests/export_harnesses_multi_platform_test.py
+++ b/tests/export_harnesses_multi_platform_test.py
@@ -74,6 +74,12 @@ class PrimitiveTest(jtu.JaxTestCase):
       self.skipTest("Eigenvalues are sorted and it is not correct to compare "
                     "decompositions for equality.")
 
+    # Tridiagonal Solve (gtsv2) on ROCm is implemented but produces
+    # numerical errors so gtsv2 cannot be marked as stable yet.
+    if "tridiagonal_solve" in harness.fullname and jtu.is_device_rocm():
+        self.skipTest("Tridiagonal Solve (gtsv2) is currently"
+                      "unsupported on ROCm")
+
     if harness.params.get("enable_xla", False):
       self.skipTest("enable_xla=False is not relevant")
 


### PR DESCRIPTION
## Motivation
The unit tests `test_prim_tridiagonal_solve_shape*` were failing since they required that an FFI call for tridiagonal solve (gtsv2) was marked as stable. There are currently numerical errors in the hipSPARSE library for this function so we cannot mark gtsv2 as stable yet. We can unskip this when the numerical errors are resolved.

- Upstream PR: https://github.com/jax-ml/jax/pull/34644

## Test Plan
The tests being skipped are:
- `tests/export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float32_3_`
- `tests/export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float64_3_`

## Test Result
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.1, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'hypothesis': '6.148.2', 'metadata': '3.1.1', 'html': '4.1.1', 'reportlog': '1.0.0', 'json-report': '1.5.0'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, hypothesis-6.148.2, metadata-3.1.1, html-4.1.1, reportlog-1.0.0, json-report-1.5.0
collected 5447 items / 5445 deselected / 2 selected
[TestLogger] Using invocation directory as test name: tests

export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float32_3_ SKIPPED (Tridiagonal Solve (gtsv2) is curren...) [ 50%][TestLogger] Using invocation directory as test name: tests

export_harnesses_multi_platform_test.py::PrimitiveTest::test_prim_tridiagonal_solve_shape_float64_3_ SKIPPED (Tridiagonal Solve (gtsv2) is curren...) [100%][TestLogger] Using invocation directory as test name: tests


============================================================ 2 skipped, 5445 deselected in 4.40s ============================================================
```