### PR TITLE
Enable polynomial roots tests on  ROCm platform on v0.8.0 branch

### DIFF
--- a/jaxlib/config.cc
+++ b/jaxlib/config.cc
@@ -82,8 +82,6 @@ class ThreadLocalConfigState {
 };
 
 // This class represents all of the global configuration state.
-// TODO(phawkins): to support free-threading, we will need to add locking to
-// this class.
 class GlobalConfigState {
  public:
   static GlobalConfigState& Instance() {

--- a/tests/polynomial_test.py
+++ b/tests/polynomial_test.py
@@ -71,8 +71,8 @@ class TestPolynomial(jtu.JaxTestCase):
     leading=[0, 2],
     trailing=[0, 2],
   )
-  # TODO(phawkins): no nonsymmetric eigendecomposition implementation on GPU.
-  @jtu.run_on_devices("cpu")
+  # TODO(phawkins): no nonsymmetric eigendecomposition implementation on TPU.
+  @jtu.skip_on_devices("tpu")
   def testRoots(self, dtype, length, leading, trailing):
     rng = jtu.rand_some_zero(self.rng())
 
@@ -97,8 +97,8 @@ class TestPolynomial(jtu.JaxTestCase):
     leading=[0, 2],
     trailing=[0, 2],
   )
-  # TODO(phawkins): no nonsymmetric eigendecomposition implementation on GPU.
-  @jtu.run_on_devices("cpu")
+  # TODO(phawkins): no nonsymmetric eigendecomposition implementation on TPU.
+  @jtu.skip_on_devices("tpu")
   def testRootsNoStrip(self, dtype, length, leading, trailing):
     rng = jtu.rand_some_zero(self.rng())
 


### PR DESCRIPTION
## Motivation

These tests were initially marked only for CPU but upstream JAX has a new update to enable it on GPU aswell.
Changes are already available in 0.8.2 so applying fix to 0.8.0 only.
No need to upstream


## Test Result
with the fix, below tests pass on ROCm
```bash
root@3ec1777a72fc:/workspace/debug_session_MI300/rocm-jax/jax# JAX_PLATFORMS=rocm pytest tests/polynomial_test.py -k "testRoots" -v
Test session starting on GPU ?
=========================================================================================== test session starts ============================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 20 items                                                                                                                                                                                         

tests/polynomial_test.py::TestPolynomial::testRoots0 PASSED                                                                                                                                          [  5%]
tests/polynomial_test.py::TestPolynomial::testRoots1 PASSED                                                                                                                                          [ 10%]
tests/polynomial_test.py::TestPolynomial::testRoots2 PASSED                                                                                                                                          [ 15%]
tests/polynomial_test.py::TestPolynomial::testRoots3 PASSED                                                                                                                                          [ 20%]
tests/polynomial_test.py::TestPolynomial::testRoots4 PASSED                                                                                                                                          [ 25%]
tests/polynomial_test.py::TestPolynomial::testRoots5 PASSED                                                                                                                                          [ 30%]
tests/polynomial_test.py::TestPolynomial::testRoots6 PASSED                                                                                                                                          [ 35%]
tests/polynomial_test.py::TestPolynomial::testRoots7 PASSED                                                                                                                                          [ 40%]
tests/polynomial_test.py::TestPolynomial::testRoots8 PASSED                                                                                                                                          [ 45%]
tests/polynomial_test.py::TestPolynomial::testRoots9 PASSED                                                                                                                                          [ 50%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip0 PASSED                                                                                                                                   [ 55%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip1 PASSED                                                                                                                                   [ 60%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip2 PASSED                                                                                                                                   [ 65%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip3 PASSED                                                                                                                                   [ 70%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip4 PASSED                                                                                                                                   [ 75%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip5 PASSED                                                                                                                                   [ 80%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip6 PASSED                                                                                                                                   [ 85%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip7 PASSED                                                                                                                                   [ 90%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip8 PASSED                                                                                                                                   [ 95%]
tests/polynomial_test.py::TestPolynomial::testRootsNoStrip9 PASSED                                                                                                                                   [100%]

============================================================================================ 20 passed in 5.66s ============================================================================================
```

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
