### PR TITLE
Skip test_tridiagonal_solve_grad test 0.8.0

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2330,6 +2330,10 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4)], dtype=float_types + complex_types)
   def test_tridiagonal_solve_grad(self, shape, dtype):
+    if jtu.is_device_rocm() and shape == (3, 4) and dtype == np.float32:
+      # numerical errors seen as of ROCm 7.2 due to rocSparse issue for grad0 variant
+      # TODO: re-enable the test once the rocSparse issue is fixed
+      self.skipTest("test_tridiagonal_solve_grad0 not supported on ROCm due to rocSparse issue")
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")
     rng = self.rng()


### PR DESCRIPTION
## Motivation

The `test_tridiagonal_solve_grad` test fails on ROCm devices due to numerical precision issues in the underlying rocSparse library. 

## Technical Details

- Added conditional skip logic using jtu.is_device_rocm(), shape == (3, 4), and dtype == np.float32 to skip only test_tridiagonal_solve_grad0 on ROCm in tests/linalg_test.py, preserving other passing test variants.

## Test Result
<img width="2771" height="493" alt="image" src="https://github.com/user-attachments/assets/99979316-b9e8-4c69-8af4-f3a9625c8e54" />


Upstream PR - https://github.com/jax-ml/jax/pull/34959

## Submission Checklist
Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.