### PR TITLE
fix: add rocm_sysdeps/lib to wheel RUNPATH

### DIFF
--- a/jaxlib/rocm/rocm_rpath.bzl
+++ b/jaxlib/rocm/rocm_rpath.bzl
@@ -35,8 +35,11 @@ _ROCM_LINK_ONLY = "@local_config_rocm//rocm:link_only"
 
 _WHEEL_RPATHS = [
     "-Wl,-rpath,$$ORIGIN/../rocm/lib",
+    "-Wl,-rpath,$$ORIGIN/../rocm/lib/rocm_sysdeps/lib",
     "-Wl,-rpath,$$ORIGIN/../../rocm/lib",
+    "-Wl,-rpath,$$ORIGIN/../../rocm/lib/rocm_sysdeps/lib",
     "-Wl,-rpath,/opt/rocm/lib",
+    "-Wl,-rpath,/opt/rocm/lib/rocm_sysdeps/lib",
 ]
 
 def _wheel_features():


### PR DESCRIPTION
Add `rocm_sysdeps/lib` to `_WHEEL_RPATHS` in `jaxlib/rocm/rocm_rpath.bzl`.

JAX ROCm wheels fail to initialize the GPU backend because 25 vendored `librocm_sysdeps_*.so` libraries are directly in `DT_NEEDED` (via XLA's `system_libs(srcs=...)` target) but the wheel RUNPATH only covers `/opt/rocm/lib`. The sysdeps actually live in `/opt/rocm/lib/rocm_sysdeps/lib/`. TheRock's own libraries handle this with `$ORIGIN/rocm_sysdeps/lib` in their RUNPATH, but RUNPATH is non-transitive and doesn't propagate to JAX's `.so` files.

This adds the `rocm_sysdeps/lib` subdirectory to each existing RUNPATH entry so the dynamic linker can resolve all sysdeps without `LD_LIBRARY_PATH`.

Fixes https://github.com/ROCm/TheRock/issues/3627