### PR TITLE
jaxlib/gpu/rnn_kernels.cc: remove premature input_tensor_desc destruction (ROCM-21859)

### DIFF
--- a/jaxlib/gpu/rnn_kernels.cc
+++ b/jaxlib/gpu/rnn_kernels.cc
@@ -360,8 +360,8 @@ static absl::Status DnnRNNForward_(gpuStream_t stream, void** buffers,
 
   return absl::OkStatus();
 }
-}
 
+static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,
 static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,
                                     const char* opaque, size_t opaque_len) {
   auto s = UnpackDescriptor<RnnDescriptor>(opaque, opaque_len);

--- a/jaxlib/gpu/rnn_kernels.cc
+++ b/jaxlib/gpu/rnn_kernels.cc
@@ -356,10 +356,10 @@ static absl::Status DnnRNNForward_(gpuStream_t stream, void** buffers,
   JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpudnnDestroyRNNDescriptor(rnn_desc)));
 #ifdef JAX_GPU_HIP
   JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpuFree(dropout_states_dev)));
-  JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpudnnDestroyTensorDescriptor(input_tensor_desc)));
 #endif
 
   return absl::OkStatus();
+}
 }
 
 static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,

--- a/jaxlib/gpu/rnn_kernels.cc
+++ b/jaxlib/gpu/rnn_kernels.cc
@@ -362,7 +362,6 @@ static absl::Status DnnRNNForward_(gpuStream_t stream, void** buffers,
 }
 
 static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,
-static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,
                                     const char* opaque, size_t opaque_len) {
   auto s = UnpackDescriptor<RnnDescriptor>(opaque, opaque_len);
   JAX_RETURN_IF_ERROR(s.status());
@@ -545,7 +544,6 @@ static absl::Status DnnRNNBackward_(gpuStream_t stream, void** buffers,
   JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpudnnDestroyRNNDescriptor(rnn_desc)));
 #ifdef JAX_GPU_HIP
   JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpuFree(dropout_states_dev)));
-  JAX_RETURN_IF_ERROR(JAX_AS_STATUS(gpudnnDestroyTensorDescriptor(input_tensor_desc)));
 #endif
 
   return absl::OkStatus();


### PR DESCRIPTION
## Problem

PR #726 ("Fix HIP memory leaks in RNN kernels", merged 2026-03-05) added
`gpudnnDestroyTensorDescriptor(input_tensor_desc)` inside the `#ifdef JAX_GPU_HIP`
cleanup blocks at the end of both `DnnRNNForward_` and `DnnRNNBackward_`.

MIOpen requires `input_tensor_desc` to remain valid throughout the
`gpudnnRNNBackwardWeights` call — it uses the descriptor as part of its
execution buffer. Destroying it in the forward / workspace-sizing path before
`BackwardWeights` completes triggers `miopenStatusUnknownError` on gfx1201
(Navi48 / RDNA4).

This regressed `experimental_rnn_test::test_lstm1` and `test_lstm9` on gfx1201
(first seen in image 1317, built 2026-04-29, ROCm 7.13.0). The same root cause
was independently identified by PR #729 / PR #730.

## Fix

Remove the two `gpudnnDestroyTensorDescriptor(input_tensor_desc)` lines from
the `#ifdef JAX_GPU_HIP` cleanup blocks in `DnnRNNForward_` and `DnnRNNBackward_`.
`input_tensor_desc` lifetime is managed by MIOpen internally; the explicit destroy
here is both premature and incorrect.

## Tests

- `tests/experimental_rnn_test.py::RNNTest::test_lstm1`
- `tests/experimental_rnn_test.py::RNNTest::test_lstm9`

## References

- ROCM-21859: https://amd-hub.atlassian.net/browse/ROCM-21859
- Regression introducer: PR #726
- Equivalent fix (v0.9.0): PR #729, PR #730
