### PR TITLE
Update Skip Reason Outputs

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -627,15 +627,18 @@ def test_device_matches(device_types: Iterable[str]) -> bool:
 
 test_device_matches.__test__ = False  # This isn't a test case, pytest.
 
-def _device_filter(predicate):
+def _device_filter(predicate, skip_reason=None):
   def skip(test_method):
     @functools.wraps(test_method)
     def test_method_wrapper(self, *args, **kwargs):
       device_tags = _get_device_tags()
       if not predicate():
-        test_name = getattr(test_method, '__name__', '[unknown test]')
-        raise unittest.SkipTest(
-          f"{test_name} not supported on device with tags {device_tags}.")
+        if skip_reason:
+          raise unittest.SkipTest(skip_reason)
+        else:
+          test_name = getattr(test_method, '__name__', '[unknown test]')
+          raise unittest.SkipTest(
+            f"{test_name} not supported on device with tags {device_tags}.")
       return test_method(self, *args, **kwargs)
     return test_method_wrapper
   return skip
@@ -644,9 +647,19 @@ def skip_on_devices(*disabled_devices):
   """A decorator for test methods to skip the test on certain devices."""
   return _device_filter(lambda: not test_device_matches(disabled_devices))
 
-def run_on_devices(*enabled_devices):
-  """A decorator for test methods to run the test only on certain devices."""
-  return _device_filter(lambda: test_device_matches(enabled_devices))
+def run_on_devices(*enabled_devices, skip_reason=None):
+  """A decorator for test methods to run the test only on certain devices.
+  
+  Args:
+    *enabled_devices: Device names that the test should run on.
+    skip_reason: Optional custom skip message when test is skipped.
+  """
+  if skip_reason is None:
+    if enabled_devices == ("cpu",):
+      skip_reason = "Skipped: CPU-only test."
+    elif enabled_devices == ("tpu",):
+      skip_reason = "Skipped: TPU-only test."
+  return _device_filter(lambda: test_device_matches(enabled_devices), skip_reason)
 
 def device_supports_buffer_donation():
   """A decorator for test methods to run the test only on devices that support

--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -643,9 +643,23 @@ def _device_filter(predicate, skip_reason=None):
     return test_method_wrapper
   return skip
 
-def skip_on_devices(*disabled_devices):
-  """A decorator for test methods to skip the test on certain devices."""
-  return _device_filter(lambda: not test_device_matches(disabled_devices))
+def skip_on_devices(*disabled_devices, skip_reason=None):
+  """A decorator for test methods to skip the test on certain devices.
+  
+  Args:
+    *disabled_devices: Device names that the test should skip on.
+    skip_reason: Optional custom skip message when test is skipped.
+  """
+  if skip_reason is None:
+    skip_messages = {
+      ("gpu",): "Skipped on all GPUs.",
+      ("cpu",): "Skipped on CPU.",
+      ("tpu",): "Skipped on TPU.",
+      ("cuda",): "Skipped on CUDA GPUs.",
+      ("rocm",): "Skipped on ROCm GPUs.",
+    }
+    skip_reason = skip_messages.get(disabled_devices)
+  return _device_filter(lambda: not test_device_matches(disabled_devices), skip_reason)
 
 def run_on_devices(*enabled_devices, skip_reason=None):
   """A decorator for test methods to run the test only on certain devices.
@@ -655,10 +669,14 @@ def run_on_devices(*enabled_devices, skip_reason=None):
     skip_reason: Optional custom skip message when test is skipped.
   """
   if skip_reason is None:
-    if enabled_devices == ("cpu",):
-      skip_reason = "Skipped: CPU-only test."
-    elif enabled_devices == ("tpu",):
-      skip_reason = "Skipped: TPU-only test."
+    device_specific_skip_reasons = {
+        ("cpu",): "Skipped: CPU-only test.",
+        ("tpu",): "Skipped: TPU-only test.",
+        ("gpu",): "Skipped: GPU-only test.",
+        ("rocm",): "Skipped: ROCm-only test.",
+        ("cuda",): "Skipped: CUDA-only test.",
+    }
+    skip_reason = device_specific_skip_reasons.get(enabled_devices)
   return _device_filter(lambda: test_device_matches(enabled_devices), skip_reason)
 
 def device_supports_buffer_donation():

--- a/tests/pallas/gpu_pallas_distributed_test.py
+++ b/tests/pallas/gpu_pallas_distributed_test.py
@@ -39,17 +39,20 @@ partial = functools.partial
 class TestCase(jt_multiprocess.MultiProcessTest):
 
   def setUp(self):
+    # Check mosaic support first (before GPU capability check)
+    if not mgpu.supports_cross_device_collectives():
+      if jtu.test_device_matches(["rocm"]):
+        self.skipTest("Mosaic not supported on ROCm currently.")
+      else:
+        self.skipTest("NVSHMEM library unavailable.")
     if (not jtu.test_device_matches(["cuda"]) or
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("Only works on GPU with capability >= sm90")
-    if not mgpu.supports_cross_device_collectives():
-      self.skipTest("NVSHMEM library unavailable.")
     if jax.process_count() == 1:
       self.skipTest("Test requires multiple processes.")
     if os.environ.get("XLA_PYTHON_CLIENT_ALLOCATOR", "") == "platform":
       self.skipTest("NVSHMEM doesn't work with the platform allocator.")
     super().setUp()
-
 
 class PallasCallRemoteDMATest(TestCase):
 


### PR DESCRIPTION
## Motivation
Update skip reasons for CPU-only and TPU-only tests to reflect they are <device> only, instead of getting not supported on device skip reasons

Previously tests had <test_name> not supported on device with tags {'rocm', 'gpu'}. " skip reason when "run_on" decorator was used. However this skip reason does not reflect real skip reason for multiple tests. If a run_on decorator is used, especially with 'cpu' or 'tpu' argument, that test is CPU-only or TPU-only. Therefore the skip reason should reflect that, instead of stating the test is not supported on a specific device/platform.

## Related PRs:
Downstream - 0.8.0 branch: https://github.com/ROCm/jax/pull/662 + https://github.com/ROCm/jax/pull/669
Upstream - https://github.com/jax-ml/jax/pull/34675
Cherry-picked from: a58fbae99d114898c0583b740d47c440fb3f2102 and 621f01a5b2ed018edf8422abdbd271198771f307

## Test Result

Before this change:
```
tests/shard_map_test.py::ShardMapTest::test_forwarding_correctness1 SKIPPEDu'}.)                 [100%] 
                                                                                                        
======================================= short test summary info ========================================
SKIPPED [1] tests/shard_map_test.py:2517: test_forwarding_correctness not supported on device with tags 
{'rocm', 'gpu'}.      
```

After this change:
```
tests/shard_map_test.py::ShardMapTest::test_forwarding_correctness1 SKIPPED (Skipped: CPU-only
test.)                                                                                           [100%]

======================================= short test summary info ========================================
SKIPPED [1] tests/shard_map_test.py:2517: Skipped: CPU-only test.
========================================== 1 skipped in 7.12s =========================================
```
The skip reason change allows us to categorize skips better.


## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
