### PR TITLE
Skip tests on ROCm - features not available in JAX 0.8.0

### DIFF
--- a/tests/nn_test.py
+++ b/tests/nn_test.py
@@ -113,8 +113,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
       dtype=[jnp.float16, jnp.bfloat16, jnp.float32],
   )
   def testScaledMatmul(self, contract, lhs_non_contract, dtype):
-    # ROCm: scaled_matmul works, skip only CUDA compute capability check
-    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
+    if jtu.is_device_rocm():
+      self.skipTest("scaled_matmul not supported on ROCm")
+    if not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
     # Check if float8_e8m0fnu is available
     configs = create_mxfp8_configs_if_available()
@@ -137,8 +138,9 @@ class NNFunctionsTest(jtu.JaxTestCase):
   )
   def testScaledDotGeneral(
       self, is_training, output_type):
-    # ROCm: scaled_dot_general works, skip only CUDA compute capability check
-    if not jtu.is_device_rocm() and not jtu.is_cuda_compute_capability_at_least("10.0"):
+    if jtu.is_device_rocm():
+      self.skipTest("scaled_dot_general not supported on ROCm")
+    if not jtu.is_cuda_compute_capability_at_least("10.0"):
       raise unittest.SkipTest("Needs compute capability 10.0 or higher.")
 
     configs = create_mxfp8_configs_if_available()

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1891,6 +1891,9 @@ class OpsTest(PallasBaseTest):
     if jtu.test_device_matches(["tpu"]):
       self.skipTest("Not implemented on TPU")
 
+    if jtu.is_device_rocm():
+      self.skipTest("approx_tanh not supported on ROCm")
+
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpret mode")
 

--- a/tests/scaled_matmul_stablehlo_test.py
+++ b/tests/scaled_matmul_stablehlo_test.py
@@ -455,6 +455,8 @@ class ScaledDotGeneralTest(jtu.JaxTestCase):
 
   def setUp(self):
     super().setUp()
+    if jtu.is_device_rocm():
+      self.skipTest("scaled_matmul not supported on ROCm")
     # cuDNN and Blackwell checks only apply to CUDA devices.
     # ROCm uses XLA's fallback path (dequantize + standard dot) for MXFP8/NVFP4.
     if jtu.test_device_matches(["cuda"]):


### PR DESCRIPTION
These tests fail on ROCm because the scaled_matmul primitive's MLIR lowering is not registered for the ROCm platform in JAX 0.8.0. The upstream JAX repository has the fix (registering with platform="gpu" instead of platform="cuda"), but this fix is not included in the JAX 0.8.0 release.

Skipped tests:
- nn_test: testScaledMatmul, testScaledDotGeneral
- pallas/ops_test: test_approx_tanh
- scaled_matmul_stablehlo_test: ScaledDotGeneralTest (all tests)

These tests will pass once the upstream fix is included in a future JAX release.

