### PR TITLE
Enable memory space export tests on ROCm GPUs

### DIFF
--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1454,7 +1454,7 @@ class JaxExportTest(jtu.JaxTestCase):
     a = jax.device_put(np.ones((2, 3), dtype=np.float32), shd)
     f = jax.jit(lambda x: x)
 
-    exported = get_exported(f, platforms=("tpu", "cuda"))(a)
+    exported = get_exported(f, platforms=("tpu", "cuda", "rocm"))(a)
     self.assertEqual(exported.in_avals[0].memory_space, core.MemorySpace.Host)
     self.assertEqual(exported.out_avals[0].memory_space, core.MemorySpace.Host)
 
@@ -1483,7 +1483,7 @@ class JaxExportTest(jtu.JaxTestCase):
     f = jax.jit(lambda: jnp.ones((2, 2), dtype=np.float32),
                 out_shardings=shd)
 
-    exported = get_exported(f, platforms=("tpu", "cuda"))()
+    exported = get_exported(f, platforms=("tpu", "cuda", "rocm"))()
     self.assertEqual(exported.out_avals[0].memory_space, core.MemorySpace.Host)
     empty_mesh = jax.sharding.AbstractMesh((), ())
     shd_ns = jax.sharding.NamedSharding(empty_mesh, P(None, None),


### PR DESCRIPTION
Add 'rocm' to the platforms list in test_memory_space_from_arg and test_memory_space_from_out_shardings to enable these tests on ROCm GPUs.

Test result:
Below is my test results with the fix:
```bash
root@181fc0e37fc6:/workspace/debug_session_MI300/rocm-jax/jax# pytest tests/export_test.py::JaxExportTest -k "test_memory_space_from" -v
Test session starting on GPU ?
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.8.0-87-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'json-report': '1.5.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'hypothesis': '6.151.5', 'html': '4.2.0', 'metadata': '3.1.1'}}
rootdir: /workspace/debug_session_MI300/rocm-jax/jax
configfile: pyproject.toml
plugins: json-report-1.5.0, rerunfailures-16.1, reportlog-1.0.0, hypothesis-6.151.5, html-4.2.0, metadata-3.1.1
collected 166 items / 164 deselected / 2 selected                                                                                                                                               

tests/export_test.py::JaxExportTest::test_memory_space_from_arg PASSED                                                                                                                    [ 50%]
tests/export_test.py::JaxExportTest::test_memory_space_from_out_shardings PASSED                                                                                                          [100%]

=============================================================================== 2 passed, 164 deselected in 2.19s ===============================================================================
```
Upstream PR: https://github.com/jax-ml/jax/pull/34890
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->