### PR TITLE
[ROCm] Cherry-pick: Fix env var leak in xla_bridge_test register_plugin tests

### DIFF
--- a/tests/xla_bridge_test.py
+++ b/tests/xla_bridge_test.py
@@ -32,6 +32,14 @@ mock = absltest.mock
 
 class XlaBridgeTest(jtu.JaxTestCase):
 
+  def setUp(self):
+    super().setUp()
+    # Tests in this class mutate xb._backend_factories via
+    # register_pjrt_plugin_factories_from_env(); isolate the mutation so it
+    # doesn't leak into other tests in the same xdist worker (e.g.,
+    # clear_backends_test.py, logging_test.py).
+    self.enter_context(mock.patch.dict(xb._backend_factories))
+
   def test_set_device_assignment_no_partition(self):
     compile_options = compiler.get_compile_options(
         num_replicas=4, num_partitions=1, device_assignment=[0, 1, 2, 3])
@@ -121,20 +129,18 @@ class XlaBridgeTest(jtu.JaxTestCase):
       xb.local_devices(backend="foo")
 
   def test_register_plugin(self):
-    with self.assertLogs(level="WARNING") as log_output:
-      with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
-        if platform.system() == "Windows":
-          os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
-              "name1;path1,name2;path2,name3"
-          )
-        else:
-          os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
-              "name1:path1,name2:path2,name3"
-          )
-        with mock.patch.object(
-            _profiler, "register_plugin_profiler", autospec=True
-        ):
-          xb.register_pjrt_plugin_factories_from_env()
+    env_value = (
+        "name1;path1,name2;path2,name3"
+        if platform.system() == "Windows"
+        else "name1:path1,name2:path2,name3"
+    )
+    with (
+        self.assertLogs(level="WARNING") as log_output,
+        mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True),
+        mock.patch.dict(os.environ, {"PJRT_NAMES_AND_LIBRARY_PATHS": env_value}),
+        mock.patch.object(_profiler, "register_plugin_profiler", autospec=True),
+    ):
+      xb.register_pjrt_plugin_factories_from_env()
     registration = xb._backend_factories["name1"]
     with mock.patch.object(xc, "make_c_api_client", autospec=True) as mock_make:
       with mock.patch.object(
@@ -165,16 +171,17 @@ class XlaBridgeTest(jtu.JaxTestCase):
     test_json_file_path = os.path.join(
         os.path.dirname(__file__), "testdata/example_pjrt_plugin_config.json"
     )
-    os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] = (
+    env_value = (
         f"name1;{test_json_file_path}"
         if platform.system() == "Windows"
         else f"name1:{test_json_file_path}"
     )
-    with mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True):
-      with mock.patch.object(
-          _profiler, "register_plugin_profiler", autospec=True
-      ):
-        xb.register_pjrt_plugin_factories_from_env()
+    with (
+        mock.patch.dict(os.environ, {"PJRT_NAMES_AND_LIBRARY_PATHS": env_value}),
+        mock.patch.object(xc, "load_pjrt_plugin_dynamically", autospec=True),
+        mock.patch.object(_profiler, "register_plugin_profiler", autospec=True),
+    ):
+      xb.register_pjrt_plugin_factories_from_env()
     registration = xb._backend_factories["name1"]
     with mock.patch.object(xc, "make_c_api_client", autospec=True) as mock_make:
       with mock.patch.object(


### PR DESCRIPTION
Cherry-pick of upstream [jax-ml/jax#37053](https://github.com/jax-ml/jax/pull/37053)
(commit `528d9cd69fb97e01ca19be6788274cb3fa5afcf1`).

> Note: upstream PR #37053 is still OPEN at the time of this cherry-pick.
> If the upstream PR is amended / rebased before merge, this downstream
> commit may need to be refreshed.

---

## Original PR description

XlaBridgeTest.test_register_plugin and test_register_plugin_with_config set os.environ["PJRT_NAMES_AND_LIBRARY_PATHS"] directly without restoring it, and they register PJRT plugin factories into the process-global xb._backend_factories without cleanup. When pytest reuses a worker process across files (e.g. xdist with --dist=loadfile), this state leaks into subsequent tests:

  - tests/logging_test.py::LoggingTest::test_subprocess_* spawns subprocesses that inherit the polluted env var. JAX init in the subprocess then tries to load the fake plugin path, crashes before emitting the expected log messages, and the assertions on captured stderr (assertIn 'INFO' / 'DEBUG') fail.

  - tests/clear_backends_test.py::ClearBackendsTest::test_clear_backends calls xla_bridge.backends() in-process, which iterates leftover 'name1'/'name2' factories and fails to initialize them.

Scope the env mutations with mock.patch.dict and add a setUp/addCleanup that snapshots and restores xb._backend_factories.
