### PR TITLE
Fix: Scaled Matmul at rocm 9.1

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -23,6 +23,7 @@ from jax._src import api
 from jax._src import core
 from jax._src import dispatch
 from jax._src import dtypes
+from jax._src import lax as lax_internal
 from jax._src import numpy as jnp
 from jax._src import tree_util
 from jax._src.custom_derivatives import custom_vjp
@@ -104,6 +105,23 @@ def _scaled_matmul_gpu_lowering(
   return [out.result]
 
 
+def _scaled_matmul_rocm_lowering(
+    ctx, a, b, a_scales, b_scales, preferred_element_type
+  ):
+  def _scaled_dot_lowering_impl(lhs, rhs, lhs_scales, rhs_scales):
+    return lax_internal.scaled_dot(
+        lhs,
+        rhs,
+        lhs_scale=lhs_scales,
+        rhs_scale=rhs_scales,
+        dimension_numbers=(((2,), (2,)), ((0,), (0,))),
+        preferred_element_type=preferred_element_type,
+    )
+  return mlir.lower_fun(_scaled_dot_lowering_impl, multiple_results=False)(
+      ctx, a, b, a_scales, b_scales
+  )
+
+
 def _scaled_matmul_abstract(a, b, a_scale, b_scale, *, preferred_element_type):
   batch, non_contracting_lhs, contracting_lhs = a.shape
   _, non_contracting_rhs, _ = b.shape
@@ -121,6 +139,11 @@ mlir.register_lowering(
     _scaled_matmul_p,
     _scaled_matmul_gpu_lowering,
     platform="cuda",
+)
+mlir.register_lowering(
+    _scaled_matmul_p,
+    _scaled_matmul_rocm_lowering,
+    platform="rocm",
 )
 
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")
@@ -684,7 +707,7 @@ def scaled_dot_bwd(dimension_numbers, preferred_element_type, configs, res, g):
       "configs": [configs[2], configs[0]]
   }
   grad_lhs = scaled_dot_general_transpose_lhs(*args, **lhs_kw_args)
-  grad_rhs = scaled_dot_general_transpose_rhs(*args, **rhs_kw_args)  # pyrefly: ignore[bad-argument-type]
+  grad_rhs = scaled_dot_general_transpose_rhs(*args, **rhs_kw_args)
 
   # We apply a Straight-Through Estimator (STE) with zero-out behavior: if
   # inputs are clipped during quantization in fprop, their corresponding gradients


### PR DESCRIPTION
 PR fixes failing ScaledMatmul and ScaledDot tests on ROCm caused by:
`MLIR translation rule for primitive 'scaled_matmul' not found for platform rocm`

On ROCm, we now register a dedicated lowering for scaled_matmul that uses a composite approach: it lowers through lax.scaled_dot instead of relying on direct fusion.
The resulting HLO can then be fused later by XLA, which matches the intended backend behavior and avoids the missing primitive translation path on ROCm.

What changed
- Implemented ROCm lowering by delegating to lax.scaled_dot.
- Kept existing CUDA lowering unchanged.

