### PR TITLE
Abort detection CI workflow

### DIFF
--- a/.github/workflows/pytest_rocm_abort.yml
+++ b/.github/workflows/pytest_rocm_abort.yml
@@ -1,0 +1,162 @@
+# CI - Pytest ROCm (Abort Support)
+#
+# This workflow runs the ROCm tests with Pytest in ROCm GHCR containers,
+# using the ROCm `pytest-abort` retry wrapper to detect/retry aborts/crashes.
+#
+# It can be triggered manually via workflow_dispatch or called by other workflows
+# via workflow_call.
+#
+# It consists of the following job:
+# run-tests:
+#    - Runs in ROCm container (ghcr.io/rocm/jax-base-ubu24-rocm*:latest)
+#    - Downloads the JAX and jaxlib wheels from GCS, and ROCm plugins from latest release.
+#    - Executes the `run_pytest_rocm_abort.sh` script, which installs wheel artifacts and
+#      runs the ROCm tests with Pytest under `pytest-abort-retry`.
+name: CI - Pytest ROCm (Abort Support)
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Which runner should the workflow run on?"
+        type: choice
+        default: "linux-x86-64-4gpu-amd"
+        options:
+          - "linux-x86-64-1gpu-amd"
+          - "linux-x86-64-4gpu-amd"
+          - "linux-x86-64-8gpu-amd"
+      python:
+        description: "Which Python version to use?"
+        type: choice
+        default: "3.11"
+        options:
+          - "3.11"
+          - "3.12"
+      rocm-version:
+        description: "Which ROCm version to test?"
+        type: choice
+        default: "7.2.0"
+        options:
+          - "7.2.0"
+      rocm-tag:
+        description: "ROCm tag for container image (e.g., rocm720)"
+        type: string
+        default: "rocm720"
+      jaxlib-version:
+        description: "Which jaxlib version to use? (head/pypi_latest)"
+        type: choice
+        default: "head"
+        options:
+          - "head"
+          - "pypi_latest"
+      skip-download-jaxlib-and-plugins-from-gcs:
+        description: "Whether to skip downloading the jaxlib and plugins from GCS (e.g for testing a jax only release)"
+        type: choice
+        default: '0'
+        options:
+          - '0'
+          - '1'
+      gcs_download_uri:
+        description: "GCS location prefix from where the artifacts should be downloaded"
+        type: string
+        default: 'gs://jax-nightly-artifacts/latest'
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection?'
+        type: string
+        default: 'no'
+  workflow_call:
+    inputs:
+      runner:
+        description: "Which runner should the workflow run on?"
+        type: string
+        default: "linux-x86-64-4gpu-amd"
+      python:
+        description: "Which Python version to use?"
+        type: string
+        default: "3.11"
+      rocm-version:
+        description: "Which ROCm version to test?"
+        type: string
+        default: "7.2.0"
+      rocm-tag:
+        description: "ROCm tag for container image (e.g., rocm720)"
+        type: string
+        default: "rocm720"
+      jaxlib-version:
+        description: "Which jaxlib version to use? (head/pypi_latest)"
+        type: string
+        default: "head"
+      skip-download-jaxlib-and-plugins-from-gcs:
+        description: "Whether to skip downloading the jaxlib and plugins from GCS (e.g for testing a jax only release)"
+        default: '0'
+        type: string
+      gcs_download_uri:
+        description: "GCS location prefix from where the artifacts should be downloaded"
+        default: 'gs://jax-nightly-artifacts/latest'
+        type: string
+
+permissions: {}
+
+env:
+  UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+
+jobs:
+  run-tests:
+    defaults:
+      run:
+        # Set the shell to bash as GitHub actions run with /bin/sh by default
+        shell: bash
+    runs-on: ${{ inputs.runner }}
+    continue-on-error: true
+    # Run in ROCm GHCR container with GPU access
+    container:
+      image: ghcr.io/rocm/jax-base-ubu24.${{ inputs.rocm-tag }}:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+    name: "${{ (contains(inputs.runner, '1gpu') && '1gpu') ||
+        (contains(inputs.runner, '4gpu') && '4gpu') ||
+        (contains(inputs.runner, '8gpu') && '8gpu') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"
+
+    env:
+      JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
+      JAXCI_PYTHON: "python${{ inputs.python }}"
+      JAXCI_ENABLE_X64: "0"
+
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
+      - name: Download JAX ROCm wheels
+        uses: ./.github/actions/download-jax-rocm-wheels
+        with:
+          python: ${{ inputs.python }}
+          rocm-version: ${{ inputs.rocm-version }}
+          jaxlib-version: ${{ inputs.jaxlib-version }}
+          skip-download-jaxlib-and-plugins-from-gcs: ${{ inputs.skip-download-jaxlib-and-plugins-from-gcs }}
+          gcs_download_uri: ${{ inputs.gcs_download_uri }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Python dependencies
+        run: |
+          $JAXCI_PYTHON -m pip install uv~=0.5.30
+          $JAXCI_PYTHON -m uv pip install -r build/test-requirements.txt
+      # Halt for testing
+      - name: Wait For Connection
+        uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c
+        with:
+          halt-dispatch-input: ${{ inputs.halt-for-connection }}
+      - name: Run Pytest ROCm tests (abort support)
+        timeout-minutes: 180
+        run: ./ci/run_pytest_rocm_abort.sh
+      - name: Upload pytest results to artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: logs_abort
+          path: |
+            logs_abort/
+          if-no-files-found: warn
+          retention-days: 2
+          overwrite: true

--- a/.github/workflows/wheel_tests_nightly_release_abort.yml
+++ b/.github/workflows/wheel_tests_nightly_release_abort.yml
@@ -1,0 +1,53 @@
+# CI - Wheel Tests (Nightly/Release) (ROCm abort only)
+#
+# This workflow runs only the ROCm wheel tests using the abort/retry wrapper workflow.
+name: CI - Wheel Tests (Nightly/Release) (ROCm abort only)
+
+on:
+  workflow_dispatch:
+    inputs:
+      gcs_download_uri:
+        description: "GCS location URI from where the artifacts should be downloaded"
+        required: true
+        default: 'gs://jax-nightly-artifacts/latest'
+        type: string
+      skip-download-jaxlib-and-plugins-from-gcs:
+        description: "Whether to download only the jax wheel from GCS (e.g for testing a jax only release)"
+        required: true
+        default: '0'
+        type: string
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection? (yes/no)'
+        required: false
+        default: 'no'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+permissions: {}
+
+env:
+  UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+
+jobs:
+  run-pytest-rocm:
+    uses: ./.github/workflows/pytest_rocm_abort.yml
+    strategy:
+        fail-fast: false # don't cancel all jobs on failure
+        matrix:
+          runner: ["linux-x86-64-1gpu-amd", "linux-x86-64-4gpu-amd", "linux-x86-64-8gpu-amd"]
+          python: ["3.11", "3.12", "3.13", "3.14"]
+          rocm: [
+            {version: "7.2.0", tag: "rocm720"},
+          ]
+    name: "Pytest ROCm abort (JAX artifacts version = ${{ startsWith(github.ref_name, 'release/') && 'latest release' || 'nightly' }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      jaxlib-version: "head"
+      skip-download-jaxlib-and-plugins-from-gcs: ${{inputs.skip-download-jaxlib-and-plugins-from-gcs}}
+      gcs_download_uri: ${{inputs.gcs_download_uri}}
+      halt-for-connection: ${{inputs.halt-for-connection}}

--- a/ci/run_pytest_rocm_abort.sh
+++ b/ci/run_pytest_rocm_abort.sh
@@ -97,7 +97,6 @@ fi
 
 echo "Final number of processes to run: $num_processes"
 
-export JAX_ENABLE_CUDA_XDIST="$gpu_count"
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="

--- a/ci/run_pytest_rocm_abort.sh
+++ b/ci/run_pytest_rocm_abort.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+# Copyright 2024 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Runs Pytest ROCm tests (with ROCm pytest-abort retry wrapper).
+# Requires the jaxlib and ROCm plugin wheels to be present inside $JAXCI_OUTPUT_DIR (../dist)
+#
+# -e: abort script if one command fails
+# -u: error if undefined variable used
+# -x: log all commands
+# -o history: record shell history
+# -o allexport: export all functions and variables to be available to subscripts
+set -exu -o history -o allexport
+
+source ci/envs/default.env
+
+# Install jaxlib and ROCm plugin wheels inside the $JAXCI_OUTPUT_DIR directory
+echo "Installing wheels locally..."
+source ./ci/utilities/install_wheels_locally.sh
+
+# Print all the installed packages
+echo "Installed packages:"
+"$JAXCI_PYTHON" -m uv pip freeze
+
+"$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
+
+rocm-smi
+
+# ==============================================================================
+# Set up the generic test environment variables
+# ==============================================================================
+export PY_COLORS=1
+export JAX_SKIP_SLOW_TESTS=true
+export NCCL_DEBUG=WARN
+export TF_CPP_MIN_LOG_LEVEL=0
+export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+
+# ==============================================================================
+# Calculate the optimal number of parallel processes for pytest
+# This will be the minimum of: GPU capacity, CPU core count, and a system RAM limit.
+# ==============================================================================
+
+export gpu_count=$(rocminfo | egrep -c "Device Type:\\s+GPU")
+echo "Number of GPUs detected: $gpu_count"
+
+# Query GPU 0 memory using rocm-smi
+export memory_per_gpu_mib=$(rocm-smi -d 0 --showmeminfo vram | grep -i "vram total" | awk '{print int($NF/1024/1024)}' | head -1)
+echo "Reported memory per GPU: $memory_per_gpu_mib MiB"
+
+# Convert effective memory from MiB to GiB.
+export memory_per_gpu_gib=$((memory_per_gpu_mib / 1024))
+echo "Effective memory per GPU: $memory_per_gpu_gib GiB"
+
+# Allow 2 GiB of GPU RAM per test.
+export max_tests_per_gpu=$((memory_per_gpu_gib / 2))
+echo "Max tests per GPU (assuming 2GiB/test): $max_tests_per_gpu"
+
+export num_processes=$((gpu_count * max_tests_per_gpu))
+echo "Initial number of processes based on GPU capacity: $num_processes"
+
+export num_cpu_cores=$(nproc)
+echo "Number of CPU cores available: $num_cpu_cores"
+
+# Reads total memory from /proc/meminfo (in KiB) and converts to GiB.
+export total_ram_gib=$(awk '/MemTotal/ {printf \"%.0f\", $2/1048576}' /proc/meminfo)
+echo "Total system RAM: $total_ram_gib GiB"
+
+# Set a safety limit for system RAM usage, e.g., 1/6th of total.
+export host_memory_limit=$((total_ram_gib / 6))
+echo "Host memory process limit (1/6th of total RAM): $host_memory_limit"
+
+if [[ $num_cpu_cores -lt $num_processes ]]; then
+  num_processes=$num_cpu_cores
+  echo "Adjusting num_processes to match CPU core count: $num_processes"
+fi
+
+if [[ $host_memory_limit -lt $num_processes ]]; then
+  num_processes=$host_memory_limit
+  echo "Adjusting num_processes to match host memory limit: $num_processes"
+fi
+
+if [[ 16 -lt $num_processes ]]; then
+  num_processes=16
+  echo "Reducing num_processes to $num_processes"
+fi
+
+echo "Final number of processes to run: $num_processes"
+
+export JAX_ENABLE_CUDA_XDIST="$gpu_count"
+export JAX_ENABLE_ROCM_XDIST="$gpu_count"
+export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
+
+# Disable core dumps just in case
+ulimit -c 0
+
+# Keep deselected tests in one place for the abort wrapper.
+ROCM_PYTEST_DESELECT_ARGS=(
+  --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data
+  --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices
+  --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric
+)
+
+# --max-runs: retry the entire pytest run up to N times on abort/crash.
+# --max-worker-restart: restart crashed xdist workers up to N times.
+# --maxfail: stop the run after N test failures.
+rocm_test_cmd() {
+  local abort_flag="${1:-0}"
+  shift
+  if [[ "$abort_flag" == "1" ]]; then
+    pytest-abort-retry --max-runs 3 --clear-crash-log -- "$@"
+  else
+    "$@"
+  fi
+}
+
+rocm_log_tail_on_failure() {
+  local logfile="$1"
+  local status="$2"
+  if [[ "$status" -ne 0 ]]; then
+    echo "Pytest failed (exit=$status). Showing last 200 lines of $logfile:"
+    tail -n 200 "$logfile" || true
+  else
+    echo "Pytest output saved to $logfile (uploaded as artifact)."
+  fi
+}
+
+rocm_install_extra_requirements() {
+  if [[ -n "${GITHUB_WORKSPACE:-}" ]]; then
+    cd "$GITHUB_WORKSPACE"
+  fi
+
+  # Install extra requirements.
+  "$JAXCI_PYTHON" -m uv pip install pytest-timeout pytest-html pytest-csv pytest-json-report pytest-abort
+}
+
+rocm_install_extra_requirements
+
+echo "Running ROCm tests (with abort/retry wrapper)..."
+mkdir -p logs_abort
+logfile="logs_abort/jax_ToT_UT_abort.log"
+
+# pytest-abort output directories (must be set before running pytest).
+export PYTEST_ABORT_LAST_RUNNING_DIR="logs_abort/last_running"
+export PYTEST_ABORT_CRASHED_TESTS_LOG="logs_abort/crashed_tests.jsonl"
+mkdir -p "$PYTEST_ABORT_LAST_RUNNING_DIR"
+
+set +e
+rocm_test_cmd 1 "$JAXCI_PYTHON" -m pytest -n "$num_processes" --max-worker-restart=200 --tb=short --timeout=1200 --timeout-method=thread tests \
+  "${ROCM_PYTEST_DESELECT_ARGS[@]}" \
+  --json-report \
+  --json-report-file=logs_abort/tests-report-abort.json \
+  --csv=logs_abort/tests-report-abort.csv \
+  --html=logs_abort/tests-report-abort.html \
+  --self-contained-html \
+  >"$logfile" 2>&1
+pytest_status=$?
+set -e
+rocm_log_tail_on_failure "$logfile" "$pytest_status"
+
+echo "Postprocessing reports with crashed tests..."
+pytest-abort-postprocess \
+  --crash-log "$PYTEST_ABORT_CRASHED_TESTS_LOG" \
+  --json-report logs_abort/tests-report-abort.json \
+  --html-report logs_abort/tests-report-abort.html \
+  --csv-report logs_abort/tests-report-abort.csv \
+  >>"$logfile" 2>&1
+
+exit "$pytest_status"

--- a/conftest.py
+++ b/conftest.py
@@ -15,10 +15,6 @@
 
 import os
 import pytest
-import json
-import threading
-import shutil
-from datetime import datetime
 
 @pytest.fixture(autouse=True)
 def add_imports(doctest_namespace):
@@ -76,174 +72,69 @@ def pytest_collection() -> None:
         "CUDA_VISIBLE_DEVICES", str(xdist_worker_number % num_cuda_devices)
     )
 
