### PR TITLE
Enable lax backend scipy tests on ROCm GPUs

### DIFF
--- a/tests/lax_scipy_sparse_test.py
+++ b/tests/lax_scipy_sparse_test.py
@@ -261,7 +261,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     preconditioner=[None, 'identity', 'exact'],
   )
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_bicgstab_on_identity_system(self, shape, dtype, preconditioner):
     A = jnp.eye(shape[1], dtype=dtype)
     solution = jnp.ones(shape[1], dtype=dtype)
@@ -280,7 +280,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     dtype=float_types + complex_types,
     preconditioner=[None, 'identity', 'exact'],
   )
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_bicgstab_on_random_system(self, shape, dtype, preconditioner):
     rng = jtu.rand_default(self.rng())
     A = rng(shape, dtype)
@@ -367,7 +367,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     preconditioner=[None, 'identity', 'exact'],
     solve_method=['batched', 'incremental'],
   )
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_gmres_on_identity_system(self, shape, dtype, preconditioner,
                                     solve_method):
     A = jnp.eye(shape[1], dtype=dtype)
@@ -391,7 +391,7 @@ class LaxBackedScipyTests(jtu.JaxTestCase):
     preconditioner=[None, 'identity', 'exact'],
     solve_method=['incremental', 'batched'],
   )
-  @jtu.skip_on_devices("gpu")
+  @jtu.skip_on_devices("cuda")
   def test_gmres_on_random_system(self, shape, dtype, preconditioner,
                                   solve_method):
     rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
Enable the following tests on ROCm platform by changing skip_on_devices("gpu") to skip_on_devices("cuda"):
- test_bicgstab_on_identity_system
- test_bicgstab_on_random_system
- test_gmres_on_identity_system
- test_gmres_on_random_system

These tests were previously skipped on all GPUs but are now supported on ROCm.

TestResults:
```bash
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system0 PASSED               [  2%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system1 PASSED               [  5%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system2 PASSED               [  7%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system3 PASSED               [ 10%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system4 PASSED               [ 12%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system5 PASSED               [ 15%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system6 PASSED               [ 17%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system7 PASSED               [ 20%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system8 PASSED               [ 22%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_identity_system9 PASSED               [ 25%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system0 PASSED                 [ 27%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system1 PASSED                 [ 30%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system2 PASSED                 [ 32%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system3 PASSED                 [ 35%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system4 PASSED                 [ 37%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system5 PASSED                 [ 40%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system6 PASSED                 [ 42%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system7 PASSED                 [ 45%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system8 PASSED                 [ 47%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_bicgstab_on_random_system9 PASSED                 [ 50%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system0 PASSED                  [ 52%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system1 PASSED                  [ 55%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system2 PASSED                  [ 57%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system3 PASSED                  [ 60%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system4 PASSED                  [ 62%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system5 PASSED                  [ 65%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system6 PASSED                  [ 67%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system7 PASSED                  [ 70%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system8 PASSED                  [ 72%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_identity_system9 PASSED                  [ 75%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system0 PASSED                    [ 77%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system1 PASSED                    [ 80%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system2 PASSED                    [ 82%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system3 PASSED                    [ 85%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system4 PASSED                    [ 87%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system5 PASSED                    [ 90%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system6 PASSED                    [ 92%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system7 PASSED                    [ 95%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system8 PASSED                    [ 97%]
tests/lax_scipy_sparse_test.py::LaxBackedScipyTests::test_gmres_on_random_system9 PASSED                    [100%]

======================================= 40 passed, 51 deselected in 13.99s ========================================
```
Upstream PR: https://github.com/jax-ml/jax/pull/34802
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->