### PR TITLE
Remove 'var': ['mean'] from unsupported_params in signature test

### DIFF
--- a/tests/lax_numpy_test.py
+++ b/tests/lax_numpy_test.py
@@ -6330,7 +6330,6 @@ class NumpySignaturesTest(jtu.JaxTestCase):
       'stack': ['casting'],
       'tri': ['like'],
       'unravel_index': ['order'],
-      'var': ['mean'],
       'vstack': ['casting'],
       'zeros': ['order', 'like'],
       'zeros_like': ['subok', 'order']


### PR DESCRIPTION
The issue found when fixing the ticket 
https://ontrack-internal.amd.com/browse/SWDEV-579298

## Summary

**Issue:** `FAILED tests/lax_numpy_test.py::NumpySignaturesTest::testWrappedSignaturesMatch`

```
AssertionError: var: unsupported={'mean'} overlaps with jnp_params={'a', 'axis', 'out', 'keepdims', 'ddof', 'where', 'dtype', 'mean', 'correction'}.
assert not {'mean'}
```

**Root Cause:** There is an extra argument `mean` in JAX 0.8.2 compared to 0.8.0 in `jax/_src/numpy/reductions.py`.

In 0.8.0:
```python
def var(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
        out: None = None, ddof: int = 0, keepdims: bool = False, *,
        where: ArrayLike | None = None, correction: int | float | None = None) -> Array:
```

In 0.8.2:
```python
def var(a: ArrayLike, axis: Axis = None, dtype: DTypeLike | None = None,
        out: None = None, ddof: int = 0, keepdims: bool = False, *,
        where: ArrayLike | None = None, mean: ArrayLike | None = None,
        correction: int | float | None = None) -> Array:
```

The `unsupported_params` dictionary in the test lists NumPy parameters that JAX does not support. Since `jnp.var` now includes the `mean` parameter in 0.8.2, the entry `'var': ['mean']` is outdated and causes the test to fail.

**Solution:** Remove `'var': ['mean']` from `unsupported_params` in `testWrappedSignaturesMatch`, as `jnp.var` now supports the `mean` parameter.

## Test result

```
pytest tests/lax_numpy_test.py::NumpySignaturesTest::testWrappedSignaturesMatch -v
============================== 1 passed in 4.79s ===============================
```

This aligns with upstream JAX main which does not have `'var': ['mean']` in `unsupported_params`.