-class ThreadSafeTestLogger:
-    """Thread-safe logging for parallel test execution and abort detection"""
-    def __init__(self):
-        self.locks = {}
-        self.global_lock = threading.Lock()
-        self.base_dir = os.path.abspath("./logs")
-        
-        # Create logs directory (archiving is handled by test runner scripts)
-        try:
-            os.makedirs(self.base_dir, exist_ok=True)
-            print(f"[TestLogger] Initialized log directory: {self.base_dir}")
-        except Exception as e:
-            print(f"[TestLogger] ERROR: Failed to create log directory {self.base_dir}: {e}")
-            # Fallback to temp directory if logs dir creation fails
-            import tempfile
-            self.base_dir = os.path.join(tempfile.gettempdir(), "jax_test_logs")
-            os.makedirs(self.base_dir, exist_ok=True)
-            print(f"[TestLogger] Using fallback directory: {self.base_dir}")
+  elif num_rocm_devices := os.environ.get("JAX_ENABLE_ROCM_XDIST", None):
+    num_rocm_devices = int(num_rocm_devices)
+    xdist_worker_name = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if not xdist_worker_name.startswith("gw"):
+      return
+    xdist_worker_number = int(xdist_worker_name[len("gw") :])
+    assigned = str(xdist_worker_number % num_rocm_devices)
 
