### PR TITLE
Remove outdated ROCm skip that depends on ROCm versions < 6.4

### DIFF
--- a/tests/sparse_test.py
+++ b/tests/sparse_test.py
@@ -42,15 +42,6 @@ from jax._src.util import split_list
 import numpy as np
 import scipy.sparse
 
-def get_rocm_version():
-  rocm_path = os.environ.get("ROCM_PATH", "/opt/rocm")
-  version_path = Path(rocm_path) / ".info" / "version"
-  if not version_path.exists():
-    raise FileNotFoundError(f"Expected ROCm version file at {version_path}")
-  version_str = version_path.read_text().strip()
-  major, minor, *_ = version_str.split(".")
-  return int(major), int(minor)
-
 jax.config.parse_flags_with_absl()
 
 all_dtypes = jtu.dtypes.integer + jtu.dtypes.floating + jtu.dtypes.complex
@@ -246,14 +237,6 @@ class cuSparseTest(sptu.SparseTestCase):
       transpose=[True, False],
   )
   def test_csr_matmat(self, shape, dtype, transpose):
-    if (
-        jtu.is_device_rocm() and
-        get_rocm_version() < (6, 4) and
-        dtype in (jtu.dtypes.floating + jtu.dtypes.complex)
-    ):
-      # TODO: Remove this check when ROCm 6.4+ is the minimum supported version
-      self.skipTest("ROCm <6.4 bug: NaN propagation when beta==0 (fixed in ROCm 6.4.0)")
-
     op = lambda M: M.T if transpose else M
 
     B_rng = jtu.rand_default(self.rng())


### PR DESCRIPTION
Note: this ROCm version check doesn't work on TheRock if /opt/rocm symlink is not present, which will not be present.
<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->