### PR TITLE
Bundle specific and generic arch build targets together.

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -17,7 +17,7 @@ common:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 common:rocm --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress
 common:rocm --copt=-Wno-gnu-offsetof-extensions
 common:rocm --copt=-Qunused-arguments
-common:rocm --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201"
+common:rocm --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx908,gfx90a,gfx942,gfx950,gfx1030,gfx1100,gfx1101,gfx1200,gfx1201,gfx9-4-generic,gfx10-3-generic,gfx11-generic,gfx12-generic"
 
 # Used for @xla//build_tools/rocm:parallel_gpu_execute
 common:rocm --legacy_external_runfiles=true


### PR DESCRIPTION
This PR is needed in order to build release wheels with generic targets while also passing all unit tests. ROCPrim currently has an issue with building cub sort for generic arch targets so the specific arch target should be used here instead.

This PR keeps the specific arch build targets used in upstream wheel building but also adds the generic arch build targets that were used in rocm-jax for release wheels.