### PR TITLE
Cherry-pick: Fix visibility in BUILD files (#757)

### DIFF
--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -478,6 +478,7 @@ rocm_nanobind_extension(
 
 py_library(
     name = "rocm_gpu_support",
+    visibility = ["//visibility:public"],
     deps = [
         ":_hybrid",
         ":_linalg",
@@ -531,6 +532,7 @@ rocm_nanobind_extension(
     name = "rocm_plugin_extension",
     srcs = ["rocm_plugin_extension.cc"],
     module_name = "rocm_plugin_extension",
+    visibility = ["//visibility:public"],
     deps = [
         ":py_client_gpu",
         "//jaxlib:kernel_nanobind_helpers",


### PR DESCRIPTION
## Summary
Cherry-pick of ROCm/jax@594e74d from `rocm-jaxlib-v0.9.1` into `rocm-jaxlib-v0.9.2`.

Adds `visibility = ["//visibility:public"]` to `rocm_gpu_support` and `rocm_plugin_extension` targets in `jaxlib/rocm/BUILD` so the ROCm plugin build can depend on them.