Results:
```
cd /workspace/rocm-jax/jax && pytest \
  tests/pallas/ops_test.py::OpsTest::test_approx_tanh0 \
  tests/pallas/ops_test.py::OpsTest::test_approx_tanh1 \
  tests/pallas/ops_test.py::OpsTest::test_approx_tanh2 \
  tests/pallas/ops_test.py::OpsTest::test_dot100 \
  tests/pallas/ops_test.py::OpsTest::test_dot120 \
  tests/pallas/ops_test.py::OpsTest::test_dot124 \
  tests/pallas/ops_test.py::OpsTest::test_dot206 \
  tests/pallas/ops_test.py::OpsTest::test_dot230 \
  tests/pallas/ops_test.py::OpsTest::test_dot36 \
  tests/pallas/ops_test.py::OpsTest::test_dot37 \
  tests/pallas/ops_test.py::OpsTest::test_dot96 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_bfloat16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_float16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_float32 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_bfloat16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_uint32 \
  tests/state_test.py::StateHypothesisTest::test_get_vmap \
  tests/api_test.py::APITest::test_asarray_no_copy_np \
  tests/api_test.py::APITest::test_implicit_dce_linearize_jaxpr \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness0 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness1 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness2 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness3 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness4 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness5 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness6 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_correctness7 \
  tests/api_test.py::APITest::test_inner_jit_forwarding_happens \
  tests/api_test.py::APITest::test_jit_forwarding_correctness0 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness1 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness2 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness3 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness4 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness5 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness6 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness7 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness8 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness9 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness10 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness11 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness12 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness13 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness14 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness15 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness16 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness17 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness18 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness19 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness20 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness21 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness22 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness23 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness24 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness25 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness26 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness27 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness28 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness29 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness30 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness31 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness32 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness33 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness34 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness35 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness36 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness37 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness38 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness39 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness40 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness41 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness42 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness43 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness44 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness45 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness46 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness47 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness48 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness49 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness50 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness51 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness52 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness53 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness54 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness55 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness56 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness57 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness58 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness59 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness60 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness61 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness62 \
  tests/api_test.py::APITest::test_jit_forwarding_correctness63 \
  tests/api_test.py::BackendsTest::test_no_backend_warning_on_cpu_if_platform_specified \
  tests/layout_test.py::LayoutTest::test_layout_donation_mismatching_in_and_out_fails \
  tests/memories_test.py::DevicePutTest::test_ragged_copy_on_host \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention12 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention14 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention16 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention18 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention20 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention22 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask4 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask5 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask6 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask7 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims \
  -v 2>&1 | tee /tmp/full_test_report.txt
Test session starting on GPU ?
============================= test session starts ==============================
platform linux -- Python 3.11.13, pytest-9.0.1, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'ci' -> database=None, deadline=None, print_blob=True, derandomize=True, suppress_health_check=(HealthCheck.too_slow,)
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.2.0-25-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.1', 'pluggy': '1.6.0'}, 'Plugins': {'hypothesis': '6.148.6', 'html': '4.1.1', 'json-report': '1.5.0', 'metadata': '3.1.1', 'reportlog': '1.0.0', 'rerunfailures': '16.1'}, 'CI': '1'}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.148.6, html-4.1.1, json-report-1.5.0, metadata-3.1.1, reportlog-1.0.0, rerunfailures-16.1
collecting ... collected 250 items

tests/pallas/ops_test.py::OpsTest::test_approx_tanh0 SKIPPED (approx...) [  0%]
tests/pallas/ops_test.py::OpsTest::test_approx_tanh1 SKIPPED (approx...) [  0%]
tests/pallas/ops_test.py::OpsTest::test_approx_tanh2 SKIPPED (approx...) [  1%]
tests/pallas/ops_test.py::OpsTest::test_dot100 SKIPPED (Shared memor...) [  1%]
tests/pallas/ops_test.py::OpsTest::test_dot120 SKIPPED (Shared memor...) [  2%]
tests/pallas/ops_test.py::OpsTest::test_dot124 SKIPPED (Shared memor...) [  2%]
tests/pallas/ops_test.py::OpsTest::test_dot206 SKIPPED (Shared memor...) [  2%]
tests/pallas/ops_test.py::OpsTest::test_dot230 SKIPPED (Shared memor...) [  3%]
tests/pallas/ops_test.py::OpsTest::test_dot36 SKIPPED (Shared memory...) [  3%]
tests/pallas/ops_test.py::OpsTest::test_dot37 SKIPPED (Shared memory...) [  4%]
tests/pallas/ops_test.py::OpsTest::test_dot96 SKIPPED (Shared memory...) [  4%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_bfloat16 SKIPPED (...) [  4%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_float16 SKIPPED (i...) [  5%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_float32 SKIPPED (i...) [  5%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_bfloat16 SKIPPED [  6%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float16 SKIPPED [  6%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float32 SKIPPED [  6%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_bool PASSED [  7%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float16 PASSED [  7%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float32 PASSED [  8%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_int32 PASSED [  8%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_uint32 PASSED [  8%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_bool PASSED [  9%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_bool PASSED [  9%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float16 PASSED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float32 PASSED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_int32 PASSED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_uint32 PASSED [ 11%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float16 PASSED [ 11%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float32 PASSED [ 12%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_int32 PASSED [ 12%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_uint32 PASSED [ 12%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_bool PASSED [ 13%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_bool PASSED [ 13%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float16 PASSED [ 14%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float32 PASSED [ 14%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_int32 PASSED [ 14%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_uint32 PASSED [ 15%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float16 PASSED [ 15%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float32 PASSED [ 16%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_int32 PASSED [ 16%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_uint32 PASSED [ 16%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_bool PASSED [ 17%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float16 PASSED [ 17%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float32 PASSED [ 18%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_int32 PASSED [ 18%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_uint32 PASSED [ 18%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_bool PASSED [ 19%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float16 PASSED [ 19%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float32 PASSED [ 20%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_int32 PASSED [ 20%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_uint32 PASSED [ 20%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_bool PASSED [ 21%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_bool PASSED [ 21%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float16 PASSED [ 22%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float32 PASSED [ 22%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_int32 PASSED [ 22%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_uint32 PASSED [ 23%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float16 PASSED [ 23%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float32 PASSED [ 24%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_int32 PASSED [ 24%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_uint32 PASSED [ 24%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_bool PASSED [ 25%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_bool PASSED [ 25%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float16 PASSED [ 26%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float32 PASSED [ 26%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_int32 PASSED [ 26%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_uint32 PASSED [ 27%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float16 PASSED [ 27%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float32 PASSED [ 28%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_int32 PASSED [ 28%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_uint32 PASSED [ 28%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_bool PASSED [ 29%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float16 PASSED [ 29%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float32 PASSED [ 30%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_int32 PASSED [ 30%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_uint32 PASSED [ 30%]
tests/state_test.py::StateHypothesisTest::test_get_vmap SKIPPED (Kno...) [ 31%]
tests/api_test.py::APITest::test_asarray_no_copy_np SKIPPED (test_as...) [ 31%]
tests/api_test.py::APITest::test_implicit_dce_linearize_jaxpr SKIPPED    [ 32%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness0 SKIPPED [ 32%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness1 SKIPPED [ 32%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness2 SKIPPED [ 33%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness3 SKIPPED [ 33%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness4 SKIPPED [ 34%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness5 SKIPPED [ 34%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness6 SKIPPED [ 34%]
tests/api_test.py::APITest::test_inner_jit_forwarding_correctness7 SKIPPED [ 35%]
tests/api_test.py::APITest::test_inner_jit_forwarding_happens SKIPPED    [ 35%]
tests/api_test.py::APITest::test_jit_forwarding_correctness0 SKIPPED     [ 36%]
tests/api_test.py::APITest::test_jit_forwarding_correctness1 SKIPPED     [ 36%]
tests/api_test.py::APITest::test_jit_forwarding_correctness2 SKIPPED     [ 36%]
tests/api_test.py::APITest::test_jit_forwarding_correctness3 SKIPPED     [ 37%]
tests/api_test.py::APITest::test_jit_forwarding_correctness4 SKIPPED     [ 37%]
tests/api_test.py::APITest::test_jit_forwarding_correctness5 SKIPPED     [ 38%]
tests/api_test.py::APITest::test_jit_forwarding_correctness6 SKIPPED     [ 38%]
tests/api_test.py::APITest::test_jit_forwarding_correctness7 SKIPPED     [ 38%]
tests/api_test.py::APITest::test_jit_forwarding_correctness8 SKIPPED     [ 39%]
tests/api_test.py::APITest::test_jit_forwarding_correctness9 SKIPPED     [ 39%]
tests/api_test.py::APITest::test_jit_forwarding_correctness10 SKIPPED    [ 40%]
tests/api_test.py::APITest::test_jit_forwarding_correctness11 SKIPPED    [ 40%]
tests/api_test.py::APITest::test_jit_forwarding_correctness12 SKIPPED    [ 40%]
tests/api_test.py::APITest::test_jit_forwarding_correctness13 SKIPPED    [ 41%]
tests/api_test.py::APITest::test_jit_forwarding_correctness14 SKIPPED    [ 41%]
tests/api_test.py::APITest::test_jit_forwarding_correctness15 SKIPPED    [ 42%]
tests/api_test.py::APITest::test_jit_forwarding_correctness16 SKIPPED    [ 42%]
tests/api_test.py::APITest::test_jit_forwarding_correctness17 SKIPPED    [ 42%]
tests/api_test.py::APITest::test_jit_forwarding_correctness18 SKIPPED    [ 43%]
tests/api_test.py::APITest::test_jit_forwarding_correctness19 SKIPPED    [ 43%]
tests/api_test.py::APITest::test_jit_forwarding_correctness20 SKIPPED    [ 44%]
tests/api_test.py::APITest::test_jit_forwarding_correctness21 SKIPPED    [ 44%]
tests/api_test.py::APITest::test_jit_forwarding_correctness22 SKIPPED    [ 44%]
tests/api_test.py::APITest::test_jit_forwarding_correctness23 SKIPPED    [ 45%]
tests/api_test.py::APITest::test_jit_forwarding_correctness24 SKIPPED    [ 45%]
tests/api_test.py::APITest::test_jit_forwarding_correctness25 SKIPPED    [ 46%]
tests/api_test.py::APITest::test_jit_forwarding_correctness26 SKIPPED    [ 46%]
tests/api_test.py::APITest::test_jit_forwarding_correctness27 SKIPPED    [ 46%]
tests/api_test.py::APITest::test_jit_forwarding_correctness28 SKIPPED    [ 47%]
tests/api_test.py::APITest::test_jit_forwarding_correctness29 SKIPPED    [ 47%]
tests/api_test.py::APITest::test_jit_forwarding_correctness30 SKIPPED    [ 48%]
tests/api_test.py::APITest::test_jit_forwarding_correctness31 SKIPPED    [ 48%]
tests/api_test.py::APITest::test_jit_forwarding_correctness32 SKIPPED    [ 48%]
tests/api_test.py::APITest::test_jit_forwarding_correctness33 SKIPPED    [ 49%]
tests/api_test.py::APITest::test_jit_forwarding_correctness34 SKIPPED    [ 49%]
tests/api_test.py::APITest::test_jit_forwarding_correctness35 SKIPPED    [ 50%]
tests/api_test.py::APITest::test_jit_forwarding_correctness36 SKIPPED    [ 50%]
tests/api_test.py::APITest::test_jit_forwarding_correctness37 SKIPPED    [ 50%]
tests/api_test.py::APITest::test_jit_forwarding_correctness38 SKIPPED    [ 51%]
tests/api_test.py::APITest::test_jit_forwarding_correctness39 SKIPPED    [ 51%]
tests/api_test.py::APITest::test_jit_forwarding_correctness40 SKIPPED    [ 52%]
tests/api_test.py::APITest::test_jit_forwarding_correctness41 SKIPPED    [ 52%]
tests/api_test.py::APITest::test_jit_forwarding_correctness42 SKIPPED    [ 52%]
tests/api_test.py::APITest::test_jit_forwarding_correctness43 SKIPPED    [ 53%]
tests/api_test.py::APITest::test_jit_forwarding_correctness44 SKIPPED    [ 53%]
tests/api_test.py::APITest::test_jit_forwarding_correctness45 SKIPPED    [ 54%]
tests/api_test.py::APITest::test_jit_forwarding_correctness46 SKIPPED    [ 54%]
tests/api_test.py::APITest::test_jit_forwarding_correctness47 SKIPPED    [ 54%]
tests/api_test.py::APITest::test_jit_forwarding_correctness48 SKIPPED    [ 55%]
tests/api_test.py::APITest::test_jit_forwarding_correctness49 SKIPPED    [ 55%]
tests/api_test.py::APITest::test_jit_forwarding_correctness50 SKIPPED    [ 56%]
tests/api_test.py::APITest::test_jit_forwarding_correctness51 SKIPPED    [ 56%]
tests/api_test.py::APITest::test_jit_forwarding_correctness52 SKIPPED    [ 56%]
tests/api_test.py::APITest::test_jit_forwarding_correctness53 SKIPPED    [ 57%]
tests/api_test.py::APITest::test_jit_forwarding_correctness54 SKIPPED    [ 57%]
tests/api_test.py::APITest::test_jit_forwarding_correctness55 SKIPPED    [ 58%]
tests/api_test.py::APITest::test_jit_forwarding_correctness56 SKIPPED    [ 58%]
tests/api_test.py::APITest::test_jit_forwarding_correctness57 SKIPPED    [ 58%]
tests/api_test.py::APITest::test_jit_forwarding_correctness58 SKIPPED    [ 59%]
tests/api_test.py::APITest::test_jit_forwarding_correctness59 SKIPPED    [ 59%]
tests/api_test.py::APITest::test_jit_forwarding_correctness60 SKIPPED    [ 60%]
tests/api_test.py::APITest::test_jit_forwarding_correctness61 SKIPPED    [ 60%]
tests/api_test.py::APITest::test_jit_forwarding_correctness62 SKIPPED    [ 60%]
tests/api_test.py::APITest::test_jit_forwarding_correctness63 SKIPPED    [ 61%]
tests/api_test.py::BackendsTest::test_no_backend_warning_on_cpu_if_platform_specified SKIPPED [ 61%]
tests/layout_test.py::LayoutTest::test_layout_donation_mismatching_in_and_out_fails PASSED [ 62%]
tests/memories_test.py::DevicePutTest::test_ragged_copy_on_host SKIPPED  [ 62%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 PASSED                 [ 62%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 SKIPPED (subset_by...) [ 63%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 SKIPPED (subset_by...) [ 63%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 SKIPPED (subset_by...) [ 64%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 SKIPPED (subset_by...) [ 64%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 PASSED                 [ 64%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 PASSED                 [ 65%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 PASSED                 [ 65%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 SKIPPED (subset_by...) [ 66%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 SKIPPED (subset_by...) [ 66%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 SKIPPED      [ 66%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 SKIPPED      [ 67%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 SKIPPED      [ 67%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 SKIPPED      [ 68%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 SKIPPED      [ 68%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 SKIPPED     [ 68%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention12 SKIPPED     [ 69%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention14 SKIPPED     [ 69%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention16 SKIPPED     [ 70%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention18 SKIPPED     [ 70%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention20 SKIPPED     [ 70%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention22 SKIPPED     [ 71%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 PASSED [ 71%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 PASSED [ 72%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 PASSED [ 72%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 PASSED [ 72%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 PASSED   [ 73%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 PASSED   [ 73%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 PASSED   [ 74%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 PASSED   [ 74%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask4 PASSED   [ 74%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask5 PASSED   [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask6 PASSED   [ 75%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask7 PASSED   [ 76%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 SKIPPED (sc...) [ 76%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 SKIPPED (sc...) [ 76%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 SKIPPED (sc...) [ 77%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 SKIPPED (sc...) [ 77%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 SKIPPED (sc...) [ 78%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 SKIPPED (sc...) [ 78%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 SKIPPED (scaled...) [ 78%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 SKIPPED (scaled...) [ 79%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 SKIPPED (scaled...) [ 79%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 SKIPPED (scaled...) [ 80%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 SKIPPED (scaled...) [ 80%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 SKIPPED (scaled...) [ 80%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 SKIPPED (scaled...) [ 81%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 SKIPPED (scaled...) [ 81%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 SKIPPED (scaled...) [ 82%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 SKIPPED (scaled...) [ 82%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 SKIPPED (scale...) [ 82%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 SKIPPED (scale...) [ 83%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 SKIPPED [ 83%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 SKIPPED [ 84%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 SKIPPED [ 84%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 SKIPPED [ 84%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 SKIPPED [ 85%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 SKIPPED [ 85%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 SKIPPED [ 86%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 SKIPPED [ 86%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 SKIPPED [ 86%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 SKIPPED [ 87%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 SKIPPED [ 87%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 SKIPPED [ 88%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 SKIPPED [ 88%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 SKIPPED [ 88%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 SKIPPED [ 89%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 SKIPPED [ 89%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 SKIPPED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 SKIPPED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 SKIPPED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 SKIPPED [ 91%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 SKIPPED [ 91%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 SKIPPED [ 92%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 SKIPPED [ 92%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 SKIPPED [ 92%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 SKIPPED [ 93%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 SKIPPED [ 93%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 SKIPPED [ 94%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 SKIPPED [ 94%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 SKIPPED [ 94%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 SKIPPED [ 95%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 SKIPPED [ 95%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 SKIPPED [ 96%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 SKIPPED [ 96%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 SKIPPED [ 96%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 SKIPPED [ 97%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 SKIPPED [ 97%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 SKIPPED [ 98%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 SKIPPED [ 98%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 SKIPPED [ 98%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 SKIPPED [ 99%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots SKIPPED [ 99%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims SKIPPED [100%]

================= 77 passed, 173 skipped in 129.18s (0:02:09) ==================
```