### PR TITLE
Skip testCudaArrayInterfaceOnNonCudaFails on ROCm platform

### DIFF
--- a/tests/array_interoperability_test.py
+++ b/tests/array_interoperability_test.py
@@ -306,13 +306,13 @@ class DLPackTest(jtu.JaxTestCase):
 
 class CudaArrayInterfaceTest(jtu.JaxTestCase):
 
-  @jtu.skip_on_devices("cuda")
+  @jtu.skip_on_devices("cuda", "rocm")
   def testCudaArrayInterfaceOnNonCudaFails(self):
     x = jnp.arange(5)
     self.assertFalse(hasattr(x, "__cuda_array_interface__"))
     with self.assertRaisesRegex(
         AttributeError,
-        "__cuda_array_interface__ is only defined for NVidia GPU buffers.",
+        "__cuda_array_interface__ is only defined for GPU buffers.",
     ):
       _ = x.__cuda_array_interface__
 


### PR DESCRIPTION
ROCm GPUs also support __cuda_array_interface__ for interoperability hence adding this test to skip on ROCm platform. Also updated error message in the test.
## Test Result
with fix on ROCm test is skipped
```bash
root@3ec1777a72fc:/workspace/debug_session_MI300/rocm-jax/jax# pytest tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceOnNonCudaFails -v
Test session starting on GPU ?
============================================================= test session starts ==============================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.0', 'html': '4.1.1', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.150.0, html-4.1.1, metadata-3.1.1
collected 1 item                                                                                                                               

tests/array_interoperability_test.py::CudaArrayInterfaceTest::testCudaArrayInterfaceOnNonCudaFails SKIPPED (testCudaArrayInterfaceOn...) [100%]

============================================================== 1 skipped in 2.25s ==============================================================
```

Upstream PR: https://github.com/jax-ml/jax/pull/34662  ( I'll update this Open PR no need of new PR ).
