### PR TITLE
[ROCm] Cherry-pick: Add ROCm xdist device pinning in conftest.py

### DIFF
--- a/build/parallel_accelerator_execute.sh
+++ b/build/parallel_accelerator_execute.sh
@@ -75,7 +75,7 @@ for j in `seq 0 $((JAX_TESTS_PER_ACCELERATOR-1))`; do
         # single command.
         export TPU_VISIBLE_CHIPS=$i
         export CUDA_VISIBLE_DEVICES=$i
-        export HIP_VISIBLE_DEVICES=$i
+        export ROCR_VISIBLE_DEVICES=$i
         echo "Running test $TEST_BINARY $* on accelerator $i"
         "$TEST_BINARY" $@
       )

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -98,9 +98,9 @@ fi
 
 echo "Final number of processes to run: $num_processes"
 
-export JAX_ENABLE_CUDA_XDIST="$gpu_count"
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
 
 # ==============================================================================

--- a/conftest.py
+++ b/conftest.py
@@ -72,3 +72,13 @@ def pytest_collection() -> None:
     os.environ.setdefault(
         "CUDA_VISIBLE_DEVICES", str(xdist_worker_number % num_cuda_devices)
     )
+
+  elif num_rocm_devices := os.environ.get("JAX_ENABLE_ROCM_XDIST", None):
+    num_rocm_devices = int(num_rocm_devices)
+    xdist_worker_name = os.environ.get("PYTEST_XDIST_WORKER", "")
+    if not xdist_worker_name.startswith("gw"):
+      return
+    xdist_worker_number = int(xdist_worker_name[len("gw") :])
+    os.environ.setdefault(
+        "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
+    )

--- a/tests/multiprocess_gpu_test.py
+++ b/tests/multiprocess_gpu_test.py
@@ -64,7 +64,7 @@ class MultiProcessGpuTest(jtu.JaxTestCase):
       env["NUM_TASKS"] = str(num_tasks)
       env["TASK"] = str(task)
       if jtu.is_device_rocm():
-        env["HIP_VISIBLE_DEVICES"] = ",".join(
+        env["ROCR_VISIBLE_DEVICES"] = ",".join(
             str((task * num_gpus_per_task) + i) for i in range(num_gpus_per_task))
       else:
         env["CUDA_VISIBLE_DEVICES"] = ",".join(


### PR DESCRIPTION
## Summary
Cherry-pick of jax-ml/jax#35944 into `rocm-jaxlib-v0.9.2` release branch.

Adds ROCm xdist device pinning support to `conftest.py`, mirroring the existing CUDA xdist logic:
- Workers are assigned GPUs via `ROCR_VISIBLE_DEVICES` in round-robin across ROCm devices
- Guards against double-filtering if `ROCR_VISIBLE_DEVICES` is already set
- Disables GPU memory preallocation in ROCm pytest (`XLA_PYTHON_CLIENT_PREALLOCATE=false`)

Without this, `JAX_ENABLE_ROCM_XDIST` has no effect and all xdist workers see all GPUs.