### PR TITLE
Update skip message version from 0.8.0 to 0.9.0 for test_is_finite on…

### DIFF
--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1037,7 +1037,7 @@ class OpsTest(PallasBaseTest):
       # originally configured. Have no way to test cuda.
 
     if jtu.is_device_rocm():
-      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
+      self.skipTest("is_finite not in Triton lowering for jax 0.9.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 
@@ -1090,7 +1090,7 @@ class OpsTest(PallasBaseTest):
       self.skipTest("Not tested on CUDA, todo for the respective team")
 
     if jtu.is_device_rocm():
-      self.skipTest("is_finite not in Triton lowering for jax 0.8.0")
+      self.skipTest("is_finite not in Triton lowering for jax 0.9.0")
 
     size = len(self.IS_FINITE_TEST_VALUES)
 


### PR DESCRIPTION
Skip these tests on JAX 0.9.0 because the pull request that makes them pass on upstream has not been merged yet.
## Test Results 
```
cd /workspace/rocm-jax/jax && pytest \
  tests/pallas/ops_test.py::OpsTest::test_dot100 \
  tests/pallas/ops_test.py::OpsTest::test_dot120 \
  tests/pallas/ops_test.py::OpsTest::test_dot124 \
  tests/pallas/ops_test.py::OpsTest::test_dot206 \
  tests/pallas/ops_test.py::OpsTest::test_dot230 \
  tests/pallas/ops_test.py::OpsTest::test_dot36 \
  tests/pallas/ops_test.py::OpsTest::test_dot37 \
  tests/pallas/ops_test.py::OpsTest::test_dot96 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_bfloat16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_float16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_float32 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_bfloat16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float16 \
  tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_uint32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_bool \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float16 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_int32 \
  tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_uint32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_bool \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float16 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_int32 \
  tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_uint32 \
  tests/layout_test.py::LayoutTest::test_layout_donation_mismatching_in_and_out_fails \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 \
  tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention12 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention14 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention16 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention18 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention20 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttention22 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask4 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask5 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask6 \
  tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask7 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 \
  tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 \
  tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots \
  tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims \
  -v
est session starting on GPU ?
=============================== test session starts ===============================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.2.0-25-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'hypothesis': '6.150.0', 'rerunfailures': '16.1', 'reportlog': '1.0.0', 'metadata': '3.1.1', 'json-report': '1.5.0', 'html': '4.1.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.150.0, rerunfailures-16.1, reportlog-1.0.0, metadata-3.1.1, json-report-1.5.0, html-4.1.1
collected 169 items                                                               

tests/pallas/ops_test.py::OpsTest::test_dot100 SKIPPED (TODO: Mosaic GP...) [  0%]
tests/pallas/ops_test.py::OpsTest::test_dot120 SKIPPED (TODO: Mosaic GP...) [  1%]
tests/pallas/ops_test.py::OpsTest::test_dot124 SKIPPED (TODO: Mosaic GP...) [  1%]
tests/pallas/ops_test.py::OpsTest::test_dot206 SKIPPED (TODO: Mosaic GP...) [  2%]
tests/pallas/ops_test.py::OpsTest::test_dot230 SKIPPED (TODO: Mosaic GP...) [  2%]
tests/pallas/ops_test.py::OpsTest::test_dot36 SKIPPED (TODO: Mosaic GPU...) [  3%]
tests/pallas/ops_test.py::OpsTest::test_dot37 SKIPPED (TODO: Mosaic GPU...) [  4%]
tests/pallas/ops_test.py::OpsTest::test_dot96 SKIPPED (TODO: Mosaic GPU...) [  4%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_bfloat16 SKIPPED (is_...) [  5%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_float16 SKIPPED (is_f...) [  5%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_float32 SKIPPED (is_f...) [  6%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_bfloat16 SKIPPED   [  7%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float16 SKIPPED    [  7%]
tests/pallas/ops_test.py::OpsTest::test_is_finite_scalar_float32 SKIPPED    [  8%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_bool SKIPPED [  8%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float16 SKIPPED [  9%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_float32 SKIPPED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_int32 SKIPPED [ 10%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_equal_uint32 SKIPPED [ 11%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_bool SKIPPED [ 11%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_bool SKIPPED [ 12%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float16 SKIPPED [ 13%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_float32 SKIPPED [ 13%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_int32 SKIPPED [ 14%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_equal_uint32 SKIPPED [ 14%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float16 SKIPPED [ 15%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_float32 SKIPPED [ 15%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_int32 SKIPPED [ 16%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_greater_uint32 SKIPPED [ 17%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_bool SKIPPED [ 17%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_bool SKIPPED [ 18%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float16 SKIPPED [ 18%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_float32 SKIPPED [ 19%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_int32 SKIPPED [ 20%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_equal_uint32 SKIPPED [ 20%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float16 SKIPPED [ 21%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_float32 SKIPPED [ 21%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_int32 SKIPPED [ 22%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_less_uint32 SKIPPED [ 23%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_bool SKIPPED [ 23%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float16 SKIPPED [ 24%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_float32 SKIPPED [ 24%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_int32 SKIPPED [ 25%]
tests/pallas/ops_test.py::OpsInterpretTest::test_comparison_scalar_not_equal_uint32 SKIPPED [ 26%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_bool SKIPPED [ 26%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float16 SKIPPED [ 27%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_float32 SKIPPED [ 27%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_int32 SKIPPED [ 28%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_equal_uint32 SKIPPED [ 28%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_bool SKIPPED [ 29%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_bool SKIPPED [ 30%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float16 SKIPPED [ 30%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_float32 SKIPPED [ 31%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_int32 SKIPPED [ 31%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_equal_uint32 SKIPPED [ 32%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float16 SKIPPED [ 33%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_float32 SKIPPED [ 33%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_int32 SKIPPED [ 34%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_greater_uint32 SKIPPED [ 34%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_bool SKIPPED [ 35%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_bool SKIPPED [ 36%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float16 SKIPPED [ 36%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_float32 SKIPPED [ 37%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_int32 SKIPPED [ 37%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_equal_uint32 SKIPPED [ 38%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float16 SKIPPED [ 39%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_float32 SKIPPED [ 39%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_int32 SKIPPED [ 40%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_less_uint32 SKIPPED [ 40%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_bool SKIPPED [ 41%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float16 SKIPPED [ 42%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_float32 SKIPPED [ 42%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_int32 SKIPPED [ 43%]
tests/pallas/ops_test.py::OpsTest::test_comparison_scalar_not_equal_uint32 SKIPPED [ 43%]
tests/layout_test.py::LayoutTest::test_layout_donation_mismatching_in_and_out_fails SKIPPED [ 44%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex0 PASSED                    [ 44%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex1 SKIPPED (subset_by_in...) [ 45%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex2 SKIPPED (subset_by_in...) [ 46%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex3 SKIPPED (subset_by_in...) [ 46%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex4 SKIPPED (subset_by_in...) [ 47%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex5 PASSED                    [ 47%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex6 PASSED                    [ 48%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex7 PASSED                    [ 49%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex8 SKIPPED (subset_by_in...) [ 49%]
tests/svd_test.py::SvdTest::testSvdSubsetByIndex9 SKIPPED (subset_by_in...) [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention0 SKIPPED (Ne...) [ 50%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention2 SKIPPED (Ne...) [ 51%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention4 SKIPPED (Ne...) [ 52%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention6 SKIPPED (Ne...) [ 52%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention8 SKIPPED (Ne...) [ 53%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention10 SKIPPED (N...) [ 53%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention12 SKIPPED (N...) [ 54%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention14 SKIPPED (N...) [ 55%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention16 SKIPPED (N...) [ 55%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention18 SKIPPED (N...) [ 56%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention20 SKIPPED (N...) [ 56%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttention22 SKIPPED (N...) [ 57%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient0 SKIPPED [ 57%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient1 SKIPPED [ 58%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient2 SKIPPED [ 59%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionBiasGradient3 SKIPPED [ 59%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask0 SKIPPED     [ 60%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask1 SKIPPED     [ 60%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask2 SKIPPED     [ 61%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask3 SKIPPED     [ 62%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask4 SKIPPED     [ 62%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask5 SKIPPED     [ 63%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask6 SKIPPED     [ 63%]
tests/nn_test.py::NNFunctionsTest::testDotProductAttentionMask7 SKIPPED     [ 64%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral0 SKIPPED (Needs...) [ 65%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral1 SKIPPED (Needs...) [ 65%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral2 SKIPPED (Needs...) [ 66%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral3 SKIPPED (Needs...) [ 66%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral4 SKIPPED (Needs...) [ 67%]
tests/nn_test.py::NNFunctionsTest::testScaledDotGeneral5 SKIPPED (Needs...) [ 68%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul0 SKIPPED (Needs com...) [ 68%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul1 SKIPPED (Needs com...) [ 69%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul2 SKIPPED (Needs com...) [ 69%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul3 SKIPPED (Needs com...) [ 70%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul4 SKIPPED (Needs com...) [ 71%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul5 SKIPPED (Needs com...) [ 71%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul6 SKIPPED (Needs com...) [ 72%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul7 SKIPPED (Needs com...) [ 72%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul8 SKIPPED (Needs com...) [ 73%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul9 SKIPPED (Needs com...) [ 73%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul10 SKIPPED (Needs co...) [ 74%]
tests/nn_test.py::NNFunctionsTest::testScaledMatmul11 SKIPPED (Needs co...) [ 75%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp40 SKIPPED [ 75%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp41 SKIPPED [ 76%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp42 SKIPPED [ 76%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp43 SKIPPED [ 77%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp44 SKIPPED [ 78%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp45 SKIPPED [ 78%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp46 SKIPPED [ 79%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp47 SKIPPED [ 79%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp48 SKIPPED [ 80%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_nvfp49 SKIPPED [ 81%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded0 SKIPPED [ 81%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded1 SKIPPED [ 82%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded2 SKIPPED [ 82%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded3 SKIPPED [ 83%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded4 SKIPPED [ 84%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded5 SKIPPED [ 84%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded6 SKIPPED [ 85%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_sharded7 SKIPPED [ 85%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap0 SKIPPED [ 86%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap1 SKIPPED [ 86%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general_vmap2 SKIPPED [ 87%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general0 SKIPPED [ 88%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general1 SKIPPED [ 88%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general2 SKIPPED [ 89%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general3 SKIPPED [ 89%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general4 SKIPPED [ 90%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general5 SKIPPED [ 91%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general6 SKIPPED [ 91%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general7 SKIPPED [ 92%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general8 SKIPPED [ 92%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_dot_general9 SKIPPED [ 93%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip0 SKIPPED [ 94%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip1 SKIPPED [ 94%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip2 SKIPPED [ 95%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_nvfp4_gradient_clip3 SKIPPED [ 95%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp40 SKIPPED [ 96%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp41 SKIPPED [ 97%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_nvfp42 SKIPPED [ 97%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale0 SKIPPED [ 98%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_quantize_requires_global_scale1 SKIPPED [ 98%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots SKIPPED [ 99%]
tests/scaled_matmul_stablehlo_test.py::ScaledDotGeneralTest::test_remat_checkpoint_dots_with_no_batch_dims SKIPPED [100%]

========================= 4 passed, 165 skipped in 8.58s ==========================
root@03756c8e0e84:/workspace/rocm-jax/jax# 
```