-    def get_file_lock(self, test_file):
-        """Get or create a lock for a specific test file"""
-        with self.global_lock:
-            if test_file not in self.locks:
-                self.locks[test_file] = threading.Lock()
-            return self.locks[test_file]
+    # If ROCR_VISIBLE_DEVICES is set, don't also set HIP_VISIBLE_DEVICES
+    # (double-filtering can produce HIP_ERROR_NoDevice). Respect the outer setting.
+    if os.environ.get("ROCR_VISIBLE_DEVICES"):
+      return
 
-    def get_test_file_name(self, session):
-        """Extract the test file name from the session"""
-        # Try to get from session config args
-        if hasattr(session, "config") and hasattr(session.config, "args"):
-            for arg in session.config.args:
-                # Handle full nodeid like "jax/tests/foo_test.py::TestClass::test_method"
-                if "tests/" in arg:
-                    # Split on :: to get just the file path
-                    file_path = arg.split("::")[0]
-                    if file_path.endswith(".py"):
-                        return os.path.basename(file_path).replace(".py", "")
-        
-        # Try to get from invocation params
-        if hasattr(session, "config") and hasattr(session.config, "invocation_params"):
-            invocation_dir = getattr(session.config.invocation_params, "dir", None)
-            if invocation_dir:
-                dir_name = os.path.basename(str(invocation_dir))
-                if dir_name:
-                    print(f"[TestLogger] Using invocation directory as test name: {dir_name}")
-                    return dir_name
-        
-        # Last resort: try to get from session items
-        if hasattr(session, "items") and session.items:
-            first_item = session.items[0]
-            if hasattr(first_item, "fspath"):
-                fspath = str(first_item.fspath)
-                if ".py" in fspath:
-                    return os.path.basename(fspath).replace(".py", "")
-        
-        print(f"[TestLogger] WARNING: Could not determine test file name, using 'unknown_test'")
-        print(f"[TestLogger] Session config args: {getattr(session.config, 'args', 'N/A')}")
-        return "unknown_test"
+    # If present-but-empty, this can hide all GPUs.
+    if os.environ.get("HIP_VISIBLE_DEVICES", None) == "":
+      del os.environ["HIP_VISIBLE_DEVICES"]
 
