### PR TITLE
Remove 'mean' from unsupported params for jnp.var

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6329,7 +6329,6 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'stack': ['casting'],
       'tri': ['like'],
       'unravel_index': ['order'],
-      'var': ['mean'],
       'vstack': ['casting'],
       'zeros': ['order', 'like'],
       'zeros_like': ['subok', 'order']


### PR DESCRIPTION
jnp.var now supports the 'mean' parameter, so it should no longer be listed in unsupported_params in testWrappedSignaturesMatch. This issue seems to originate due to merge artifact. this was mostly leftover fluff.

Test Results:
Below is my test result with the fix

```bash
root@181fc0e37fc6:/workspace/debug_session_MI300/rocm-jax/jax# pytest tests/lax_numpy_test.py::NumpySignaturesTest::testWrappedSignaturesMatch
Test session starting on GPU ?
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.151.5, html-4.2.0, metadata-3.1.1
collected 1 item                                                                                                                                                                                

tests/lax_numpy_test.py .                                                                                                                                                                 [100%]

======================================================================================= 1 passed in 1.86s =======================================================================================
```
No need to upstream, it already has that fix 
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->