### PR TITLE
Add `device test` unit tests for ROCm (JAX v0.9.0)

### DIFF
--- a/tests/device_test.py
+++ b/tests/device_test.py
@@ -28,6 +28,9 @@ class DeviceTest(jtu.JaxTestCase):
     if jtu.is_device_cuda():
       self.assertEqual(device.platform, 'gpu')
       self.assertEqual(repr(device), 'CudaDevice(id=0)')
+    elif jtu.is_device_rocm():
+      self.assertEqual(device.platform, 'gpu')
+      self.assertEqual(repr(device), 'RocmDevice(id=0)')
     elif jtu.test_device_matches(['tpu']):
       self.assertEqual(device.platform, 'tpu')
       self.assertEqual(
@@ -44,6 +47,8 @@ class DeviceTest(jtu.JaxTestCase):
     # TODO(pobudzey): Add a test for rocm devices when available.
     if jtu.is_device_cuda():
       self.assertEqual(str(device), 'cuda:0')
+    elif jtu.is_device_rocm():
+      self.assertEqual(str(device), 'rocm:0')
     elif jtu.test_device_matches(['tpu']):
       self.assertEqual(str(device), 'TPU_0(process=0,(0,0,0,0))')
     elif jtu.test_device_matches(['cpu']):


### PR DESCRIPTION
## Motivation
The test file `device_test.py` contained tests for different devices supported on JAX but not ROCm devices. They have now been added.

Upstream PR: https://github.com/jax-ml/jax/pull/34974

## Technical Details
Two ROCm-specific branches have been added to device tests checking the results of the `repr` and `str` functions on the device objects.

- `tests/device_test.py::DeviceTest::test_repr`
- `tests/device_test.py::DeviceTest::test_str`

## Test Plan
The unit test file `device_test.py` should now have ROCm-specific checks for all its unit tests.

## Test Results
```
==================================================================== test session starts ====================================================================
platform linux -- Python 3.12.3, pytest-9.0.2, pluggy-1.6.0 -- /usr/bin/python3
cachedir: .pytest_cache
metadata: {'Python': '3.12.3', 'Platform': 'Linux-6.8.0-45-generic-x86_64-with-glibc2.39', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'rerunfailures': '16.1', 'html': '4.2.0', 'metadata': '3.1.1', 'reportlog': '1.0.0', 'hypothesis': '6.150.2', 'json-report': '1.5.0'}}
hypothesis profile 'default'
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: rerunfailures-16.1, html-4.2.0, metadata-3.1.1, reportlog-1.0.0, hypothesis-6.150.2, json-report-1.5.0
collected 2 items
[TestLogger] Using invocation directory as test name: tests

device_test.py::DeviceTest::test_repr PASSED                                                                                                          [ 50%][TestLogger] Using invocation directory as test name: tests

device_test.py::DeviceTest::test_str PASSED                                                                                                           [100%][TestLogger] Using invocation directory as test name: tests


==================================================================== 2 passed in 13.18s =====================================================================
```
