### PR TITLE
Cherry-pick fixes for JAX 0.9.2 release from JAX 0.9.1

### DIFF
--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -23,6 +23,7 @@ from jax._src import api
 from jax._src import core
 from jax._src import dispatch
 from jax._src import dtypes
+from jax._src import lax as lax_internal
 from jax._src import numpy as jnp
 from jax._src import tree_util
 from jax._src.custom_derivatives import custom_vjp
@@ -104,6 +105,23 @@ def _scaled_matmul_gpu_lowering(
   return [out.result]
 
 
+def _scaled_matmul_rocm_lowering(
+    ctx, a, b, a_scales, b_scales, preferred_element_type
+  ):
+  def _scaled_dot_lowering_impl(lhs, rhs, lhs_scales, rhs_scales):
+    return lax_internal.scaled_dot(
+        lhs,
+        rhs,
+        lhs_scale=lhs_scales,
+        rhs_scale=rhs_scales,
+        dimension_numbers=(((2,), (2,)), ((0,), (0,))),
+        preferred_element_type=preferred_element_type,
+    )
+  return mlir.lower_fun(_scaled_dot_lowering_impl, multiple_results=False)(
+      ctx, a, b, a_scales, b_scales
+  )
+
+
 def _scaled_matmul_abstract(a, b, a_scale, b_scale, *, preferred_element_type):
   batch, non_contracting_lhs, contracting_lhs = a.shape
   _, non_contracting_rhs, _ = b.shape
@@ -121,6 +139,11 @@ mlir.register_lowering(
     _scaled_matmul_p,
     _scaled_matmul_gpu_lowering,
     platform="cuda",
+)
+mlir.register_lowering(
+    _scaled_matmul_p,
+    _scaled_matmul_rocm_lowering,
+    platform="rocm",
 )
 
 _scaled_matmul_p_wrapper = core.Primitive("scaled_matmul_wrapper")

--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -116,7 +116,7 @@ def _scaled_matmul_rocm_lowering(
         rhs,
         lhs_scale=lhs_scales,
         rhs_scale=rhs_scales,
-        # `scaled_matmul` is canonicalized to (B, M, K) x (B, N, K), so we
+        #  `scaled_matmul` is canonicalized to (B, M, K) x (B, N, K), so we
         # contract over K (axis 2) and batch over B (axis 0), yielding (B, M, N).
         dimension_numbers=(((2,), (2,)), ((0,), (0,))),
         preferred_element_type=preferred_element_type,

--- a/jax/_src/cudnn/scaled_matmul_stablehlo.py
+++ b/jax/_src/cudnn/scaled_matmul_stablehlo.py
@@ -108,12 +108,16 @@ def _scaled_matmul_gpu_lowering(
 def _scaled_matmul_rocm_lowering(
     ctx, a, b, a_scales, b_scales, preferred_element_type
   ):
+  # Lower `scaled_matmul` to `lax.scaled_dot` on ROCm so the backend can match
+  # the `xla.scaled_dot` composite while preserving `scaled_matmul` semantics.
   def _scaled_dot_lowering_impl(lhs, rhs, lhs_scales, rhs_scales):
     return lax_internal.scaled_dot(
         lhs,
         rhs,
         lhs_scale=lhs_scales,
         rhs_scale=rhs_scales,
+        # `scaled_matmul` is canonicalized to (B, M, K) x (B, N, K), so we
+        # contract over K (axis 2) and batch over B (axis 0), yielding (B, M, N).
         dimension_numbers=(((2,), (2,)), ((0,), (0,))),
         preferred_element_type=preferred_element_type,
     )
@@ -140,6 +144,11 @@ mlir.register_lowering(
     _scaled_matmul_gpu_lowering,
     platform="cuda",
 )
+
+# Keep CUDA lowering on the existing `__op$block_scaled_dot` custom call.
+# ROCm is registered separately because AMD's backend does not support that
+# custom call; instead, lowering through `lax.scaled_dot` lets XLA emit
+# `kScaledDot`, which ROCm can then fuse via Triton or hipBLASLt when possible.
 mlir.register_lowering(
     _scaled_matmul_p,
     _scaled_matmul_rocm_lowering,

--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -121,6 +121,10 @@ class AnnTest(jtu.JaxTestCase):
     num_devices = jax.device_count()
     if num_devices % 2 != 0:
       self.skipTest("Works only when number of devices is a multiple of 2.")
+    # TODO(araganes): Re-enable once upstream HloShardingV3 lands (JAX 0.9.2+).
+    # New pmap's SPMD tiling can't convert back to 1D pmap mesh on ROCm.
+    if jtu.is_device_rocm():
+      self.skipTest("IndivisibleError: SPMD tiling incompatible with 1D pmap mesh on ROCm")
     rng = jtu.rand_default(self.rng())
     qy = rng(qy_shape, dtype)
     db = rng(db_shape, dtype)

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2468,6 +2468,10 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4)], dtype=float_types + complex_types)
   def test_tridiagonal_solve_grad(self, shape, dtype):
+    if jtu.is_device_rocm() and shape == (3, 4) and dtype == np.float32:
+      # numerical errors seen as of ROCm 7.2 due to rocSparse issue for grad0 variant
+      # TODO: re-enable the test once the rocSparse issue is fixed
+      self.skipTest("test_tridiagonal_solve_grad0 not supported on ROCm due to rocSparse issue")
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")
     rng = self.rng()


### PR DESCRIPTION
## Summary

Cherry-picks for JAX 0.9.2 ROCm release:

- Skip ann_test test_pmap on ROCm due to IndivisibleError (jax-ml/jax#35611)
- Skip test_tridiagonal_solve_grad0 due to rocSparse numerical issue (jax-ml/jax#35917)
- Add ROCm lowering for ScaledMatmul/ScaledDot (jax-ml/jax#35995)
