### PR TITLE
Fix test_cuda_array_interface test skip condition

### DIFF
--- a/tests/buffer_callback_test.py
+++ b/tests/buffer_callback_test.py
@@ -19,6 +19,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax._src import test_util as jtu
+from jax._src.lib import jaxlib_extension_version
 from jax.experimental import buffer_callback
 
 jax.config.parse_flags_with_absl()
@@ -97,7 +98,7 @@ class BufferCallbackTest(jtu.JaxTestCase):
   )
   @jtu.run_on_devices("gpu")
   def test_cuda_array_interface(self, dtype, command_buffer_compatible):
-    if command_buffer_compatible:
+    if command_buffer_compatible and jaxlib_extension_version < 337:
       self.skipTest("Requires jaxlib extension version of at least 337.")
 
     def callback(ctx, out, arg):


### PR DESCRIPTION
Fix skip condition to properly check jaxlib_extension_version >= 337 instead of unconditionally skipping command_buffer_compatible=True.

Motivation:
currently test is skipped on unconditionally without checking jaxlib version. we will fix this and enable all buffer callback tests on ROCm

Test Result:
```bash
root@a3c1f1fad18e:/workspace/debug_session_MI300/rocm-jax/jax# pytest 'tests/buffer_callback_test.py::BufferCallbackTest' -k 'cuda_array_interface'   
Test session starting on GPU ?
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 51 items / 29 deselected / 22 selected                                                                                                                                                     

tests/buffer_callback_test.py ......................                                                                                                                                           [100%]

================================================================================= 22 passed, 29 deselected in 2.61s ==================================================================================
```
upstream PR:https://github.com/jax-ml/jax/pull/34501
## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
