### PR TITLE
Backport approx_tanh fix (cherry-pick jax-ml/jax#34598)

### DIFF
--- a/jax/_src/pallas/triton/primitives.py
+++ b/jax/_src/pallas/triton/primitives.py
@@ -22,6 +22,9 @@ from typing import TypeAlias
 import jax
 from jax._src import core as jax_core
 from jax._src import state
+from jax._src import tree_util
+from jax._src.lib.mlir import ir
+from jax._src.lib.mlir.dialects import arith as arith_dialect
 from jax._src.lib.mlir.dialects import gpu as gpu_dialect
 from jax._src.lib.triton import dialect as tt_dialect
 from jax._src.pallas import primitives as pallas_primitives
@@ -125,11 +128,14 @@ def _elementwise_inline_asm_lowering(
 ):
   del result_shape_dtypes  # Unused.
 
-  # For ROCm, PTX inline assembly is not supported. For tanh.approx, we use
-  # Triton's __triton_hip_fast_tanhf (fast exp-based formula) for f32, and
-  # OCML's __ocml_tanh_f64 for f64. See: https://github.com/triton-lang/triton/pull/7780
-  if ctx.context.platform == "rocm" and "tanh.approx" in asm:
-    return _approx_tanh_rocm_lowering(ctx, *args)
+  if "tanh.approx" in asm:
+    if ctx.context.platform == "rocm":
+      return _approx_tanh_rocm_lowering(ctx, *args)
+    if ctx.avals_in[0].dtype == jnp.float64:
+      raise TypeError(
+          "approx_tanh does not support float64 on CUDA; it is only"
+          " supported on ROCm"
+      )
 
   return tt_dialect.ElementwiseInlineAsmOp(
       [*map(mlir.aval_to_ir_type, ctx.avals_out)],
@@ -148,27 +154,12 @@ def _approx_tanh_rocm_lowering(
   """Lower approx_tanh for ROCm.
 
   AMD CDNA3 (MI300X/gfx942) does not have a hardware tanh instruction.
-
-  For f32 (and f16/bf16 via casting): We use Triton's __triton_hip_fast_tanhf
-  which implements a fast exp-based formula: tanh(x) = (exp(2x) - 1) / (exp(2x) + 1)
   See: https://github.com/triton-lang/triton/pull/7780
-
-  For f64: We use OCML's __ocml_tanh_f64 (AMD's Open Compute Math Library)
-  since fast_tanhf only supports f32.
   """
-  from jax._src.lib.mlir import ir
-  from jax._src.lib.mlir.dialects import arith as arith_dialect
-
   [arg] = args
   [out_aval] = ctx.avals_out
   in_dtype = ctx.avals_in[0].dtype
 
-  # Helper to get IR type for a dtype
-  def dtype_to_ir_type(dtype):
-    dtype = jnp.dtype(dtype)
-    return mlir.dtype_to_ir_type(dtype)
-
-  # f64: use __ocml_tanh_f64 (fast_tanhf only supports f32)
   if in_dtype == jnp.float64:
     result_type = mlir.aval_to_ir_type(out_aval)
     result = tt_dialect.extern_elementwise(
@@ -181,42 +172,29 @@ def _approx_tanh_rocm_lowering(
     )
     return [result]
 
-  # fast_tanhf only supports f32. For f16/bf16, cast to f32, compute, cast back.
   needs_cast = in_dtype in (jnp.float16, jnp.bfloat16)
 
   if needs_cast:
-    # Cast input to f32 (extend)
-    f32_type = dtype_to_ir_type(jnp.float32)
+    f32_type = mlir.dtype_to_ir_type(jnp.dtype(jnp.float32))
     if out_aval.shape:
       f32_result_type = ir.RankedTensorType.get(out_aval.shape, f32_type)
     else:
       f32_result_type = f32_type
-    arg_f32 = arith_dialect.extf(f32_result_type, arg)
+    arg = arith_dialect.extf(f32_result_type, arg)
 
-    # Call __triton_hip_fast_tanhf (fast exp-based implementation)
-    tanh_result = tt_dialect.extern_elementwise(
-        f32_result_type,
-        [arg_f32],
-        libname="libdevice",
-        libpath="",
-        symbol="__triton_hip_fast_tanhf",
-        pure=True,
-    )
+  result_type = f32_result_type if needs_cast else mlir.aval_to_ir_type(out_aval)
+  result = tt_dialect.extern_elementwise(
+      result_type,
+      [arg],
+      libname="libdevice",
+      libpath="",
+      symbol="__triton_hip_fast_tanhf",
+      pure=True,
+  )
 
-    # Cast result back to original dtype (truncate)
+  if needs_cast:
     out_type = mlir.aval_to_ir_type(out_aval)
-    result = arith_dialect.truncf(out_type, tanh_result)
-  else:
-    # f32: call __triton_hip_fast_tanhf directly
-    result_type = mlir.aval_to_ir_type(out_aval)
-    result = tt_dialect.extern_elementwise(
-        result_type,
-        list(args),
-        libname="libdevice",
-        libpath="",
-        symbol="__triton_hip_fast_tanhf",
-        pure=True,
-    )
+    result = arith_dialect.truncf(out_type, result)
 
   return [result]
 

--- a/tests/pallas/ops_test.py
+++ b/tests/pallas/ops_test.py
@@ -1926,47 +1926,6 @@ class OpsTest(PallasBaseTest):
 
     np.testing.assert_allclose(f(), kernel())
 
-  @parameterized.parameters("float16", "bfloat16", "float32", "float64")
-  def test_approx_tanh(self, dtype):
-    self.skip_if_mosaic_gpu()
-
-    if jtu.test_device_matches(["tpu"]):
-      self.skipTest("Not implemented on TPU")
-
-    if self.INTERPRET:
-      self.skipTest("approx_tanh is not supported in interpret mode")
-
-    if (dtype == "bfloat16" and
-        jtu.test_device_matches(["cuda"]) and
-        not jtu.is_cuda_compute_capability_at_least("9.0")):
-      self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
-
-    if dtype == "float64":
-      if jtu.test_device_matches(["cuda"]):
-        self.skipTest("f64 approx_tanh is only supported on ROCm")
-
-    # Enable x64 for f64 test if not already enabled, restore after test
-    original_x64 = jax.config.x64_enabled
-    if dtype == "float64" and not original_x64:
-      jax.config.update("jax_enable_x64", True)
-      self.addCleanup(lambda: jax.config.update("jax_enable_x64", False))
-
-    @functools.partial(
-        self.pallas_call, out_shape=jax.ShapeDtypeStruct((4,), dtype),
-    )
-    def kernel(x_ref, o_ref):
-      o_ref[...] = plgpu_triton.approx_tanh(x_ref[...])
-
-    x = jnp.asarray([-1, 0.42, 0.24, 1]).astype(dtype)
-    # We upcast to float32 because NumPy <2.0 does not handle custom dtypes
-    # properly. See https://github.com/jax-ml/jax/issues/11014.
-    np.testing.assert_allclose(
-        kernel(x).astype(jnp.float32),
-        jnp.tanh(x).astype(jnp.float32),
-        atol=5e-3,
-        rtol=5e-3,
-    )
-
   @parameterized.parameters(
       ((2, 4), (8,)),
       ((2, 4), (8, 1)),

--- a/tests/pallas/triton_pallas_test.py
+++ b/tests/pallas/triton_pallas_test.py
@@ -47,8 +47,8 @@ class PallasBaseTest(jtu.JaxTestCase):
       if not self.INTERPRET:
         self.skipTest("On CPU the test works only in interpret mode")
     elif jtu.test_device_matches(["gpu"]):
-      if jtu.test_device_matches(["cuda"]) and \
-         not jtu.is_cuda_compute_capability_at_least("9.0"):
+      if (jtu.test_device_matches(["cuda"]) and
+          not jtu.is_cuda_compute_capability_at_least("9.0")):
         self.skipTest("Only works on GPU with capability >= sm90")
     else:
       self.skipTest("Test only works on CPU and GPU")
@@ -293,14 +293,24 @@ class TritonPallasTest(PallasBaseTest):
     else:
       self.fail("Expected exception due to invalid broadcasting")
 
-  @parameterized.parameters("float16", "bfloat16", "float32")
+  @parameterized.parameters("float16", "bfloat16", "float32", "float64")
   def test_approx_tanh(self, dtype):
     if self.INTERPRET:
       self.skipTest("approx_tanh is not supported in interpret mode")
 
     if (dtype == "bfloat16" and
+        jtu.test_device_matches(["cuda"]) and
         not jtu.is_cuda_compute_capability_at_least("9.0")):
       self.skipTest("tanh.approx.bf16 requires a GPU with capability >= sm90")
+
+    if dtype == "float64":
+      if jtu.test_device_matches(["cuda"]):
+        self.skipTest("f64 approx_tanh is only supported on ROCm")
+
+    original_x64 = jax.config.x64_enabled
+    if dtype == "float64" and not original_x64:
+      jax.config.update("jax_enable_x64", True)
+      self.addCleanup(lambda: jax.config.update("jax_enable_x64", False))
 
     @functools.partial(
         self.pallas_call, out_shape=jax.ShapeDtypeStruct((4,), dtype),


### PR DESCRIPTION
## Motivation
Cherry-pick of jax-ml/jax#34598 onto rocm-jaxlib-v0.8.2.

## Details 
approx_tanh was returning near-zero/garbage outputs on ROCm because the lowering  emitted NVIDIA PTX inline asm (tanh.approx.*). Cherry picked this fix from upstream which adds platform detection and routes ROCm to proper implementations
- f32/f16/bf16: __triton_hip_fast_tanhf (via triton-lang/triton#7780)
- f64: __ocml_tanh_f64

Tested on Navi48 (gfx94X) — all 4 approx_tanh variants (f16/bf16/f32/f64) pass.

<img width="1181" height="463" alt="image" src="https://github.com/user-attachments/assets/97eb03e9-4962-40b5-994e-7884398887d8" />


Fixes: SWDEV-582866 / ROCM-20866