### PR TITLE
Cherry pick upstream merged commits for v0.10.0 release

### DIFF
--- a/.github/actions/download-jax-rocm-wheels/action.yml
+++ b/.github/actions/download-jax-rocm-wheels/action.yml
@@ -84,19 +84,31 @@ runs:
           if [[ ${INPUTS_JAXLIB_VERSION} == "head" ]]; then
             gcloud storage cp -r "${INPUTS_GCS_DOWNLOAD_URI}/jaxlib*${PYTHON_MAJOR_MINOR}*${OS}*${ARCH}*.whl" $(pwd)/dist/
 
-            # Resolve the S3 URI for ROCm plugin/PJRT wheels.
+            # Resolve ROCm plugin/PJRT wheels path via CloudFront.
+            ROCM_WHEELS_BASE_URL="https://d22q5eopkfeftw.cloudfront.net"
             if [[ "${INPUTS_S3_DOWNLOAD_URI}" == "latest" ]]; then
-              S3_URI=$(aws s3 cp "s3://jax-ci-amd/rocm-wheels/LATEST" -)
-              echo "Resolved LATEST pointer to: ${S3_URI}"
+              RESOLVED_S3_URI=$(curl -fsSL "${ROCM_WHEELS_BASE_URL}/rocm-wheels/LATEST" | tr -d '[:space:]')
+              WHEELS_PATH="${RESOLVED_S3_URI#s3://jax-ci-amd/}"
+              echo "Resolved LATEST pointer to: ${WHEELS_PATH}"
             else
-              S3_URI="${INPUTS_S3_DOWNLOAD_URI}"
+              WHEELS_PATH="${INPUTS_S3_DOWNLOAD_URI#s3://jax-ci-amd/}"
             fi
 
-            echo "Downloading ROCm wheels from ${S3_URI}..."
-            aws s3 cp --recursive "${S3_URI}/" $(pwd)/dist/ \
-              --exclude "*" \
-              --include "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-*-py3-none-manylinux*.whl" \
-              --include "jax_rocm${JAXCI_ROCM_VERSION}_plugin-*-${PYTHON_MAJOR_MINOR}*manylinux*.whl"
+            WHEELS_URL="${ROCM_WHEELS_BASE_URL}/${WHEELS_PATH%/}"
+            echo "Downloading ROCm wheels from ${WHEELS_URL}..."
+
+            LISTING=$(curl -fsSL "${WHEELS_URL}/")
+            FILES=$(echo "$LISTING" | grep -oE 'href="[^"]+\.whl"' | cut -d'"' -f2)
+            PJRT_FILE=$(echo "$FILES" | grep "jax_rocm${JAXCI_ROCM_VERSION}_pjrt-" | head -n1)
+            PLUGIN_FILE=$(echo "$FILES" | grep "jax_rocm${JAXCI_ROCM_VERSION}_plugin-" | grep "${PYTHON_MAJOR_MINOR}" | head -n1)
+
+            if [[ -z "${PJRT_FILE}" || -z "${PLUGIN_FILE}" ]]; then
+              echo "Could not find ROCm PJRT or plugin wheels in ${WHEELS_URL}"
+              exit 1
+            fi
+
+            PYTHON_BIN="python${INPUTS_PYTHON}"
+            "${PYTHON_BIN}" -m pip download --dest "$(pwd)/dist" "${WHEELS_URL}/${PJRT_FILE}" "${WHEELS_URL}/${PLUGIN_FILE}"
           elif [[ ${INPUTS_JAXLIB_VERSION} == "pypi_latest" ]]; then
             PYTHON=python${INPUTS_PYTHON}
             $PYTHON -m pip download jaxlib jax-rocm${JAXCI_ROCM_VERSION}-pjrt jax-rocm${JAXCI_ROCM_VERSION}-plugin --dest $(pwd)/dist/

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -136,11 +136,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6
-        with:
-          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
-          aws-region: us-east-1
       - name: Download JAX ROCm wheels
         uses: ./.github/actions/download-jax-rocm-wheels
         with:
@@ -176,6 +171,12 @@ jobs:
         run: |
           set -euo pipefail
           tar -czf logs.tar.gz logs
