### PR TITLE
Modified memory space export test to run on ROCm (for some tests).

### DIFF
--- a/tests/export_serialization_back_compat_test.py
+++ b/tests/export_serialization_back_compat_test.py
@@ -190,8 +190,19 @@ class CompatTest(jtu.JaxTestCase):
 
       if testdata is None:
         serialized = self.export_and_serialize(
-            f, a, platforms=("tpu", "cuda"))
+            f, a, platforms=("tpu", "cuda", "rocm"))
       else:
+        # The testdata for the serialization formats has been generated and
+        # is awaiting review and merging upstream. It is not included
+        # downstream to avoid import errors. For this reason, the downstream
+        # version of this test is currently skipped.
+        #
+        # TODO: Remove this skip once the testdata and modified unit test
+        # are merged upstream.
+        if jtu.is_device_rocm():
+          self.skipTest("Serialized export testdata for serialization format "
+                        f"{testdata['serialization_version']} is not "
+                        "currently available for ROCm.")
         serialized = testdata["exported_serialized"]
 
     exported = _export.deserialize(serialized)


### PR DESCRIPTION
## Motivation
The unit test `test_with_memory_space` checks that the exported serialization of memory space information works properly across serialization formats. Support for testing ROCm devices has been partially added to this unit test. On current serialization formats, ROCm is enabled. For older formats, a generated testdata file in the JAX wheel is required. Adding this file downstream will create import errors so these tests have been skipped for now. After the upstream PR with this testdata file has been reviewed and merged, these tests will be unskipped. A link to the upstream PR is included below:

Upstream PR: https://github.com/jax-ml/jax/pull/34929

## Technical Details
- Modified unit test `test_with_memory_space` to enable ROCM on current serialization formats. All other formats are skipped.

## Test Plan
The unit test `test_with_memory_space` includes three variants that test across serialization formats:
- `tests/export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_current`
- `tests/export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_v5`
- `tests/export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_v6`

## Test Result
 `tests/export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_current` passes on ROCm devices while all other formats are skipped.

```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'html': '4.2.0', 'metadata': '3.1.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.2', 'json-report': '1.5.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, html-4.2.0, metadata-3.1.1, reportlog-1.0.0, hypothesis-6.150.2, json-report-1.5.0
collected 11 items / 8 deselected / 3 selected
[TestLogger] Using invocation directory as test name: tests

export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_current PASSED                                                           [ 33%][TestLogger] Using invocation directory as test name: tests

export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_v5 SKIPPED (Serialized export testdata for serialization format 5 is...) [ 66%][TestLogger] Using invocation directory as test name: tests

export_serialization_back_compat_test.py::CompatTest::test_with_memory_space_v6 SKIPPED (Serialized export testdata for serialization format 6 is...) [100%][TestLogger] Using invocation directory as test name: tests


======================================================== 1 passed, 2 skipped, 8 deselected in 5.02s =========================================================
```