### PR TITLE
Temporarily disable the cron trigger for the cont. wheel tests workflow

### DIFF
--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -35,8 +35,8 @@ permissions:
   actions: read
 
 on:
-  schedule:
-    - cron: "0 */3 * * *" # Run once every 3 hours
+  # schedule:
+  #  - cron: "0 */3 * * *" # Run once every 3 hours
   workflow_dispatch: # allows triggering the workflow run manually
 
 concurrency:


### PR DESCRIPTION
Temporarily disable the cron trigger since this workflow updates a shared latest pointer file. While the cron runs together with upstream workflows and S3 prefixes across repositories are not yet aligned, the pointer may reference unintended artifacts, causing inconsistent artifact selection. This change is temporary.