### PR TITLE
[ROCm] Cherry-pick: Fix inter-block write race in pallas test_non_range_while_loop

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -2014,10 +2014,6 @@ class PallasControlFlowTest(ptu.PallasTest):
     """Tests lowering of a while_loop which cannot reduce to a fori_loop."""
 
     def kernel(x_ref, r_ref):
-      @pl.when(pl.program_id(0) == 0)
-      def _():
-        r_ref[0, 0] = 0
-
       def cond(state):
         i, s = state
         return jnp.logical_and(i < 1024, s < 1024)
@@ -2026,24 +2022,24 @@ class PallasControlFlowTest(ptu.PallasTest):
         i, s = state
         sl = jax.lax.div(i, jnp.astype(128, i.dtype))
         l = jax.lax.rem(i, jnp.astype(128, i.dtype))
-        v = x_ref[0, sl, l]
+        v = x_ref[sl, l]
         return i + 1, s + v
 
-      i = jnp.int32(0)
-      _, r_ref[0, 0] = jax.lax.while_loop(cond, body, (i, r_ref[0, 0]))
+      _, r_ref[0, 0] = jax.lax.while_loop(
+          cond, body, (jnp.int32(0), jnp.zeros((), intx)))
 
-    x = jnp.arange(4096)
-    x = jnp.reshape(x, [4, 8, 128])
+    x = jnp.arange(1024)
+    x = jnp.reshape(x, [8, 128])
 
     r = pl.pallas_call(
         kernel,
-        grid=(4,),
+        grid=(1,),
         out_specs=pl.BlockSpec((1, 1), memory_space=smem_on_tpu()),
         out_shape=jax.ShapeDtypeStruct([1, 1], intx),
         in_specs=[
             pl.BlockSpec(
-                (1, 8, 128),
-                lambda i: (i, 0, 0),
+                (8, 128),
+                lambda i: (0, 0),
                 memory_space=smem_on_tpu(),
             )
         ],


### PR DESCRIPTION
Cherry-pick of upstream [jax-ml/jax#37183](https://github.com/jax-ml/jax/pull/37183)
(commit `c7b37967bfca8a3a549159b7109cbfb4b7cb1470`).

> Note: upstream PR #37183 is still OPEN at the time of this cherry-pick.
> If the upstream PR is amended / rebased before merge, this downstream
> commit may need to be refreshed.

---

## Original PR description

**Update:**
As per feedback changed the test to use `grid=(1,)` instead. so that below racey condition never triggers.

**Explanation related to original change:**
The kernel uses `grid=(4,)` with all blocks writing to a single shared output cell `r_ref[0,0]`. The init store is correctly guarded by `@pl.when(pl.program_id(0) == 0)`, but the final store after `jax.lax.while_loop` is not, so 4 grid blocks race to write to the same global cell with no atomic, no fence, no across-block guard.

Per the test setup, the per-block local accumulators are:
- block 0: 1035 (loops 46 iters until accumulator >= 1024)
- block 1: 1024, block 2: 2048, block 3: 3072 (each exits after 1 iter)

Bug is more clear at assembly level — see the upstream PR for the full annotated ISA showing the unguarded `global_store_dword` after the while-loop and the corresponding fixed ISA after restricting to a single block via `grid=(1,)`.
