### PR TITLE
Phambinh/skip fused attention navi lds limit

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1190,6 +1190,17 @@ class LaxTest(jtu.JaxTestCase):
           raise SkipTest(
               f"The dot algorithm '{algorithm}' requires CUDA compute "
               "capability >= 8.0.")
+        # TF32 is not supported on Navi/RDNA GPUs. XLA only allows it on
+        # MI100+ (gfx9 CDNA) — see xla/service/algorithm_util.cc.
+        # "Radeon" in device_kind identifies Navi/RDNA consumer GPUs
+        # (e.g. "AMD Radeon RX 9070 XT") vs MI/Instinct data center GPUs
+        # (e.g. "AMD Instinct MI300X") which support TF32.
+        if (algorithm == lax.DotAlgorithmPreset.TF32_TF32_F32
+            and jtu.is_device_rocm()
+            and "Radeon" in jax.local_devices()[0].device_kind):
+          raise SkipTest(
+              f"The dot algorithm '{algorithm}' is not supported on "
+              "Navi/RDNA GPUs.")
       elif algorithm not in {
           lax.DotAlgorithmPreset.DEFAULT,
           lax.DotAlgorithmPreset.ANY_F8_ANY_F8_F32,

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -98,6 +98,8 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
     """Test jax_visible_devices works in distributed settings."""
     if not jtu.test_device_matches(['gpu']):
       raise unittest.SkipTest('Tests only for GPU.')
+    if jax.device_count() < 4:
+      raise unittest.SkipTest('Test requires at least 4 GPUs.')
 
     port = portpicker.pick_unused_port()
     num_gpus = 4

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -178,6 +178,9 @@ class FusedAttentionTest(PallasBaseTest):
     # Navi/RDNA GPUs have 64KB LDS (shared memory), which is insufficient
     # for the attention kernel when head_dim is padded to 128+
     # (the kernel requests up to 98KB).
+    # "Radeon" in device_kind identifies Navi/RDNA consumer GPUs
+    # (e.g. "AMD Radeon RX 9070 XT") vs MI/Instinct data center GPUs
+    # (e.g. "AMD Instinct MI300X") which have larger shared memory.
     if (jtu.is_device_rocm()
         and "Radeon" in jax.local_devices()[0].device_kind
         and pl.next_power_of_2(head_dim) >= 128):
@@ -282,6 +285,9 @@ class FusedAttentionTest(PallasBaseTest):
     # Navi/RDNA GPUs have 64KB LDS (shared memory), which is insufficient
     # for the backward attention kernel when head_dim is padded to 128+
     # (the kernel requests up to 90KB).
+    # "Radeon" in device_kind identifies Navi/RDNA consumer GPUs
+    # (e.g. "AMD Radeon RX 9070 XT") vs MI/Instinct data center GPUs
+    # (e.g. "AMD Instinct MI300X") which have larger shared memory.
     if (jtu.is_device_rocm()
         and "Radeon" in jax.local_devices()[0].device_kind
         and pl.next_power_of_2(head_dim) >= 128):

--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -175,6 +175,14 @@ class FusedAttentionTest(PallasBaseTest):
       use_fwd,
       use_segment_ids,
   ):
+    # Navi/RDNA GPUs have 64KB LDS (shared memory), which is insufficient
+    # for the attention kernel when head_dim is padded to 128+
+    # (the kernel requests up to 98KB).
+    if (jtu.is_device_rocm()
+        and "Radeon" in jax.local_devices()[0].device_kind
+        and pl.next_power_of_2(head_dim) >= 128):
+      self.skipTest("Navi/RDNA GPUs have 64KB LDS, less than kernel demand")
+
     k1, k2, k3 = random.split(random.key(0), 3)
     q = random.normal(
         k1, (batch_size, seq_len, num_heads, head_dim), dtype=jnp.float16
@@ -270,6 +278,14 @@ class FusedAttentionTest(PallasBaseTest):
     if jtu.is_cuda_compute_capability_at_least("8.0"):
       # TODO(b/416306534)
       self.skipTest("Precision issues after CUDA 12.8.1 upgrade")
+
+    # Navi/RDNA GPUs have 64KB LDS (shared memory), which is insufficient
+    # for the backward attention kernel when head_dim is padded to 128+
+    # (the kernel requests up to 90KB).
+    if (jtu.is_device_rocm()
+        and "Radeon" in jax.local_devices()[0].device_kind
+        and pl.next_power_of_2(head_dim) >= 128):
+      self.skipTest("Navi/RDNA GPUs have 64KB LDS, less than kernel demand")
 
     k1, k2, k3 = random.split(random.key(0), 3)
     q = random.normal(


### PR DESCRIPTION
This one addresses  the ticket https://ontrack-internal.amd.com/browse/SWDEV-579393 that happen in Navi 
# Navi/RDNA GPU Test Skips

Summary of tests skipped on Navi/RDNA GPUs and the reasons why.

## 1. Fused Attention Tests — 64KB LDS Limit

**Tests:**
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd0`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd1`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd4`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd7`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd1`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd4`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd7`
- `tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8`

**Reason:** Navi/RDNA GPUs have 64KB of LDS (Local Data Store / shared memory). When
`head_dim` is padded to 128+, the Pallas fused attention kernels request up to 90–98KB
of shared memory, exceeding the 64KB limit. The runtime error is:

```
RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 90112, available: 65536
```

These tests pass on MI300 (Instinct) GPUs which have larger shared memory capacity.

**Detection:** Skip when `"Radeon"` is in `device_kind` and `head_dim` padded to ≥128.

## 2. TF32 Dot Algorithm Test — Unsupported on Navi

**Test:**
- `tests/lax_test.py::LaxTest::testDotAlgorithm13`

**Reason:** TF32 (TensorFloat-32) is not supported on Navi/RDNA GPUs. XLA only allows
`ALG_DOT_TF32_TF32_F32` on ROCm MI100 and above (gfx9 CDNA series: gfx908, gfx90a,
gfx942). Navi GPUs (gfx11xx, gfx12xx) are not in the `gfx9_mi100_or_later()` allowlist.
See `xla/service/algorithm_util.cc` lines 290–295 and
`xla/stream_executor/rocm/rocm_compute_capability.h` lines 124–126. The runtime error is:

```
UNIMPLEMENTED: Unsupported algorithm on the current device(s): ALG_DOT_TF32_TF32_F32
```

**Detection:** Skip when `"Radeon"` is in `device_kind` and algorithm is `TF32_TF32_F32`.


## 3. Distributed Visible Devices Test — Requires 4 GPUs

**Test:**
- `tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices`

**Reason:** The test hardcodes `num_gpus = 4` and spawns 4 tasks referencing GPU indices
0–3. On some Navi clusters (e.g., `ctr-navi4x-aj50-ws08`) there are only 2 GPUs, so the
test fails because GPU indices 2 and 3 do not exist.

**Detection:** Skip when `jax.device_count() < 4`.
**Results** 
 pytest tests/lax_test.py::LaxTest::testDotAlgorithm13 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd1 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd4 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd7 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd0 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd1 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd4 tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd7 tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices --tb=short -q
Test session starting on GPU ?
ssssssssss                                                                                                                                                  [100%]
10 skipped in 30.75s
