### PR TITLE
[ROCm][Pallas] Fix ROCm GPU architecture detection and route to Triton backend

### DIFF
--- a/jax/_src/pallas/pallas_call.py
+++ b/jax/_src/pallas/pallas_call.py
@@ -1135,14 +1135,21 @@ def _pallas_call_lowering(
   def gpu_lowering(ctx: mlir.LoweringRuleContext,
                    *in_nodes: mlir.ir.Value | Sequence[mlir.ir.Value],
                    **params):
+    is_rocm = ctx.module_context.platforms == ("rocm",)
     try:
       match backend:
         case "mosaic_gpu":
+          if is_rocm:
+            raise ValueError(
+                "Mosaic GPU backend does not yet support AMD ROCm devices. "
+                "Use backend='triton' for ROCm."
+            )
           from jax._src.pallas.mosaic_gpu import pallas_call_registration
         case "triton":
           from jax._src.pallas.triton import pallas_call_registration  # type: ignore
         case None:
-          if _PALLAS_USE_MOSAIC_GPU.value:
+          # Mosaic GPU only supports NVIDIA CUDA, not AMD ROCm.
+          if _PALLAS_USE_MOSAIC_GPU.value and not is_rocm:
             from jax._src.pallas.mosaic_gpu import pallas_call_registration
           else:
             from jax._src.pallas.triton import pallas_call_registration  # type: ignore

--- a/jax/experimental/mosaic/gpu/core.py
+++ b/jax/experimental/mosaic/gpu/core.py
@@ -709,7 +709,14 @@ def _infer_arch() -> tuple[int, int]:
     device = jex_backend.get_default_device()
   if not hasattr(device, "compute_capability"):
     return (9, 0)  # TODO(apaszke): Remove this once we figure out the export story.
-  return tuple(map(int, device.compute_capability.split(".")))  # type: ignore
+  arch_name = device.compute_capability
+  # Handle ROCm devices that return architecture strings like "gfxXXX".
+  if arch_name.startswith("gfx"):
+    raise ValueError(
+        f"Mosaic GPU does not yet support AMD ROCm devices. "
+        f"Got compute_capability: {arch_name}"
+    )
+  return tuple(map(int, arch_name.split(".")))  # type: ignore
 
 
 def _lower_as_gpu_kernel(

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -2783,7 +2783,8 @@ class OpsTest(PallasBaseTest):
 
   def test_delay(self):
     if jtu.test_device_matches(["gpu"]):
-      if not use_mosaic_gpu:
+      # ROCm always uses Triton (Mosaic GPU doesn't support ROCm).
+      if jtu.is_device_rocm() or not use_mosaic_gpu:
         self.skipTest("Delay is only implemented on the MGPU backend for GPUs.")
     if self.INTERPRET:
       self.skipTest("Not implemented in interpret mode.")


### PR DESCRIPTION
### Motivation

Pallas tests fail on AMD ROCm GPUs with the error:

```
ValueError: invalid literal for int() with base 10: 'gfx950'
```

This occurs because:
1. The Mosaic GPU backend (NVIDIA-specific) attempts to parse the GPU architecture string
2. NVIDIA GPUs return `compute_capability` as "major.minor" (e.g., "9.0")
3. AMD ROCm GPUs return architecture identifiers like "gfx950"
4. The code tries to parse "gfx950" as an integer, causing the failure

### Solution

This PR fixes the issue with three changes:

1. **`jax/_src/pallas/pallas_call.py`**: Route ROCm devices to Triton backend
   - Added `is_rocm` check in `gpu_lowering()`
   - When `backend=None` and running on ROCm, automatically use Triton instead of Mosaic GPU
   - Added clear error if user explicitly requests `backend='mosaic_gpu'` on ROCm

2. **`jax/experimental/mosaic/gpu/core.py`**: Add safety check in `_infer_arch()`
   - Detect ROCm architecture strings (starting with "gfx") and raise a descriptive error

3. **`tests/pallas/ops_test.py`**: Fix `test_delay` skip logic
   - The `delay` primitive is only implemented in Mosaic GPU, not Triton
   - Updated skip condition to include ROCm devices: `jtu.is_device_rocm() or not use_mosaic_gpu`

### Testing

- 122 tests now pass (previously failing with gfx950 error)
- `test_delay` properly skips on ROCm since delay is MGPU-only


## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