-    def log_running_test(self, test_file, test_name, nodeid, start_time):
-        """Log the currently running test for abort detection"""
-        lock = self.get_file_lock(test_file)
-        with lock:
-            log_data = {
-                "test_file": test_file,
-                "test_name": test_name,
-                "nodeid": nodeid,
-                "start_time": start_time,
-                "status": "running",
-                "pid": os.getpid(),
-                "gpu_id": os.environ.get("HIP_VISIBLE_DEVICES", "unknown"),
-            }
+    # HIP layer isolation (ROCm also accepts CUDA_VISIBLE_DEVICES, but we avoid it here).
+    os.environ["HIP_VISIBLE_DEVICES"] = assigned
 
-            log_file = f"{self.base_dir}/{test_file}_last_running.json"
-            try:
-                # Ensure directory still exists (might have been deleted)
-                os.makedirs(self.base_dir, exist_ok=True)
-                with open(log_file, "w") as f:
-                    json.dump(log_data, f, indent=2)
-            except Exception as e:
-                print(f"[TestLogger] ERROR: Failed to write running test log to {log_file}: {e}")
-                print(f"[TestLogger] Current working directory: {os.getcwd()}")
-                print(f"[TestLogger] Base directory: {self.base_dir}")
-                print(f"[TestLogger] Base directory exists: {os.path.exists(self.base_dir)}")
-                raise
+def pytest_configure(config) -> None:
+  # Real pytest hook (runs early in main + each xdist worker).
+  xdist_worker_name = os.environ.get("PYTEST_XDIST_WORKER", "") or "main"
 
