### PR TITLE
Fix deprecated mpmath.ctx_mp.mpnumeric import for mpmath >= 1.4.0

### DIFF
--- a/jax/_src/test_util.py
+++ b/jax/_src/test_util.py
@@ -1988,7 +1988,7 @@ class vectorize_with_mpmath(np.vectorize):
         dtype = None
       if dtype is not None:
         return np.fromiter(map(self.mptonp, x_flat), dtype=dtype).reshape(x.shape)
-    elif isinstance(x, self.mpmath.ctx_mp.mpnumeric):
+    elif isinstance(x, self.mpmath.ctx_mp_python.mpnumeric):
       ctx = x.context
       if isinstance(x, ctx.mpc):
         fp_format = self.contexts_inv[ctx]
@@ -2038,13 +2038,13 @@ class vectorize_with_mpmath(np.vectorize):
       lst = []
       for r in result:
         if ((isinstance(r, np.ndarray) and r.dtype.kind == 'O')
-            or isinstance(r, self.mpmath.ctx_mp.mpnumeric)):
+            or isinstance(r, self.mpmath.ctx_mp_python.mpnumeric)):
           r = self.mptonp(r)
         lst.append(r)
       return tuple(lst)
 
     if ((isinstance(result, np.ndarray) and result.dtype.kind == 'O')
-        or isinstance(result, self.mpmath.ctx_mp.mpnumeric)):
+        or isinstance(result, self.mpmath.ctx_mp_python.mpnumeric)):
       return self.mptonp(result)
 
     return result

--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -4419,7 +4419,7 @@ class FunctionAccuracyTest(jtu.JaxTestCase):
     is_complex = dtype().dtype.kind == 'c'
 
     def func(x):
-      assert isinstance(x, mpmath.ctx_mp.mpnumeric)
+      assert isinstance(x, mpmath.ctx_mp_python.mpnumeric)
       assert x.context.prec == prec
       assert isinstance(x, x.context.mpc if is_complex else x.context.mpf)
       return x


### PR DESCRIPTION
## Description:
mpmath 1.4.0 deprecated the mpnumeric attribute on ctx_mp, emitting a DeprecationWarning when accessed. This causes test failures in all testFailureOnComplexPlane and testSuccessOnComplexPlane tests.
After cherry pick upstream fix, the test is skipped as it should. 
## Fix
Replace ctx_mp.mpnumeric with ctx_mp_python.mpnumeric. Compatible with both old and new mpmath versions.
## Files changed:
Cherry-pick of upstream JAX fix: https://github.com/jax-ml/jax/commit/b5c9201579c0b0f8088cf2e91f7b745a39cfa7f3

<img width="1035" height="487" alt="image" src="https://github.com/user-attachments/assets/b38ffb9e-125f-42bd-ba9e-8981623241a5" />

