### PR TITLE
Enable testMultivariateNormalSingularCovariance on ROCm 

### DIFF
--- a/tests/random_lax_test.py
+++ b/tests/random_lax_test.py
@@ -963,7 +963,7 @@ class DistributionsTest(RandomTestBase):
                         check_dtypes=False)
 
   @jtu.sample_product(method=['cholesky', 'eigh', 'svd'])
-  @jtu.skip_on_devices('gpu', 'tpu')  # Some NaNs on accelerators.
+  @jtu.skip_on_devices('cuda', 'tpu')  # Some NaNs on accelerators. ROCm supported 
   def testMultivariateNormalSingularCovariance(self, method):
     # Singular covariance matrix https://github.com/jax-ml/jax/discussions/13293
     mu = jnp.zeros((2,))


### PR DESCRIPTION
## Motivation

Unskip this test on ROCm devices now that Gesvdj support was added in #580. All methods (cholesky, eigh, svd) now work correctly on ROCm.

## Technical Details

Modified the `@jtu.skip_on_devices` decorator in `tests/random_lax_test.py` from `'gpu', 'tpu'` to `'cuda', 'tpu'`

## Test Result

<img width="2791" height="632" alt="image" src="https://github.com/user-attachments/assets/0e9c3670-a16e-46f5-9024-f05e266818bd" />


Upstream PR - https://github.com/jax-ml/jax/pull/34567

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