-    def clear_running_test(self, test_file):
-        """Clear the running test log when test completes successfully"""
-        lock = self.get_file_lock(test_file)
-        with lock:
-            log_file = f"{self.base_dir}/{test_file}_last_running.json"
-            if os.path.exists(log_file):
-                os.remove(log_file)
+  # xdist master: print planned mapping (worker stdout is often hidden)
+  numproc = int(getattr(getattr(config, "option", None), "numprocesses", 0) or 0)
+  if xdist_worker_name == "main" and numproc > 0:
+    hip0 = (os.environ.get("HIP_VISIBLE_DEVICES") or "").strip()
+    cuda_x = (os.environ.get("JAX_ENABLE_CUDA_XDIST") or "").strip()
+    tpu_x = (os.environ.get("JAX_ENABLE_TPU_XDIST") or "").strip()
+    rocm_x = (os.environ.get("JAX_ENABLE_ROCM_XDIST") or "").strip()
+    if cuda_x:
+      try:
+        ndev = int(cuda_x)
+      except ValueError:
+        ndev = 0
+      if ndev > 0:
+        mapping = ", ".join(f"gw{i}->CUDA_VISIBLE_DEVICES={i % ndev}" for i in range(numproc))
+        print(f"[DeviceVisibility] xdist planned mapping: {mapping}", flush=True)
+    elif tpu_x:
+      mapping = ", ".join(f"gw{i}->TPU_VISIBLE_CHIPS={i}" for i in range(numproc))
+      print(f"[DeviceVisibility] xdist planned mapping: {mapping}", flush=True)
+    elif rocm_x:
+      try:
+        ndev = int(rocm_x)
+      except ValueError:
+        ndev = 0
+      if ndev > 0:
+        mapping = ", ".join(f"gw{i}->HIP_VISIBLE_DEVICES={i % ndev}" for i in range(numproc))
+        print(f"[DeviceVisibility] xdist planned mapping: {mapping}", flush=True)
+    elif hip0:
+      print(f"[DeviceVisibility] master HIP_VISIBLE_DEVICES={hip0}", flush=True)
 
