### PR TITLE
Add ROCm platform to export memory_space tests

### DIFF
--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -1411,7 +1411,7 @@ class JaxExportTest(jtu.JaxTestCase):
     a = jax.device_put(1, shd)
     f = jax.jit(lambda x: x)
 
-    exported = get_exported(f, platforms=("tpu", "cuda"))(a)
+    exported = get_exported(f, platforms=("tpu", "cuda", "rocm"))(a)
     self.assertEqual(exported.in_avals[0].memory_space, core.MemorySpace.Host)
     self.assertEqual(exported.out_avals[0].memory_space, core.MemorySpace.Host)
     if jtu.device_under_test() in ("tpu", "gpu"):
@@ -1425,7 +1425,7 @@ class JaxExportTest(jtu.JaxTestCase):
     f = jax.jit(lambda x: (x, jnp.ones((2, 2), dtype=np.float32)),
                 out_shardings=(shd, shd))
 
-    exported = get_exported(f, platforms=("tpu", "cuda"))(a)
+    exported = get_exported(f, platforms=("tpu", "cuda", "rocm"))(a)
     self.assertEqual(exported.in_avals[0].memory_space, core.MemorySpace.Host)
     self.assertEqual(exported.out_avals[0].memory_space, core.MemorySpace.Host)
     self.assertEqual(exported.out_avals[1].memory_space, core.MemorySpace.Host)


### PR DESCRIPTION
## Summary
- Add "rocm" to the platforms tuple in `test_memory_space` and `test_memory_space_from_out_shardings` tests
- Fixes test failures on ROCm: `ValueError: Function '<lambda>' was exported for platforms '('tpu', 'cuda')' but it is used on '('rocm',)'.`

This one already fix in upstream and jax 0.9.0
https://github.com/jax-ml/jax/pull/34890
and for ROCM 
https://github.com/ROCm/jax/pull/690

## Test result
```
pytest tests/export_test.py::JaxExportTest::test_memory_space tests/export_test.py::JaxExportTest::test_memory_space_from_out_shardings -v
Test session starting on GPU ?
=================================== test session starts ===================================
platform linux -- Python 3.11.13, pytest-9.0.2, pluggy-1.6.0 -- /usr/local/bin/python3.11
cachedir: .pytest_cache
hypothesis profile 'default'
metadata: {'Python': '3.11.13', 'Platform': 'Linux-6.2.0-25-generic-x86_64-with-glibc2.35', 'Packages': {'pytest': '9.0.2', 'pluggy': '1.6.0'}, 'Plugins': {'hypothesis': '6.151.4', 'html': '4.2.0', 'json-report': '1.5.0', 'metadata': '3.1.1', 'reportlog': '1.0.0', 'rerunfailures': '16.1'}}
rootdir: /workspace/rocm-jax/jax
configfile: pyproject.toml
plugins: hypothesis-6.151.4, html-4.2.0, json-report-1.5.0, metadata-3.1.1, reportlog-1.0.0, rerunfailures-16.1
collected 2 items                                                                         

tests/export_test.py::JaxExportTest::test_memory_space PASSED                       [ 50%]
tests/export_test.py::JaxExportTest::test_memory_space_from_out_shardings PASSED    [100%]

==================================== 2 passed in 5.80s ====================================
root@5f1420f8e109:/workspace/rocm-jax/ja
```
This one partly fix for https://ontrack-internal.amd.com/browse/SWDEV-579299