### PR TITLE
Cherry-pick test updates. 

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -115,8 +115,51 @@ echo "Running ROCm tests..."
 # TODO: Verify if CSV/HTML report generation should be kept (unique to ROCm)
 # TODO: Verify if log file output should be kept (unique to ROCm)
 export NPROC=32
+LOGS_DIR="logs"
+mkdir -p "${LOGS_DIR}"
+mkdir -p test-artifacts
+
+# Don't abort the script if one command fails to ensure we run both test
+# commands below.
+set +e
+
+# Run single-accelerator tests in parallel
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
-tests \
+--json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
+--junitxml=test-artifacts/junit-single.xml \
+--dist=loadfile \
+-m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
---deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric
+--deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+tests
+
+first_cmd_retval=$?
+
+if [[ $gpu_count -gt 1 ]]; then
+  # Run multi-accelerator tests across all GPUs without xdist.
+  unset JAX_ENABLE_ROCM_XDIST
+
+  "$JAXCI_PYTHON" -m pytest --tb=short \
+    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
+    --junitxml=test-artifacts/junit-multi.xml \
+    -m "multiaccelerator" \
+    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+    --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
+    --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+    tests
+
+  second_cmd_retval=$?
+else
+  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
+  second_cmd_retval=0
+fi
+
+# Exit with failure if either command fails.
+if [[ $first_cmd_retval -ne 0 ]]; then
+  exit $first_cmd_retval
+elif [[ $second_cmd_retval -ne 0 ]]; then
+  exit $second_cmd_retval
+else
+  exit 0
+fi

--- a/conftest.py
+++ b/conftest.py
@@ -82,3 +82,8 @@ def pytest_collection() -> None:
     os.environ.setdefault(
         "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
     )
+    # ROCR_VISIBLE_DEVICES filters HSA to a single physical device, which
+    # becomes HIP index 0. The container env-file may preset
+    # HIP_VISIBLE_DEVICES to all GPUs; override to "0" so HIP doesn't try to
+    # enable agents that ROCr just hid.
+    os.environ["HIP_VISIBLE_DEVICES"] = "0"

--- a/conftest.py
+++ b/conftest.py
@@ -79,8 +79,8 @@ def pytest_collection() -> None:
     if not xdist_worker_name.startswith("gw"):
       return
     xdist_worker_number = int(xdist_worker_name[len("gw") :])
-    os.environ.setdefault(
-        "ROCR_VISIBLE_DEVICES", str(xdist_worker_number % num_rocm_devices)
+    os.environ["ROCR_VISIBLE_DEVICES"] = str(
+        xdist_worker_number % num_rocm_devices
     )
     # ROCR_VISIBLE_DEVICES filters HSA to a single physical device, which
     # becomes HIP index 0. The container env-file may preset


### PR DESCRIPTION
This PR divides the testing process to sgpu and mgpu
Cherry-picked [Override HIP_VISIBLE_DEVICES per ROCm xdist worker](https://github.com/ROCm/jax/commit/bd4e8dec8d80aaac0302ab95ab7db1b20a20d27f) and [[ROCm] Split ROCm pytest into single- and multi-accelerator passes](https://github.com/ROCm/jax/commit/091bea882a7c5c9815d1eec96bd43ba872b36f01)

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->