### PR TITLE
Rename the benchmarks workflow consistently

### DIFF
--- a/.github/workflows/wheel_benchmarks_nightly_release.yml
+++ b/.github/workflows/wheel_benchmarks_nightly_release.yml
@@ -1,4 +1,4 @@
-name: CI - Wheel Tests (Nightly/Release)
+name: CI - Wheel Benchmarks (Nightly/Release)
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This PR renames the benchmarks workflow to avoid duplicate workflow names. No functional changes.