### PR TITLE
Skip testEighTinyNorm test 0.8.2

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -569,8 +569,11 @@ class NumpyLinalgTest(jtu.JaxTestCase):
       self.assertLessEqual(
           np.linalg.norm(np.matmul(a, v) - w * v), 2.5 * eps * np.linalg.norm(a)
       )
-
   def testEighTinyNorm(self):
+    if jtu.is_device_rocm():
+      # numerical errors seen as of ROCm 7.2 due to hipSolver issue
+      # TODO: re-enable the test once the hipSolver issue is fixed
+      self.skipTest("testEighTinyNorm not supported on ROCm due to hipSOLVER issue")
     rng = jtu.rand_default(self.rng())
     a = rng((300, 300), dtype=np.float32)
     eps = jnp.finfo(a.dtype).eps


### PR DESCRIPTION
 ## Motivation
The testEighTinyNorm test fails on ROCm devices due to numerical precision issues in the underlying hipSolver https://ontrack-internal.amd.com/browse/SWDEV-578349

### Technical Details
Added @jtu.skip_on_devices("rocm") decorator to skip testEighTinyNorm  in `tests/linalg_test.py

### Test Result
<img width="1596" height="450" alt="image" src="https://github.com/user-attachments/assets/775611f3-05f7-4b02-b9fe-4e2f5ebd7dfc" />

Upstream - https://github.com/jax-ml/jax/pull/34902

Submission Checklist
Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