+  if os.environ.get("JAX_ENABLE_TPU_XDIST", None):
+    if xdist_worker_name.startswith("gw"):
+      xdist_worker_number = int(xdist_worker_name[len("gw") :])
+      os.environ.setdefault("TPU_VISIBLE_CHIPS", str(xdist_worker_number))
+      os.environ.setdefault("ALLOW_MULTIPLE_LIBTPU_LOAD", "true")
 
-# Global logger instance
-test_logger = ThreadSafeTestLogger()
-
-
-@pytest.hookimpl(hookwrapper=True)
-def pytest_runtest_protocol(item, nextitem):
-    """Hook that wraps around each test to track running tests for crash detection.
-    
-    This creates a "last_running" file before each test starts and deletes it
-    when the test completes successfully. If the test crashes, the file remains
-    and can be detected by the test runner.
-    """
-    test_file = test_logger.get_test_file_name(item.session)
-    test_name = item.name
-    nodeid = item.nodeid
-    start_time = datetime.now().isoformat()
-
-    # Log that this test is starting
-    try:
-        test_logger.log_running_test(test_file, test_name, nodeid, start_time)
-    except Exception as e:
-        print(f"[TestLogger] WARNING: Failed to log running test: {e}")
-        # Continue anyway - not critical for test execution
-
-    test_completed = False
-    try:
-        outcome = yield
-        # Test completed (successfully or with normal failure)
-        test_completed = True
-        
-        # Clear the crash detection file
-        try:
-            test_logger.clear_running_test(test_file)
-        except Exception as e:
-            print(f"[TestLogger] WARNING: Failed to clear running test log: {e}")
-            
-    except Exception as e:
-        # Test raised exception (might be crash, might be normal exception)
-        print(f"[TestLogger] Test {test_name} exception: {e}")
-        if not test_completed:
-            # Don't clear the file - this might be a crash
-            print(f"[TestLogger] Leaving crash file for detection")
-        raise
-
-
-@pytest.hookimpl(tryfirst=True)
-def pytest_sessionstart(session):
-    """Called after the Session object has been created"""
-    gpu = os.environ.get('HIP_VISIBLE_DEVICES', '?')
-    print(f"Test session starting on GPU {gpu}")
-
-
-@pytest.hookimpl(trylast=True)
-def pytest_sessionfinish(session, exitstatus):
-    """Called after test run finished.
-    
-    If a crash file still exists, it means a test crashed and the runner
-    will detect it. We just report it here for visibility.
-    """
-    test_file = test_logger.get_test_file_name(session)
-    log_file = f"{test_logger.base_dir}/{test_file}_last_running.json"
-    
-    if os.path.exists(log_file):
-        try:
-            with open(log_file, "r") as f:
-                abort_data = json.load(f)
-            print(
-                f"\n[CRASH DETECTED] {abort_data.get('nodeid', abort_data.get('test_name', 'unknown'))} "
-                f"(GPU: {abort_data.get('gpu_id', '?')}, PID: {abort_data.get('pid', '?')})"
-            )
-            print(f"[CRASH DETECTED] Crash file will be processed by test runner")
-        except Exception as e:
-            print(f"[TestLogger] WARNING: Crash file exists but unreadable: {e}")
-    else:
-        # Normal completion - no crash
-        pass
+  elif num_cuda_devices := os.environ.get("JAX_ENABLE_CUDA_XDIST", None):
+    if xdist_worker_name.startswith("gw"):
+      num_cuda_devices = int(num_cuda_devices)
+      xdist_worker_number = int(xdist_worker_name[len("gw") :])
+      os.environ.setdefault(
+          "CUDA_VISIBLE_DEVICES", str(xdist_worker_number % num_cuda_devices)
+      )


