### PR TITLE
Skip ann_test test_pmap on ROCm due to IndivisibleError

### DIFF
--- a/tests/ann_test.py
+++ b/tests/ann_test.py
@@ -121,6 +121,10 @@ class AnnTest(jtu.JaxTestCase):
     num_devices = jax.device_count()
     if num_devices % 2 != 0:
       self.skipTest("Works only when number of devices is a multiple of 2.")
+    # TODO(araganes): Re-enable once upstream HloShardingV3 lands (JAX 0.9.2+).
+    # New pmap's SPMD tiling can't convert back to 1D pmap mesh on ROCm.
+    if jtu.is_device_rocm():
+      self.skipTest("IndivisibleError: SPMD tiling incompatible with 1D pmap mesh on ROCm")
     rng = jtu.rand_default(self.rng())
     qy = rng(qy_shape, dtype)
     db = rng(db_shape, dtype)


### PR DESCRIPTION
## Motivation

`AnnTest::test_pmap` fails on ROCm with `jax._src.sharding.IndivisibleError: shape=[1, 2, 4] is incompatible with mesh_shape=...` after the JAX 0.8.2 → 0.9.1 bump.

Inside `jax.pmap`, `lax.approx_min_k(..., aggregate_to_topk=False)` produces an XLA SPMD tile `{devices=[1,2,4]<=[8] last_tile_dim_replicate}`. JAX 0.9.x's new `_gspmd_to_named_sharding_via_mesh` → `parse_flatten_op_sharding` path then tries to translate this 3-D tile back into the 1-D pmap mesh of size 8 and fails, since `[1, 2, 4]` cannot factor into a 1-D mesh.


## Technical Details

Cherry-pick of upstream commit `596683446be555baf6dbf7803d45e51eb33bdcd1` onto `rocm-jaxlib-v0.9.1`. Adds a ROCm-only `skipTest` guard in `AnnTest.test_pmap` (`tests/ann_test.py`):

if jtu.is_device_rocm():
  self.skipTest("IndivisibleError: SPMD tiling incompatible with 1D pmap mesh on ROCm")