+      - name: Configure AWS Credentials
+        if: ${{ !cancelled() }}
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
       - name: Upload test-artifacts to AMD S3
         if: ${{ !cancelled() }}
         env:

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,9 +20,9 @@ bazel_dep(name = "zlib", version = "1.3.1.bcr.5")
 bazel_dep(name = "rules_ml_toolchain")
 archive_override(
     module_name = "rules_ml_toolchain",
-    integrity = "sha256-8skk6Foiui6qDAhlfl9UZ/7bw9BQb5zAxp3Zftn7ryg=",
-    strip_prefix = "rules_ml_toolchain-99c43dfe995a0e81c767d5b6d686191992672fe6",
-    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/99c43dfe995a0e81c767d5b6d686191992672fe6.tar.gz"],
+    integrity = "sha256-y3Y1Yi6lJsiSOl6tbpncK6Vc3mrpYTv5stNLPwAPKc4=",
+    strip_prefix = "rules_ml_toolchain-84ac62e4db38215a2a7d3ad8cd4d7452134e3ec6",
+    urls = ["https://github.com/google-ml-infra/rules_ml_toolchain/archive/84ac62e4db38215a2a7d3ad8cd4d7452134e3ec6.tar.gz"],
 )
 
 # TODO: use a released version when available

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,10 +17,10 @@ xla_workspace3()
 # Details: https://github.com/google-ml-infra/rules_ml_toolchain
 tf_http_archive(
     name = "rules_ml_toolchain",
-    sha256 = "f2c924e85a22ba2eaa0c08657e5f5467fedbc3d0506f9cc0c69dd97ed9fbaf28",
-    strip_prefix = "rules_ml_toolchain-99c43dfe995a0e81c767d5b6d686191992672fe6",
+    sha256 = "cb7635622ea526c8923a5ead6e99dc2ba55cde6ae9613bf9b2d34b3f000f29ce",
+    strip_prefix = "rules_ml_toolchain-84ac62e4db38215a2a7d3ad8cd4d7452134e3ec6",
     urls = tf_mirror_urls(
-        "https://github.com/google-ml-infra/rules_ml_toolchain/archive/99c43dfe995a0e81c767d5b6d686191992672fe6.tar.gz",
+        "https://github.com/google-ml-infra/rules_ml_toolchain/archive/84ac62e4db38215a2a7d3ad8cd4d7452134e3ec6.tar.gz",
     ),
 )
 

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -115,10 +115,48 @@ export NPROC=32
 LOGS_DIR="logs"
 mkdir -p "${LOGS_DIR}"
 mkdir -p test-artifacts
+
+# Don't abort the script if one command fails to ensure we run both test
+# commands below.
+set +e
+
+# Run single-accelerator tests in parallel
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
---json-report --json-report-file=${LOGS_DIR}/pytest_results.json \
---junitxml=test-artifacts/junit.xml \
-tests \
+--json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
+--junitxml=test-artifacts/junit-single.xml \
+--dist=loadfile \
+-m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
---deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric
+--deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+tests
+
+first_cmd_retval=$?
+
+if [[ $gpu_count -gt 1 ]]; then
+  # Run multi-accelerator tests across all GPUs without xdist.
+  unset JAX_ENABLE_ROCM_XDIST
+
+  "$JAXCI_PYTHON" -m pytest --tb=short \
+    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
+    --junitxml=test-artifacts/junit-multi.xml \
+    -m "multiaccelerator" \
+    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+    --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
+    --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+    tests
+
+  second_cmd_retval=$?
+else
+  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
+  second_cmd_retval=0
+fi
+
+# Exit with failure if either command fails.
+if [[ $first_cmd_retval -ne 0 ]]; then
+  exit $first_cmd_retval
+elif [[ $second_cmd_retval -ne 0 ]]; then
+  exit $second_cmd_retval
+else
+  exit 0
+fi

--- a/conftest.py
+++ b/conftest.py
@@ -82,3 +82,8 @@ def pytest_collection() -> None:
     os.environ["ROCR_VISIBLE_DEVICES"] = str(
         xdist_worker_number % num_rocm_devices
     )
+    # ROCR_VISIBLE_DEVICES filters HSA to a single physical device, which
+    # becomes HIP index 0. The container env-file may preset
+    # HIP_VISIBLE_DEVICES to all GPUs; override to "0" so HIP doesn't try to
+    # enable agents that ROCr just hid.
+    os.environ["HIP_VISIBLE_DEVICES"] = "0"

--- a/conftest.py
+++ b/conftest.py
@@ -79,6 +79,6 @@ def pytest_collection() -> None:
     if not xdist_worker_name.startswith("gw"):
       return
     xdist_worker_number = int(xdist_worker_name[len("gw") :])
-    os.environ.setdefault(
-        "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
+    os.environ["ROCR_VISIBLE_DEVICES"] = str(
+        xdist_worker_number % num_rocm_devices
     )

--- a/jaxlib/rocm/BUILD
+++ b/jaxlib/rocm/BUILD
@@ -499,6 +499,7 @@ rocm_nanobind_extension(
 
 py_library(
     name = "rocm_gpu_support",
+    visibility = ["//visibility:public"],
     deps = [
         ":_hybrid",
         ":_linalg",
@@ -553,6 +554,7 @@ rocm_nanobind_extension(
     srcs = ["rocm_plugin_extension.cc"],
     enable_stub_generation = False,
     module_name = "rocm_plugin_extension",
+    visibility = ["//visibility:public"],
     deps = [
         ":py_client_gpu",
         "//jaxlib:kernel_nanobind_helpers",


### PR DESCRIPTION
This PR cherry picks the commits that have been merged but did not make it into the 0.10.0 release.

Selected commits:

- Fix visibility in BUILD files (https://github.com/ROCm/jax/commit/3992836e1149f960d331988ac1fe7d54848dcc86)
- Use CloudFront download for ROCm wheels instead of S3 (https://github.com/jax-ml/jax/commit/0874961e81a173e4b158232dff47f98ed33a3a7a)
- Split ROCm pytest into single- and multi-accelerator passes (https://github.com/jax-ml/jax/commit/7cb36e57959f5a0a7e9d0db69918ea319e7d0e8f)
-  Override HIP_VISIBLE_DEVICES per ROCm xdist worker (https://github.com/jax-ml/jax/commit/c0badd6340c2ea79297407944abf0e31ada53056)
- Update rules_ml_toolchain reference (https://github.com/jax-ml/jax/commit/1808cfa00b8171a9153c6e2a235ca00d8949237a)