### PR TITLE
Enable array interoperability tests on ROCm platform

### DIFF
--- a/jaxlib/py_array.cc
+++ b/jaxlib/py_array.cc
@@ -966,9 +966,10 @@ nb::dict PyArray::CudaArrayInterface() {
   ifrt::Array* ifrt_array = arr.ifrt_array();
   std::optional<xla::Shape>& scratch = arr.GetStorage().dynamic_shape;
   auto* pjrt_buffer = GetPjrtBuffer(ifrt_array);
-  if (pjrt_buffer->client()->platform_id() != xla::CudaId()) {
+  if (pjrt_buffer->client()->platform_id() != xla::CudaId() &&
+      pjrt_buffer->client()->platform_id() != xla::RocmId()) {
     throw nb::attribute_error(
-        "__cuda_array_interface__ is only defined for NVidia GPU buffers.");
+        "__cuda_array_interface__ is only defined for GPU buffers.");
   }
   if (pjrt_buffer->IsTuple()) {
     throw nb::attribute_error(

--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -309,7 +309,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     ):
       _ = x.__cuda_array_interface__
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def testCudaArrayInterfaceOnShardedArrayFails(self):
     devices = jax.local_devices()
     if len(devices) <= 1:
@@ -330,7 +330,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     shape=all_shapes,
     dtype=cuda_array_interface_dtypes,
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def testCudaArrayInterfaceWorks(self, shape, dtype):
     rng = jtu.rand_default(self.rng())
     x = rng(shape, dtype)
@@ -340,7 +340,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     self.assertEqual(shape, a["shape"])
     self.assertEqual(z.__array_interface__["typestr"], a["typestr"])
 
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def testCudaArrayInterfaceBfloat16Fails(self):
     rng = jtu.rand_default(self.rng())
     x = rng((2, 2), jnp.bfloat16)
@@ -385,7 +385,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
     shape=all_shapes,
     dtype=jtu.dtypes.supported(cuda_array_interface_dtypes),
   )
-  @jtu.run_on_devices("cuda")
+  @jtu.run_on_devices("gpu")
   def testCaiToJax(self, shape, dtype):
     dtype = np.dtype(dtype)
 
@@ -394,7 +394,7 @@ class CudaArrayInterfaceTest(jtu.JaxTestCase):
 
     # using device with highest device_id for testing the correctness
     # of detecting the device id from a pointer value
-    device = jax.devices('cuda')[-1]
+    device = jax.devices('gpu')[-1]
     with jax.default_device(device):
       y = jnp.array(x, dtype=dtype)
       # TODO(parkers): Remove after setting 'stream' properly below.


### PR DESCRIPTION
This change enables the tests/array_interoperability_test.py::CudaArrayInterfaceTest on ROCm GPUs.Currently plugin load and platform detection for this test is hard coded to CUDA. My fix addresses this and adds support for ROCm.

## Technical Details

1. jaxlib/py_array.cc: Add ROCm platform check alongside CUDA for
   __cuda_array_interface__ property support.

2. jax/_src/numpy/array_constructors.py:
   - Add ROCm plugin extension discovery with debug logging

3. tests/array_interoperability_test.py: Change the following tests to use
   @jtu.run_on_devices("gpu") to run on both CUDA and ROCm:
   - testCaiToJax
   - testCudaArrayInterfaceWorks
   - testCudaArrayInterfaceBfloat16Fails
   - testCudaArrayInterfaceOnShardedArrayFails

## Test Result
```bash
root@3ec1777a72fc:/workspace/debug_session_MI300/rocm-jax/jax# pytest tests/array_interoperability_test.py -k "testCaiToJax or testCudaArrayInterfaceWorks or testCudaArrayInterfaceBfloat16Fails or testCudaArrayInterfaceOnShardedArrayFails" -v
Test session starting on GPU ?
======================================================================================== test session starts =========================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 107 items / 85 deselected / 22 selected                                                                                                                                                    

tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax0 PASSED                                                                                                             [  4%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax1 PASSED                                                                                                             [  9%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax2 PASSED                                                                                                             [ 13%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax3 PASSED                                                                                                             [ 18%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax4 PASSED                                                                                                             [ 22%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax5 PASSED                                                                                                             [ 27%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax6 PASSED                                                                                                             [ 31%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax7 PASSED                                                                                                             [ 36%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax8 PASSED                                                                                                             [ 40%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCaiToJax9 PASSED                                                                                                             [ 45%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceBfloat16Fails PASSED                                                                                       [ 50%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceOnShardedArrayFails PASSED                                                                                 [ 54%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks0 PASSED                                                                                              [ 59%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks1 PASSED                                                                                              [ 63%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks2 PASSED                                                                                              [ 68%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks3 PASSED                                                                                              [ 72%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks4 PASSED                                                                                              [ 77%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks5 PASSED                                                                                              [ 81%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks6 PASSED                                                                                              [ 86%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks7 PASSED                                                                                              [ 90%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks8 PASSED                                                                                              [ 95%]
tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceWorks9 PASSED                                                                                              [100%]

================================================================================= 22 passed, 85 deselected in 3.38s ==================================================================================
```
Upstream PR:https://github.com/jax-ml/jax/pull/34662
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