### PR DESCRIPTION
## ROCm CI: add abort-only ROCm workflows for pytest-abort

- Adds a ROCm abort/retry pytest runner script ci/run_pytest_rocm_abort.sh that installs ROCm’s pytest-abort tooling, sets PYTEST_ABORT_* directories, runs pytest via pytest-abort-retry, and postprocesses JSON/HTML/CSV reports to include crashed tests.
- Introduces two new abort-only workflows:
.github/workflows/pytest_rocm_abort.yml: same inputs as pytest_rocm.yml but always runs ./ci/run_pytest_rocm_abort.sh and uploads logs_abort/
.github/workflows/wheel_tests_nightly_release_abort.yml: ROCm-abort-only entrypoint that calls pytest_rocm_abort.yml (no CPU/CUDA/TPU jobs)

## Test Plan

- Trigger .github/workflows/pytest_rocm_abort.yml manually and confirm it:
runs ./ci/run_pytest_rocm_abort.sh
creates logs_abort/last_running/, logs_abort/crashed_tests.jsonl, and logs_abort/tests-report-abort.{json,html,csv}
uploads logs_abort/ as workflow artifacts
- Trigger .github/workflows/wheel_tests_nightly_release_abort.yml and confirm it only runs the ROCm abort job and calls pytest_rocm_abort.yml.
