### PR TITLE
Skip failing tests

### DIFF
--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -570,7 +570,12 @@ class NumpyLinalgTest(jtu.JaxTestCase):
           np.linalg.norm(np.matmul(a, v) - w * v), 2.5 * eps * np.linalg.norm(a)
       )
 
+
   def testEighTinyNorm(self):
+    if jtu.is_device_rocm():
+      # numerical errors seen as of ROCm 7.2 due to hipSolver issue
+      # TODO: re-enable the test once the hipSolver issue is fixed
+      self.skipTest("testEighNorm not supported on ROCm due to hipSOLVER issue")
     rng = jtu.rand_default(self.rng())
     a = rng((300, 300), dtype=np.float32)
     eps = jnp.finfo(a.dtype).eps

--- a/tests/linalg_test.py
+++ b/tests/linalg_test.py
@@ -2376,6 +2376,7 @@ class LaxLinalgTest(jtu.JaxTestCase):
 
   @jtu.sample_product(shape=[(3,), (3, 4), (3, 4, 5)],
                       dtype=float_types + complex_types)
+  @jtu.skip_on_devices("rocm")  # Numerical errors on ROCm
   def test_tridiagonal_solve(self, shape, dtype):
     if dtype not in float_types and jtu.test_device_matches(["gpu"]):
       self.skipTest("Data type not supported on GPU")


### PR DESCRIPTION
Cherry-pick [Skipping testEighTinyNorm due to hipSolver issues](https://github.com/ROCm/jax/commit/8063b95fd6d9be490de324b5ee9a10c93801bb8d) and [Skip test_tridiagonal_solve on ROCm due to hipSPARSE numerical errors](https://github.com/ROCm/jax/commit/b5aec550fbb220227665051ff18015deae667bbd)
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->