### PR TITLE
[ROCm] Skip TF32 dot algorithm tests on Navi/RDNA GPUs

### DIFF
--- a/tests/lax_test.py
+++ b/tests/lax_test.py
@@ -1180,6 +1180,15 @@ class LaxTest(jtu.JaxTestCase):
           raise SkipTest(
               f"The dot algorithm '{algorithm}' requires CUDA compute "
               "capability >= 8.0.")
+        # TF32 is not supported on Navi/RDNA GPUs. XLA only allows it on
+        # MI100+ (gfx9 CDNA) -- see xla/service/algorithm_util.cc.
+        if (algorithm in {lax.DotAlgorithmPreset.TF32_TF32_F32,
+                          lax.DotAlgorithmPreset.TF32_TF32_F32_X3}
+            and jtu.is_device_rocm()
+            and "Radeon" in jax.local_devices()[0].device_kind):
+          raise SkipTest(
+              f"The dot algorithm '{algorithm}' is not supported on "
+              "Navi/RDNA GPUs.")
       elif algorithm not in {
           lax.DotAlgorithmPreset.DEFAULT,
           lax.DotAlgorithmPreset.ANY_F8_ANY_F8_F32,
@@ -1189,15 +1198,6 @@ class LaxTest(jtu.JaxTestCase):
       }:
         raise SkipTest(
             f"The dot algorithm '{algorithm}' is not supported on GPU.")
-    if jtu.test_device_matches(["tpu"]):
-      if algorithm not in {
-          lax.DotAlgorithmPreset.DEFAULT,
-          lax.DotAlgorithmPreset.BF16_BF16_F32,
-          lax.DotAlgorithmPreset.BF16_BF16_F32_X3,
-          lax.DotAlgorithmPreset.BF16_BF16_F32_X6,
-      }:
-        raise SkipTest(
-            f"The dot algorithm '{algorithm}' is not supported on TPU."
         )
     lhs_shape = (3, 4)
     rhs_shape = (4, 3)


### PR DESCRIPTION
## Summary

Cherry-pick the Navi/RDNA TF32 skip guard from `rocm-jaxlib-v0.8.2` to `rocm-jaxlib-v0.9.1`.

- Skip `TF32_TF32_F32` and `TF32_TF32_F32_X3` dot algorithm tests on Radeon/RDNA GPUs
- TF32 is only supported on CDNA GPUs (MI100+/gfx9) via MFMA instructions; RDNA GPUs lack this hardware
- The test was being skipped on v0.8.2 but fails on v0.9.1 due to upstream [jax-ml/jax#34534](https://github.com/jax-ml/jax/pull/34534) changing the skip guard to CUDA-only

## Root Cause

Upstream PR [jax-ml/jax#34534](https://github.com/jax-ml/jax/pull/34534) (merged 2026-02-11 by `magaonka-amd`) changed the TF32 skip logic from:
```python
if not jtu.is_cuda_compute_capability_at_least("8.0"):
```
to:
```python
if jtu.test_device_matches(["cuda"]) and not jtu.is_cuda_compute_capability_at_least("8.0"):
```

This correctly enables TF32 tests on ROCm CDNA GPUs (MI100+) but also unblocks them on RDNA GPUs (Navi/Radeon) where XLA's `gfx9_mi100_or_later()` gate correctly returns `UNIMPLEMENTED`.

The `rocm-jaxlib-v0.8.2` branch had a supplementary skip block (via [ROCm/jax#635](https://github.com/ROCm/jax/pull/635)) that checked `"Radeon" in device_kind` to skip TF32 on RDNA GPUs. This was never upstreamed or cherry-picked to v0.9.1.

## Test plan

- [ ] Run `tests/lax_test.py::LaxTest::testDotAlgorithm13` on Navi4x/gfx1201 — should now be **SKIPPED** instead of **FAILED**
- [ ] Run full `testDotAlgorithm` suite on MI300X/gfx942 — TF32 tests should still **PASS**
- [ ] Run full `testDotAlgorithm` suite on Navi4x — non-TF32 tests should still pass, TF32 variants skipped

Fixes: [ROCM-25363](https://amd-hub.atlassian.net/browse/ROCM-25363)

[ROCM-25363]: https://amd-hub.atlassian.net/browse/ROCM-25363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