### PR TITLE
[ROCm] Enable HLO module transform registration for GPU backends

### DIFF
--- a/jax/_src/BUILD
+++ b/jax/_src/BUILD
@@ -1299,6 +1299,7 @@ pytype_strict_library(
         ":config",
         ":core",
         ":layout",
+        ":mesh",
         ":mlir",
         ":sharding",
         ":sharding_impls",

--- a/jax/_src/api.py
+++ b/jax/_src/api.py
@@ -1284,9 +1284,10 @@ def _mapped_axis_size(fn, tree, vals, dims, name, axis_size=None):
         f"*args={args} and **kwargs={kwargs}"
     )
 
-  def _get_axis_size(name: str, x, shape: tuple[core.AxisSize, ...], axis: int
-                     ) -> core.AxisSize | None:
+  def _get_axis_size(name: str, x, axis: int) -> core.AxisSize | None:
+    shape: tuple[core.AxisSize, ...] = ()
     try:
+      shape = np.shape(x)
       return shape[axis]
     except (IndexError, TypeError) as e:
       if not core.valid_jaxtype(x) or not isinstance(axis, int):
@@ -1299,7 +1300,7 @@ def _mapped_axis_size(fn, tree, vals, dims, name, axis_size=None):
           f"but is only {len(shape)} (its shape is {shape})") from e
 
   all_mapped_sizes = [
-    None if d is None else _get_axis_size(name, x, np.shape(x), d)
+    None if d is None else _get_axis_size(name, x, d)
     for x, d in zip(vals, dims)
   ]
   all_sizes = [s for s in all_mapped_sizes if s is not None]

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -3846,11 +3846,15 @@ class ShapeDtypeStruct:
   def like(cls, x) -> ShapeDtypeStruct:
     from jax._src.state.types import AbstractRef  # pyrefly: ignore[missing-import]
     from jax._src.array import ArrayImpl  # pyrefly: ignore[missing-import]
+    from jax._src.hijax import HiType  # pyrefly: ignore[missing-import]
     aval = shaped_abstractify(x)
     if isinstance(aval, AbstractRef):
       raise NotImplementedError(
           "Ref/AbstractRef support is not implemented. Please file an issue at"
           " https://github.com/jax-ml/jax/issues")
+    if isinstance(aval, HiType):
+      raise NotImplementedError(
+          "Passing a HiVal to `ShapeDtypeStruct.like` is not implemented.")
     aval_s = None if aval.sharding.mesh.empty else aval.sharding
     if getattr(x, '_committed', True):
       sharding = (x.format if isinstance(x, ArrayImpl) else

--- a/jax/_src/core.py
+++ b/jax/_src/core.py
@@ -633,8 +633,6 @@ class Primitive:
   ref_primitive: bool = False
   # set for primitives that can skip canonicalization of values
   skip_canonicalization: bool = False
-  # hook for converting a hijax primitive to a lojax primitive
-  to_lojax: Callable[..., Any] | None = None
   # set for primitives that allocate references
   ref_allocating: bool = False
 
@@ -702,7 +700,15 @@ class Primitive:
   def get_bind_params(self, params):
     return params
 
+  def to_lojax(self, *args, **params):
+    raise NotImplementedError(
+        f"Primitive '{self.name}' has is_high=True but no to_lojax "
+        f"lowering rule.")
+
   def is_high(self, *avals, **params) -> bool:
+    for v in params.values():
+      if isinstance(v, (Jaxpr, ClosedJaxpr)) and v.is_high:
+        return True
     return False
 
 

--- a/jax/_src/custom_batching.py
+++ b/jax/_src/custom_batching.py
@@ -351,6 +351,7 @@ batching.primitive_batchers[custom_vmap_p] = custom_vmap_batching
 ad.primitive_jvps[custom_vmap_p] = custom_vmap_jvp
 mlir.register_lowering(custom_vmap_p, mlir.lower_fun(
     custom_vmap_impl, multiple_results=True))
+custom_vmap_p.to_lojax = custom_vmap_impl
 
 
 # -- custom vmap applications

--- a/jax/_src/hypothesis_test_util.py
+++ b/jax/_src/hypothesis_test_util.py
@@ -20,6 +20,7 @@ import os
 import unittest
 
 import hypothesis as hp
+from hypothesis import errors as hp_errors
 from hypothesis.internal import detection
 from hypothesis.internal import reflection
 from hypothesis.strategies._internal import core as hps_internal_core
@@ -54,6 +55,12 @@ def _shard_aware_hypothesis_inner_test(inner_test):
     if _TEST_TOTAL_SHARDS == 1:
       return inner_test(*args, **kwargs)
 
+    # If we have already encountered a failure in this test case execution,
+    # assume we are in shrinking/explain phase, which won't work with sharding.
+    self = kwargs["self"] if "self" in kwargs else args[0]
+    if getattr(self, "_hypothesis_failed", False):
+      return inner_test(*args, **kwargs)
+
     mod = hypothesis_inner_test_shard(
         inner_test, args, kwargs, _TEST_TOTAL_SHARDS
     )
@@ -62,7 +69,14 @@ def _shard_aware_hypothesis_inner_test(inner_test):
       # will skip the *entire* test, not just the current example.
       return None
     else:
-      return inner_test(*args, **kwargs)
+      try:
+        return inner_test(*args, **kwargs)
+      # Skipped tests aren't failures and don't trigger shrinking phase.
+      except (hp_errors.UnsatisfiedAssumption, unittest.SkipTest):
+        raise
+      except Exception:
+        self._hypothesis_failed = True
+        raise
 
   return shard_aware_inner_test_fn
 

--- a/jax/_src/mesh.py
+++ b/jax/_src/mesh.py
@@ -579,6 +579,31 @@ empty_abstract_mesh = AbstractMesh((), ())
 empty_concrete_mesh = Mesh(np.empty((), dtype=object), ())
 
 class use_abstract_mesh:
+  """Sets a abstract mesh in a thread-local context.
+
+  ``jax.sharding.use_abstract_mesh`` can be used as a context manager.
+
+  For example::
+
+    abstract_device = jax.sharding.AbstractDevice(
+        device_kind='TPU v6 lite', num_cores=1, platform='tpu')
+    abstract_mesh = jax.sharding.AbstractMesh((2,), ('x',), (AxisType.Explicit,),
+                                               abstract_device=abstract_device)
+
+    @jax.jit
+    def f(x):
+      return x * 2
+
+    with jax.sharding.use_abstract_mesh(abstract_mesh):
+      # Note: `f` will be traced and lowered for TPU platform.
+      f.trace(inp).lower()
+      # Note: `f` will be traced for TPU and lowered for CPU.
+      f.trace(inp).lower(lowering_platforms=('cpu',))
+
+  Note: In the example above, setting the abstract mesh at the top level only
+        takes effect if all mesh axes are Explicit. This is temporary until we
+        fix the underlying issues.
+  """
   __slots__ = ['mesh', 'prev']
 
   def __init__(self, mesh: AbstractMesh):

--- a/jax/_src/numpy/ufuncs.py
+++ b/jax/_src/numpy/ufuncs.py
@@ -3706,7 +3706,8 @@ def heaviside(x1: ArrayLike, x2: ArrayLike, /) -> Array:
   x1, x2 = promote_dtypes_inexact(x1, x2)
   zero = _lax_const(x1, 0)
   return _where(lax.lt(x1, zero), zero,
-                _where(lax.gt(x1, zero), _lax_const(x1, 1), x2))
+                _where(lax.gt(x1, zero), _lax_const(x1, 1),
+                       _where(lax._isnan(x1), x1, x2)))
 
 
 @export

--- a/jax/_src/pallas/mosaic/lowering.py
+++ b/jax/_src/pallas/mosaic/lowering.py
@@ -52,6 +52,7 @@ from jax._src.lax import control_flow
 from jax._src.lax import lax as lax_internal
 from jax._src.lax.control_flow import BranchesPlatforms
 from jax._src.lib import jax_mlir_ext
+from jax._src.lib import jaxlib_extension_version
 from jax._src.lib import xla_client
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith
@@ -4597,10 +4598,11 @@ def _device_id_to_logical(
 
     # We resolve the axis indices in the code below. We already asserted that
     # the required axis names are present in the current kernel type's mesh.
+    subcore_index = None
     if dest_kernel_type == tpu_core.CoreType.SC_VECTOR_SUBCORE:
       if not mpmd_core_axis_names and dest_kernel_type == kernel_type:
         # short circuit for same core semaphores without a core type annotation
-        return logical_device_id, None
+        return logical_device_id, None, None
       assert isinstance(dest_mesh, sc_core.VectorSubcoreMesh), (
           f"Unrecognized dest_mesh: {type(dest_mesh)} != VectorSubcoreMesh")
       sc_info = tpu_info.get_tpu_info().sparse_core
@@ -4609,11 +4611,15 @@ def _device_id_to_logical(
         core_id = lax.axis_index(dest_mesh.core_axis_name)
       if (subcore_id := core_index_map[dest_mesh.subcore_axis_name]) is None:
         subcore_id = lax.axis_index(dest_mesh.subcore_axis_name)
-      core_index = sc_info.num_subcores * core_id + subcore_id
+      if jaxlib_extension_version < 462:
+        core_index = sc_info.num_subcores * core_id + subcore_id
+      else:
+        core_index = core_id
+        subcore_index = subcore_id
     elif dest_kernel_type == tpu_core.CoreType.SC_SCALAR_SUBCORE:
       if not mpmd_core_axis_names and dest_kernel_type == kernel_type:
         # short circuit for same core semaphores without a core type annotation
-        return logical_device_id, None
+        return logical_device_id, None, None
       assert isinstance(dest_mesh, sc_core.ScalarSubcoreMesh), (
           f"Unrecognized dest_mesh: {type(dest_mesh)} != ScalarSubcoreMesh")
       if (core_id := core_index_map[dest_mesh.axis_name]) is None:
@@ -4636,7 +4642,7 @@ def _device_id_to_logical(
       else:
         raise ValueError(
             f"Expected zero or one core index, got {core_index_map=}.")
-    return logical_device_id, core_index
+    return logical_device_id, core_index, subcore_index
 
   return lower_fun(jax_fn, in_avals=(device_id_aval,))(ctx, device_id)
 
@@ -4687,10 +4693,11 @@ def _semaphore_signal_lowering_rule(
   else:
     dest_mesh = None
     dest_kernel_type = kernel_type
+  subcore_index = None
   if device_id is not None or dest_kernel_type != kernel_type:
     # TODO(rdyro): Unify the `core_index` argument to use core meshes instead.
     with ctx.lowering_context.grid_name_context():
-      device_id, core_id = _device_id_to_logical(
+      device_id, core_id, subcore_index = _device_id_to_logical(
           ctx, device_id, device_id_type, device_id_aval,
           dest_mesh=dest_mesh
       )
@@ -4700,7 +4707,14 @@ def _semaphore_signal_lowering_rule(
             "Cannot specify both `core_index` and the core axis in `device_id`."
         )
       core_index = core_id
-  tpu.sem_signal(sem, value, device_id=device_id, core_id=core_index)
+  if jaxlib_extension_version < 462:
+    assert subcore_index is None, (
+        "`subcore_index` is not supported in this version of jaxlib."
+    )
+    tpu.sem_signal(sem, value, device_id=device_id, core_id=core_index)
+  else:
+    tpu.sem_signal(sem, value, device_id=device_id, core_id=core_index,
+                   subcore_id=subcore_index)  # pyrefly: ignore[unexpected-keyword]
   return []
 
 
@@ -4743,22 +4757,38 @@ def _dma_start_lowering_rule(
     dest_mesh = None
     dest_kernel_type = kernel_type
   core_id = None
+  subcore_id = None
   if device_id is not None or dest_kernel_type != kernel_type:
     with ctx.lowering_context.grid_name_context():
-      device_id, core_id = _device_id_to_logical(
+      device_id, core_id, subcore_id = _device_id_to_logical(
           ctx, device_id, device_id_type, device_id_aval, dest_mesh=dest_mesh
       )
 
   def _dma_start(src_ref, dst_ref, sem, src_sem) -> list[ir.Value]:
-    tpu.enqueue_dma(
-        source=src_ref,
-        target=dst_ref,
-        target_semaphore=sem,
-        source_semaphore=src_sem,
-        device_id=device_id,
-        core_id=core_id,
-        priority=priority,
-    )
+    if jaxlib_extension_version < 462:
+      assert subcore_id is None, (
+          "`subcore_id` is not supported in this version of jaxlib."
+      )
+      tpu.enqueue_dma(
+          source=src_ref,
+          target=dst_ref,
+          target_semaphore=sem,
+          source_semaphore=src_sem,
+          device_id=device_id,
+          core_id=core_id,
+          priority=priority,
+      )
+    else:
+      tpu.enqueue_dma(
+          source=src_ref,
+          target=dst_ref,
+          target_semaphore=sem,
+          source_semaphore=src_sem,
+          device_id=device_id,
+          core_id=core_id,
+          subcore_id=subcore_id,  # pyrefly: ignore[unexpected-keyword]
+          priority=priority,
+      )
     return []
 
   return lower_with_transformed_refs(
@@ -4786,7 +4816,7 @@ def _dma_wait_lowering_rule(ctx: LoweringRuleContext, *args, tree,
       dest_mesh = sem_aval.memory_space.mesh
     else:
       dest_mesh = None
-    device_id, core_id = _device_id_to_logical(
+    device_id, core_id, _ = _device_id_to_logical(
         ctx, device_id, device_id_type, device_id_aval, dest_mesh=dest_mesh
     )
   else:

--- a/jax/_src/pallas/mosaic/sc_lowering.py
+++ b/jax/_src/pallas/mosaic/sc_lowering.py
@@ -24,6 +24,7 @@ from jax._src import numpy as jnp
 from jax._src import state
 from jax._src import tree_util
 from jax._src import util
+from jax._src.lib import jaxlib_extension_version
 from jax._src.lib.mlir import ir
 from jax._src.lib.mlir.dialects import arith
 from jax._src.lib.mlir.dialects import memref
@@ -457,27 +458,43 @@ def _dma_start_lowering_rule(
         "`pltpu.async_copy(..., dst_ref=ref.at[iota_ref], ...)`."
     )
   core_index = None
+  subcore_index = None
   if device_id is not None:
     if isinstance(sem_aval.memory_space, pallas_core.CoreMemorySpace):
       dest_mesh = sem_aval.memory_space.mesh
     else:
       dest_mesh = None
-    device_id, core_index = tc_lowering._device_id_to_logical(
+    device_id, core_index, subcore_index = tc_lowering._device_id_to_logical(
         ctx, device_id, device_id_type, device_id_aval, dest_mesh
     )
 
   # If not ``None``, we lower to an indirect DMA instead.
   if indirect_offsets is None:
     def _dma_start(src_ref, dst_ref, sem, src_sem):
-      tpu.enqueue_dma(
-          source=src_ref,
-          target=dst_ref,
-          target_semaphore=sem,
-          source_semaphore=src_sem,
-          device_id=device_id,
-          priority=priority,
-        core_id=core_index,
-      )
+      if jaxlib_extension_version < 462:
+        assert subcore_index is None, (
+            "`subcore_index` is not supported in this version of jaxlib."
+        )
+        tpu.enqueue_dma(
+            source=src_ref,
+            target=dst_ref,
+            target_semaphore=sem,
+            source_semaphore=src_sem,
+            device_id=device_id,
+            priority=priority,
+            core_id=core_index,
+        )
+      else:
+        tpu.enqueue_dma(
+            source=src_ref,
+            target=dst_ref,
+            target_semaphore=sem,
+            source_semaphore=src_sem,
+            device_id=device_id,
+            priority=priority,
+            core_id=core_index,
+            subcore_id=subcore_index,  # pyrefly: ignore[unexpected-keyword]
+        )
       return []
 
     return tc_lowering.lower_with_transformed_refs(
@@ -536,6 +553,7 @@ def _dma_wait_lowering_rule(
       ctx.lowering_context.kernel_type,
   )
   core_id = None
+  subcore_id = None
   if insert_dummy_device:
     i32 = ir.IntegerType.get_signless(32)
     core_id = device_id = arith.constant(i32, ir.IntegerAttr.get(i32, 0))
@@ -544,17 +562,23 @@ def _dma_wait_lowering_rule(
       dest_mesh = sem_aval.memory_space.mesh
     else:
       dest_mesh = None
-    device_id, core_id = tc_lowering._device_id_to_logical(
+    device_id, core_id, subcore_id = tc_lowering._device_id_to_logical(
         ctx, device_id, device_id_type, device_id_aval, dest_mesh
     )
     if core_id:
       raise NotImplementedError(
           "Core index must be None when waiting on a local DMA."
       )
+    if subcore_id:
+      raise NotImplementedError(
+          "Subcore index must be None when waiting on a local DMA."
+      )
 
   # If not ``None``, we lower to an indirect DMA instead of a regular DMA.
   if indirect_offsets is None:
     def _dma_wait(src_ref, dst_ref, sem):
+      # `wait_dma2` does not support `subcore_id`, so it is ignored until
+      # we migrate to `wait_dma`.
       tpu.wait_dma2(
         sem, src_ref, dst_ref, device_id=device_id, core_id=core_id
       )

--- a/jax/_src/pallas/mosaic_gpu/lowering.py
+++ b/jax/_src/pallas/mosaic_gpu/lowering.py
@@ -3893,14 +3893,13 @@ def _cond_lowering_rule(ctx: LoweringRuleContext, index, *args, branches,
     raise NotImplementedError("platform_dependent cond")
   index_aval, *_arg_avals = ctx.avals_in
 
+  _is_acc = lambda x: isinstance(x, mgpu.WGMMAAccumulator)
+  _ensure = _ensure_ir_value
+  if ctx.module_ctx.lowering_semantics == mgpu.LoweringSemantics.Lane:
+    _ensure = lambda v, aval: v if _is_acc(v) else _ensure_fa(v, aval.dtype)
+
   def _yielded_values(outs, avals):
-    ret: list[Any] = []
-    for out, aval in zip(outs, avals):
-      if isinstance(out, (mgpu.WGMMAAccumulator, mgpu.FragmentedArray)):
-        ret.append(out)
-      else:
-        ret.append(_ensure_ir_value(out, aval.dtype))
-    return ret
+    return [*map(_ensure, outs, avals)]
 
   # We need to know the result types ahead of time to construct the switch
   # operation. Below we lower the first branch in a throw-away module to

--- a/jax/_src/pjit.py
+++ b/jax/_src/pjit.py
@@ -1250,11 +1250,6 @@ def _pjit_lower(
     lowering_platforms: tuple[str, ...] | None,
     lowering_parameters: mlir.LoweringParameters,
     pgle_profiler: profiler.PGLEProfiler | None) -> pxla.MeshComputation:
-  if (isinstance(ctx_mesh, mesh_lib.AbstractMesh) and
-      (abd := ctx_mesh.abstract_device) is not None):
-    plat = (abd.platform,)
-    lowering_platforms = (plat if lowering_platforms is None else
-                          lowering_platforms + plat)
   return pxla.lower_sharding_computation(
       jaxpr, 'jit', name, in_shardings, out_shardings,
       in_layouts, out_layouts, tuple(donated_invars),

--- a/jax/_src/stages.py
+++ b/jax/_src/stages.py
@@ -52,6 +52,7 @@ from jax._src.lib import hlo
 from jax._src.lib import xla_client as xc
 from jax._src.lib.mlir import ir
 from jax._src.sharding_impls import UnspecifiedValue
+from jax._src.mesh import AbstractMesh
 from jax._src.tree_util import FlatTree, tree_unflatten
 from jax._src.typing import ArrayLike
 
@@ -479,11 +480,15 @@ class Traced(Stage):
   def lower(self, *, lowering_platforms: tuple[str, ...] | None = None,
             _private_parameters: mlir.LoweringParameters | None = None):
     """Lower to compiler input, returning a ``Lowered`` instance."""
+    from jax._src.pjit import _resolve_and_lower  # pyrefly: ignore[missing-import]
     lo = self.lojax
     if _private_parameters is None:
       _private_parameters = mlir.LoweringParameters()
     try:
-      from jax._src.pjit import _resolve_and_lower  # pyrefly: ignore[missing-import]
+      ctx_mesh = lo._params['ctx_mesh']
+      if (lowering_platforms is None and isinstance(ctx_mesh, AbstractMesh)
+          and (abd := ctx_mesh.abstract_device) is not None):
+        lowering_platforms = (abd.platform,)
       lowering = _resolve_and_lower(
           lo._meta_tys_flat, **lo._params, lowering_platforms=lowering_platforms,
           lowering_parameters=_private_parameters, pgle_profiler=None)

--- a/jax/_src/tpu_custom_call.py
+++ b/jax/_src/tpu_custom_call.py
@@ -73,6 +73,9 @@ def get_ir_version(ctx: mlir.LoweringRuleContext) -> int | None:
       or is_cloud_tpu_older_than(2026, 5, 5, backend)
   ):
     return _FWD_COMPAT_VERSION
+  # TODO(emilyaf): remove the forward compatibility check after 2026-07-08.
+  if is_cloud_tpu_older_than(2026, 6, 8, backend):
+    return 13
   return None
 
 

--- a/jax/_src/util.py
+++ b/jax/_src/util.py
@@ -390,7 +390,6 @@ def immutable(cls):
     raise AttributeError(f"cannot delete field {name!r}")
   cls.__setattr__ = __setattr__
   cls.__delattr__ = __delattr__
-
   return cls
 
 

--- a/jax/_src/xla_transform.py
+++ b/jax/_src/xla_transform.py
@@ -69,8 +69,12 @@ def register_hlo_module_transformation(
   stage_int = stage.value
 
   # Canonicalize platforms to a list of strings early.
+  # When platforms=None we want all backends. Backend factory keys (e.g.
+  # "rocm") may differ from the platform string a client reports at runtime
+  # (e.g. "gpu"), so we include both forms and "gpu" as a catch-all for GPU
+  # plugin clients.
   if platforms is None:
-    platforms_list = ["cpu"] + list(xla_bridge._backend_factories.keys())
+    platforms_list = ["cpu", "gpu"] + list(xla_bridge._backend_factories.keys())
     platforms_list = list(dict.fromkeys(platforms_list))
   elif isinstance(platforms, str):
     platforms_list = [platforms]

--- a/jax/experimental/mosaic/gpu/__init__.py
+++ b/jax/experimental/mosaic/gpu/__init__.py
@@ -71,6 +71,7 @@ from .fragmented_array import (
     WGMMA_LAYOUT_UPCAST_4X as WGMMA_LAYOUT_UPCAST_4X,
     TMEM_NATIVE_LAYOUT as TMEM_NATIVE_LAYOUT,
     TMA_INDICES_LAYOUT as TMA_INDICES_LAYOUT,
+    TMA_INDICES_4_LAYOUT as TMA_INDICES_4_LAYOUT,
     tmem_native_layout as tmem_native_layout,
     WGSplatFragLayout as WGSplatFragLayout,
     WGStridedFragLayout as WGStridedFragLayout,

--- a/jax/experimental/mosaic/gpu/fragmented_array.py
+++ b/jax/experimental/mosaic/gpu/fragmented_array.py
@@ -954,6 +954,13 @@ TMA_INDICES_LAYOUT = TiledLayout(
     vector_dim=-1,
 )
 
+# A replicated layout for TMA indices where every thread holds the same indices.
+TMA_INDICES_4_LAYOUT = TiledLayout(
+    Tiling(((4,),)),
+    warp_dims=(Replicated(4),),
+    lane_dims=(Replicated(32),),
+    vector_dim=-1,
+)
 
 def can_relayout_wgmma_4x_to_wgmma_2x(bitwidth: int) -> bool:
   return bitwidth == 4

--- a/jax/experimental/mosaic/gpu/launch_context.py
+++ b/jax/experimental/mosaic/gpu/launch_context.py
@@ -1506,7 +1506,7 @@ class LaunchContext:
         raise ValueError("Gather/scatter TMA can't perform reductions")
       if not isinstance(predicate, _DefaultPredicate):
         raise ValueError("Gather/scatter TMA can't use a predicate")
-      if gather_indices.layout != fa.TMA_INDICES_LAYOUT:
+      if gather_indices.layout not in (fa.TMA_INDICES_LAYOUT, fa.TMA_INDICES_4_LAYOUT):
         raise ValueError(f"Unsupported gather indices layout: {gather_indices.layout}")
       ROWS_PER_INSTR = 4
       # Make sure we'll always be accessing SMEM with sufficient alignment.
@@ -1539,15 +1539,26 @@ class LaunchContext:
           gmem_ref, (), gmem_peer_id, (1, slice_shape[-1]), swizzle, reduction_op,
       )
 
-      # Indices are split over 4 warps, and replicated within each warp.
-      assert fa.TMA_INDICES_LAYOUT.vector_length == ROWS_PER_INSTR
-      # Index 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 ...
-      # Warp  <--- 0 ---> <--- 1 ---> <--- 2 ---> <--- 3 ---> <--- 0 --
-      warp_idx = arith.remui(
-          utils.warp_idx(sync=True),
-          arith.constant(i32, utils.WARPS_IN_WARPGROUP),
-      )
-      gather_linear_idx_warp = arith.muli(warp_idx, c(ROWS_PER_INSTR, i32))
+      assert gather_indices.layout.vector_length == ROWS_PER_INSTR
+      # TMA instructions are uniform, so we can't use multiple lanes.
+      if gather_indices.layout == fa.TMA_INDICES_4_LAYOUT:
+        gather_linear_idx_warp = arith.constant(i32, 0)
+        predicate = utils.single_thread_predicate(utils.ThreadSubset.WARPGROUP)
+        indexing_stride = 1
+        # Note: If we have several tiles here, we could still issue copies from
+        # each warp to increase parallelism, though it's primarily useful for
+        # saving SMEM when loading a small number of long rows.
+      else:
+        # Indices are split over 4 warps, and replicated within each warp.
+        # Index 00 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 ...
+        # Warp  <--- 0 ---> <--- 1 ---> <--- 2 ---> <--- 3 ---> <--- 0 --
+        warp_idx = arith.remui(
+            utils.warp_idx(sync=True),
+            arith.constant(i32, utils.WARPS_IN_WARPGROUP),
+        )
+        gather_linear_idx_warp = arith.muli(warp_idx, c(ROWS_PER_INSTR, i32))
+        predicate = utils.single_thread_predicate(utils.ThreadSubset.WARP)
+        indexing_stride = utils.WARPS_IN_WARPGROUP
 
       # Since the TMA instruction is limited to 2D gathers, we flatten all
       # non-gather dims into the column index.
@@ -1572,8 +1583,6 @@ class LaunchContext:
           arith.constant(index, 0),
       )
       col_base_offset = arith.index_cast(i32, col_base_offset)
-      # TMA instructions are uniform, so we can't use multiple lanes.
-      predicate = utils.single_thread_predicate(utils.ThreadSubset.WARP)
       # We need to unroll over all non-gather dimensions other than the last one
       non_gather_slice_shape = tuple(
           1 if g else d for d, g in zips(slice_shape[:-1], is_gather_dim[:-1])
@@ -1583,7 +1592,7 @@ class LaunchContext:
         if utils.bitwidth(gather_indices.mlir_dtype) != 32:
           reg = arith.extui(ir.VectorType.get((4,), i32), reg)
         # Compute which rows within the 2D slice we'll be gathering.
-        gather_linear_idx_reg = i * ROWS_PER_INSTR * utils.WARPS_IN_WARPGROUP
+        gather_linear_idx_reg = i * ROWS_PER_INSTR * indexing_stride
         gather_linear_idx = arith.addi(
             gather_linear_idx_warp, arith.constant(i32, gather_linear_idx_reg)
         )

--- a/jax/experimental/mosaic/gpu/test_util.py
+++ b/jax/experimental/mosaic/gpu/test_util.py
@@ -33,6 +33,7 @@ class RegisterLayout(enum.Enum):
   TCGEN05_TMEM_NATIVE = enum.auto()
   SMEM_GMEM_COPY = enum.auto()
   TMA_INDICES = enum.auto()
+  TMA_INDICES_4 = enum.auto()
 
   def to_mgpu(
       self, shape: tuple[int, int], dtype: jax.typing.DTypeLike | ir.Type
@@ -65,6 +66,8 @@ class RegisterLayout(enum.Enum):
         )
       case RegisterLayout.TMA_INDICES:
         return fa.TMA_INDICES_LAYOUT
+      case RegisterLayout.TMA_INDICES_4:
+        return fa.TMA_INDICES_4_LAYOUT
 
   def to_layout_attr(
       self, shape: tuple[int, int], dtype: jax.typing.DTypeLike | ir.Type

--- a/jaxlib/mlir.cc
+++ b/jaxlib/mlir.cc
@@ -157,21 +157,23 @@ absl::StatusOr<nb::bytes> PySerializePortableArtifact(
                       xla::ParseMlirModuleString(mlir_module, context));
 
   // Serialize portable artifact
+  std::string bytecode;
+  {
+    nb::gil_scoped_release gil_release;
 #if JAX_IFRT_VERSION_NUMBER >= 54
-  TF_ASSIGN_OR_RETURN(
-      std::string bytecode,
-      xla::SerializeUsingVersionedStablehlo(
-          *module, target, sdy_version,
-          /*inplace=*/true,
-          /*allow_mixed_serialization=*/use_mixed_serialization));
+    TF_ASSIGN_OR_RETURN(
+        bytecode, xla::SerializeUsingVersionedStablehlo(
+                      *module, target, sdy_version,
+                      /*inplace=*/true,
+                      /*allow_mixed_serialization=*/use_mixed_serialization));
 #else
-  TF_ASSIGN_OR_RETURN(
-      std::string bytecode,
-      xla::SerializeUsingVersionedStablehlo(
-          *module, target,
-          /*inplace=*/true,
-          /*allow_mixed_serialization=*/use_mixed_serialization));
+    TF_ASSIGN_OR_RETURN(
+        bytecode, xla::SerializeUsingVersionedStablehlo(
+                      *module, target,
+                      /*inplace=*/true,
+                      /*allow_mixed_serialization=*/use_mixed_serialization));
 #endif
+  }
   return nb::bytes(bytecode.data(), bytecode.size());
 }
 
@@ -179,21 +181,23 @@ absl::StatusOr<nb::bytes> PySerializePortableArtifact(
     PyModule& module, std::string_view target, std::string_view sdy_version,
     bool use_mixed_serialization) {
   mlir::ModuleOp module_op = unwrap(module.get());
+  std::string bytecode;
+  {
+    nb::gil_scoped_release gil_release;
 #if JAX_IFRT_VERSION_NUMBER >= 54
-  TF_ASSIGN_OR_RETURN(
-      std::string bytecode,
-      xla::SerializeUsingVersionedStablehlo(
-          module_op, target, sdy_version,
-          /*inplace=*/false,
-          /*allow_mixed_serialization=*/use_mixed_serialization));
+    TF_ASSIGN_OR_RETURN(
+        bytecode, xla::SerializeUsingVersionedStablehlo(
+                      module_op, target, sdy_version,
+                      /*inplace=*/false,
+                      /*allow_mixed_serialization=*/use_mixed_serialization));
 #else
-  TF_ASSIGN_OR_RETURN(
-      std::string bytecode,
-      xla::SerializeUsingVersionedStablehlo(
-          module_op, target,
-          /*inplace=*/false,
-          /*allow_mixed_serialization=*/use_mixed_serialization));
+    TF_ASSIGN_OR_RETURN(
+        bytecode, xla::SerializeUsingVersionedStablehlo(
+                      module_op, target,
+                      /*inplace=*/false,
+                      /*allow_mixed_serialization=*/use_mixed_serialization));
 #endif
+  }
   return nb::bytes(bytecode.data(), bytecode.size());
 }
 
@@ -202,9 +206,12 @@ absl::StatusOr<nb::object> PyDeserializePortableArtifact(
   MlirContext c_context = ctx->get();
   mlir::MLIRContext* context = unwrap(c_context);
   context->loadDialect<mlir::sdy::SdyDialect, mlir::mpmd::MpmdDialect>();
-  mlir::OwningOpRef<mlir::ModuleOp> module =
-      mlir::stablehlo::deserializePortableArtifact(
-          std::string_view(bytecode_str.c_str(), bytecode_str.size()), context);
+  std::string_view bytecode(bytecode_str.c_str(), bytecode_str.size());
+  mlir::OwningOpRef<mlir::ModuleOp> module;
+  {
+    nb::gil_scoped_release gil_release;
+    module = mlir::stablehlo::deserializePortableArtifact(bytecode, context);
+  }
   if (!module)
     return tsl::errors::InvalidArgument("Failed to deserialize StableHLO");
   return PyModule::forModule(wrap(module.release())).releaseObject();

--- a/jaxlib/mosaic/dialect/tpu/tpu_ops.cc
+++ b/jaxlib/mosaic/dialect/tpu/tpu_ops.cc
@@ -1372,6 +1372,13 @@ LogicalResult GetBarrierSemaphoreOp::verify() {
   return success();
 }
 
+void SemaphoreSignalOp::build(OpBuilder& builder, OperationState& state,
+                              Value semaphore, Value amount, Value device_id,
+                              Value core_id) {
+  build(builder, state, semaphore, amount, device_id, core_id,
+        /*subcore_id=*/nullptr);
+}
+
 mlir::tpu::CoreType SemaphoreSignalOp::getTargetCoreType() {
   return getRefCoreType(getSemaphore()).value_or(GetCoreTypeOfParentOp(**this));
 }
@@ -1394,6 +1401,13 @@ LogicalResult SemaphoreSignalOp::verify() {
                           stringifyCoreType(issuing_core_type)));
     }
   }
+  // Subcore ID applies only to SC vector subcore semaphore ops.
+  if (target_core_type != CoreType::kScVectorSubcore &&
+      getSubcoreId() != nullptr) {
+    return emitOpError(
+        "Subcore id should not be set unless target core type is SC vector "
+        "subcore");
+  }
   return success();
 }
 
@@ -1405,6 +1419,13 @@ LogicalResult SemaphoreWaitOp::verify() {
   return success();
 }
 
+void EnqueueDMAOp::build(OpBuilder& builder, OperationState& state,
+                         Value source, Value source_semaphore, Value target,
+                         Value target_semaphore, Value device_id, Value core_id,
+                         uint32_t priority, bool strict_ordering) {
+  build(builder, state, source, source_semaphore, target, target_semaphore,
+        device_id, core_id, /*subcore_id=*/nullptr, priority, strict_ordering);
+}
 mlir::tpu::CoreType EnqueueDMAOp::getTargetCoreType() {
   return getRefCoreType(getTargetSemaphore())
       .value_or(GetCoreTypeOfParentOp(**this));
@@ -1495,6 +1516,12 @@ LogicalResult EnqueueDMAOp::verify() {
       return emitOpError(
           "Non-DMA semaphores are not supported for DMAs involving SMEM");
     }
+  }
+  // Subcore ID applies only to SC vector subcore DMAs.
+  if (target_core != CoreType::kScVectorSubcore && getSubcoreId() != nullptr) {
+    return emitOpError(
+        "Subcore id should not be set unless target core type is SC vector "
+        "subcore");
   }
   return success();
 }
@@ -1595,6 +1622,13 @@ LogicalResult WaitDMAOp::verify() {
   CoreType issuing_core = GetCoreTypeOfParentOp(**this);
   if (getRefCoreType(sem).value_or(issuing_core) != issuing_core) {
     return emitOpError("Can only await semaphores attached to the local core");
+  }
+
+  // Subcore ID applies only to SC vector subcore.
+  if (issuing_core != CoreType::kScVectorSubcore && getSubcoreId() != nullptr) {
+    return emitOpError(
+        "Subcore id should not be set unless issuing core type is SC vector "
+        "subcore");
   }
 
   return success();

--- a/jaxlib/mosaic/dialect/tpu/tpu_ops.td
+++ b/jaxlib/mosaic/dialect/tpu/tpu_ops.td
@@ -712,7 +712,7 @@ def TPU_UnpackSubelementsOp : TPU_Op<"unpack_subelements", [Pure]> {
 }
 
 // unsigned_integers applies to the result type (for the source type the sign
-// doesn't matter: integer-to-integer conversions truncate the high bits, 
+// doesn't matter: integer-to-integer conversions truncate the high bits,
 // floats are always signed).
 // Float to integer packing rounds to nearest even.
 // WARNING: pack(pack(a, b), pack(c, d)) == pack(a, b, c, d) only holds for
@@ -1368,15 +1368,20 @@ def TPU_SemaphoreSignalOp : TPU_Op<"sem_signal", [AttrSizedOperandSegments]> {
     MemRefOf<[TPU_SemaphoreType]>:$semaphore,
     I32:$amount,
     Optional<I32>:$device_id, // For remote DMAs
-    Optional<I32>:$core_id
+    Optional<I32>:$core_id,
+    Optional<I32>:$subcore_id
   );
 let assemblyFormat = [{
-    $semaphore `,` $amount (`device_id` $device_id^)? (`core_id` $core_id^)? attr-dict `:` type($semaphore)
+    $semaphore `,` $amount (`device_id` $device_id^)? (`core_id` $core_id^)? (`subcore_id` $subcore_id^)? attr-dict `:` type($semaphore)
   }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
     mlir::tpu::CoreType getTargetCoreType();
   }];
+  let builders = [
+    // A backward-compatible builder that sets `subcore_id` to nullptr.
+    OpBuilder<(ins "Value":$semaphore, "Value":$amount, "Value":$device_id, "Value":$core_id)>,
+  ];
 }
 
 def TPU_BarrierOp : TPU_Op<"barrier"> {
@@ -1407,6 +1412,8 @@ def TPU_BarrierOp : TPU_Op<"barrier"> {
 // device_id         : The id of the device to copy to for remote DMAs.
 // core_id           : The id of the core to copy to for remote and cross-core
 //                     DMAs.
+// subcore_id        : The id of the subcore to copy to for remote and cross-core
+//                     DMAs, if applicable.
 // priority          : The priority of the DMA.
 // strict_ordering   : True if the DMA requires strict ordering. If false, the
 //                     ordering is either strict or relaxed depending on the
@@ -1419,6 +1426,7 @@ def TPU_EnqueueDMAOp : TPU_Op<"enqueue_dma", [AttrSizedOperandSegments]> {
     Optional<MemRefOf<[TPU_SomeSemaphoreType]>>:$target_semaphore,
     Optional<I32>:$device_id, // For remote DMAs
     Optional<I32>:$core_id,
+    Optional<I32>:$subcore_id,
     // Smaller number means higher priority. 0 is the highest and the default.
     DefaultValuedAttr<I32Attr, "0">:$priority,
     DefaultValuedAttr<BoolAttr, "false">:$strict_ordering
@@ -1430,12 +1438,17 @@ def TPU_EnqueueDMAOp : TPU_Op<"enqueue_dma", [AttrSizedOperandSegments]> {
     (`target_semaphore` `(` $target_semaphore^ `:` type($target_semaphore) `)`)?
     (`device_id` `(` $device_id^ `)`)?
     (`core_id` `(` $core_id^ `)`)?
+    (`subcore_id` `(` $subcore_id^ `)`)?
     attr-dict
   }];
   let hasVerifier = 1;
   let extraClassDeclaration = [{
     mlir::tpu::CoreType getTargetCoreType();
   }];
+  let builders = [
+    // A backward-compatible builder that sets `subcore_id` to nullptr.
+    OpBuilder<(ins "Value":$source, "Value":$source_semaphore, "Value":$target, "Value":$target_semaphore, "Value":$device_id, "Value":$core_id, CArg<"uint32_t", "0">:$priority, CArg<"bool", "false">:$strict_ordering)>,
+  ];
 }
 
 // A base class for all ops that need to differentiate between gather and
@@ -1531,6 +1544,7 @@ def TPU_WaitDMAOp : TPU_Op<"wait_dma", [AttrSizedOperandSegments]> {
     Optional<MemRefOf<[TPU_SomeSemaphoreType]>>:$target_semaphore,
     Optional<I32>:$device_id, // For remote DMAs
     Optional<I32>:$core_id,
+    Optional<I32>:$subcore_id,
     DefaultValuedAttr<I32Attr, "0">:$priority,
     DefaultValuedAttr<BoolAttr, "false">:$strict_ordering,
     BoolAttr:$wait_target
@@ -1542,6 +1556,7 @@ def TPU_WaitDMAOp : TPU_Op<"wait_dma", [AttrSizedOperandSegments]> {
     (`target_semaphore` `(` $target_semaphore^ `:` type($target_semaphore) `)`)?
     (`device_id` `(` $device_id^ `)`)?
     (`core_id` `(` $core_id^ `)`)?
+    (`subcore_id` `(` $subcore_id^ `)`)?
     attr-dict
   }];
   let hasVerifier = 1;

--- a/jaxlib/mosaic/dialect/tpu/transforms/serde.cc
+++ b/jaxlib/mosaic/dialect/tpu/transforms/serde.cc
@@ -22,7 +22,9 @@ limitations under the License.
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/Builders.h"
 #include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/OpDefinition.h"
 #include "mlir/IR/OperationSupport.h"
@@ -99,6 +101,134 @@ LogicalResult dynamic_gather_downgrade(Operation* op, int version, bool&) {
   return success();
 }
 
+// Upgrades an operation from a version without subcore_id (v13) to HEAD (v14+)
+// by delinearizing a single core_id into separate core_id and subcore_id.
+// This runs during deserialization (`serialize = false`), where operations have
+// already been demangled from `stable_mosaic.<op>` back to regular MLIR ops.
+// Therefore, we emit standard unmangled constant and arithmetic operations.
+LogicalResult delinearize_subcore(Operation* op, int core_id_seg,
+                                  int subcore_id_seg) {
+  CoreType core_type = GetCoreTypeOfParentOp(*op);
+  if (core_type != CoreType::kScVectorSubcore) {
+    return success();
+  }
+  auto segment_attr =
+      op->getAttrOfType<DenseI32ArrayAttr>("operandSegmentSizes");
+  if (!segment_attr) {
+    return op->emitError("Missing operandSegmentSizes attribute");
+  }
+  SmallVector<int32_t> sizes(segment_attr.asArrayRef());
+  if (sizes.size() <= core_id_seg || sizes.size() <= subcore_id_seg) {
+    return op->emitError("Unexpected size of operandSegmentSizes");
+  }
+  if (sizes[core_id_seg] == 0) {
+    return success();
+  }
+  int core_id_op_idx = 0;
+  for (int i = 0; i < core_id_seg; ++i) {
+    core_id_op_idx += sizes[i];
+  }
+  int subcore_id_op_idx = 0;
+  for (int i = 0; i < subcore_id_seg; ++i) {
+    subcore_id_op_idx += sizes[i];
+  }
+  Value core_id_val = op->getOperand(core_id_op_idx);
+
+  // For version < 14, the only supported TPUs with SC vector subcores
+  // have 16 subcores per core.
+  const int64_t num_subcores = 16;
+
+  OpBuilder builder(op);
+  auto loc = op->getLoc();
+
+  auto create_constant_op = [&](Location loc, int64_t val) -> Value {
+    TypedAttr val_attr = builder.getI32IntegerAttr(val);
+    return builder.create<arith::ConstantOp>(loc, val_attr);
+  };
+
+  Value c16 = create_constant_op(loc, num_subcores);
+  Value new_core_id = builder.create<arith::DivUIOp>(loc, core_id_val, c16);
+  Value new_subcore_id = builder.create<arith::RemUIOp>(loc, core_id_val, c16);
+
+  op->setOperand(core_id_op_idx, new_core_id);
+  op->insertOperands(subcore_id_op_idx, {new_subcore_id});
+  sizes[subcore_id_seg] = 1;
+  op->setAttr("operandSegmentSizes",
+              DenseI32ArrayAttr::get(op->getContext(), sizes));
+  return success();
+}
+
+// Downgrades an operation from HEAD (v14+) to a version without subcore_id
+// (v13) by combining separate core_id and subcore_id into a single linearized
+// core_id. This runs during serialization (`serialize = true`), where every
+// operation in the module must be mangled with `stable_mosaic.`. Because MLIR's
+// post-order walk has already advanced past the insertion point of new
+// constants before downgrade rules execute, `RunSerde` will not visit or
+// auto-mangle them. We therefore explicitly create pre-mangled
+// `stable_mosaic.arith.*` operations.
+LogicalResult linearize_subcore(Operation* op, int core_id_seg,
+                                int subcore_id_seg) {
+  CoreType core_type = GetCoreTypeOfParentOp(*op);
+  if (core_type != CoreType::kScVectorSubcore) {
+    return op->emitError(
+        "subcore_id linearization requested for non-SC vector subcore type");
+  }
+  auto segment_attr =
+      op->getAttrOfType<DenseI32ArrayAttr>("operandSegmentSizes");
+  if (!segment_attr) {
+    return op->emitError("Missing operandSegmentSizes attribute");
+  }
+  SmallVector<int32_t> sizes(segment_attr.asArrayRef());
+  if (sizes.size() <= core_id_seg || sizes.size() <= subcore_id_seg) {
+    return op->emitError("Unexpected size of operandSegmentSizes");
+  }
+  // This function should only be called if subcore_id is specified, in which
+  // case core_id must be specified too.
+  if (sizes[core_id_seg] == 0 || sizes[subcore_id_seg] == 0) {
+    return op->emitError(
+        "Expected both core_id and subcore_id to be present for linearization");
+  }
+  int core_id_op_idx = 0;
+  for (int i = 0; i < core_id_seg; ++i) {
+    core_id_op_idx += sizes[i];
+  }
+  int subcore_id_op_idx = 0;
+  for (int i = 0; i < subcore_id_seg; ++i) {
+    subcore_id_op_idx += sizes[i];
+  }
+  Value core_id_val = op->getOperand(core_id_op_idx);
+  Value subcore_id_val = op->getOperand(subcore_id_op_idx);
+
+  OpBuilder builder(op);
+  auto loc = op->getLoc();
+  const int64_t num_subcores = 16;
+
+  auto create_constant_op = [&](Location loc, int64_t val) -> Value {
+    TypedAttr val_attr = builder.getI32IntegerAttr(val);
+    OperationState state(loc, "stable_mosaic.arith.constant");
+    state.addTypes(builder.getI32Type());
+    state.addAttribute("value", val_attr);
+    Operation* const_op = builder.create(state);
+    return const_op->getResult(0);
+  };
+
+  Value c16 = create_constant_op(loc, num_subcores);
+  OperationState mul_state(loc, "stable_mosaic.arith.muli");
+  mul_state.addTypes(builder.getI32Type());
+  mul_state.addOperands({core_id_val, c16});
+  Operation* mul_op = builder.create(mul_state);
+  OperationState add_state(loc, "stable_mosaic.arith.addi");
+  add_state.addTypes(builder.getI32Type());
+  add_state.addOperands({mul_op->getResult(0), subcore_id_val});
+  Operation* add_op = builder.create(add_state);
+  Value new_core_id = add_op->getResult(0);
+
+  op->setOperand(core_id_op_idx, new_core_id);
+  op->eraseOperand(subcore_id_op_idx);
+  // The caller will update operandSegmentSizes to sizes.drop_back().
+  return success();
+}
+
 LogicalResult enqueue_dma_upgrade(Operation* op, int version, bool&) {
   // Added AttrSizedOperandSegments and core_id in version 2.
   if (version < 2) {
@@ -122,10 +252,50 @@ LogicalResult enqueue_dma_upgrade(Operation* op, int version, bool&) {
                 mlir::IntegerAttr::get(
                     mlir::IntegerType::get(op->getContext(), 32), 0));
   }
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    SmallVector<int32_t> new_sizes(segment_attr.asArrayRef());
+    if (new_sizes.size() != 6) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for enqueue_dma");
+    }
+    new_sizes.push_back(0);
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), new_sizes));
+    return delinearize_subcore(op, 5, 6);
+  }
   return success();
 }
 
 LogicalResult enqueue_dma_downgrade(Operation* op, int version, bool&) {
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    const ArrayRef<int32_t> sizes = segment_attr.asArrayRef();
+    if (sizes.size() != 7) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for enqueue_dma");
+    }
+    if (sizes[6] != 0) {
+      LogicalResult linearize = linearize_subcore(op, 5, 6);
+      if (linearize.failed()) {
+        return linearize;
+      }
+    }
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), sizes.drop_back()));
+  }
   if (version < 12) {
     auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
         OpTrait::AttrSizedOperandSegments<
@@ -234,6 +404,54 @@ LogicalResult wait_dma2_downgrade(Operation* op, int version, bool&) {
   return success();
 }
 
+LogicalResult wait_dma_upgrade(Operation* op, int version, bool&) {
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    SmallVector<int32_t> new_sizes(segment_attr.asArrayRef());
+    if (new_sizes.size() != 6) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for wait_dma");
+    }
+    new_sizes.push_back(0);
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), new_sizes));
+    return delinearize_subcore(op, 5, 6);
+  }
+  return success();
+}
+
+LogicalResult wait_dma_downgrade(Operation* op, int version, bool&) {
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    const ArrayRef<int32_t> sizes = segment_attr.asArrayRef();
+    if (sizes.size() != 7) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for wait_dma");
+    }
+    if (sizes[6] != 0) {
+      LogicalResult linearize = linearize_subcore(op, 5, 6);
+      if (linearize.failed()) {
+        return linearize;
+      }
+    }
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), sizes.drop_back()));
+  }
+  return success();
+}
+
 LogicalResult semaphore_signal_upgrade(Operation* op, int version, bool&) {
   // Added AttrSizedOperandSegments and core_id in version 2.
   if (version < 2) {
@@ -249,10 +467,50 @@ LogicalResult semaphore_signal_upgrade(Operation* op, int version, bool&) {
       return op->emitError("Unexpected operand count in tpu.semaphore_signal");
     }
   }
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    SmallVector<int32_t> new_sizes(segment_attr.asArrayRef());
+    if (new_sizes.size() != 4) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for semaphore_signal.");
+    }
+    new_sizes.push_back(0);
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), new_sizes));
+    return delinearize_subcore(op, 3, 4);
+  }
   return success();
 }
 
 LogicalResult semaphore_signal_downgrade(Operation* op, int version, bool&) {
+  if (version < 14) {
+    auto segment_attr = op->getAttrOfType<DenseI32ArrayAttr>(
+        OpTrait::AttrSizedOperandSegments<
+            EnqueueDMAOp>::getOperandSegmentSizeAttr());
+    if (!segment_attr) {
+      return op->emitError("Missing or invalid AttrSizedOperandSegments");
+    }
+    const ArrayRef<int32_t> sizes = segment_attr.asArrayRef();
+    if (sizes.size() != 5) {
+      return op->emitError(
+          "Unexpected size of AttrSizedOperandSegments for semaphore_signal");
+    }
+    if (sizes[4] != 0) {
+      LogicalResult linearize = linearize_subcore(op, 3, 4);
+      if (linearize.failed()) {
+        return linearize;
+      }
+    }
+    op->setAttr(OpTrait::AttrSizedOperandSegments<
+                    EnqueueDMAOp>::getOperandSegmentSizeAttr(),
+                DenseI32ArrayAttr::get(op->getContext(), sizes.drop_back()));
+  }
   if (version < 2) {
     auto operands = op->getAttrOfType<mlir::DenseI32ArrayAttr>(
         OpTrait::AttrSizedOperandSegments<
@@ -376,6 +634,7 @@ const llvm::StringMap<SerdeRuleType>& upgrade_rules() {
   static auto rules = new llvm::StringMap<SerdeRuleType>{
       {EnqueueDMAOp::getOperationName(), enqueue_dma_upgrade},
       {WaitDMA2Op::getOperationName(), wait_dma2_upgrade},
+      {WaitDMAOp::getOperationName(), wait_dma_upgrade},
       {DynamicGatherOp::getOperationName(), dynamic_gather_upgrade},
       {IotaOp::getOperationName(), iota_upgrade},
       {SemaphoreSignalOp::getOperationName(), semaphore_signal_upgrade},
@@ -392,6 +651,7 @@ const llvm::StringMap<SerdeRuleType>& downgrade_rules() {
   static auto rules = new llvm::StringMap<SerdeRuleType>{
       {EnqueueDMAOp::getOperationName(), enqueue_dma_downgrade},
       {WaitDMA2Op::getOperationName(), wait_dma2_downgrade},
+      {WaitDMAOp::getOperationName(), wait_dma_downgrade},
       {DynamicGatherOp::getOperationName(), dynamic_gather_downgrade},
       {IotaOp::getOperationName(), iota_downgrade},
       {SemaphoreSignalOp::getOperationName(), semaphore_signal_downgrade},

--- a/jaxlib/mosaic/dialect/tpu/transforms/serde.h
+++ b/jaxlib/mosaic/dialect/tpu/transforms/serde.h
@@ -42,7 +42,7 @@ struct MosaicSerdePass : public jaxlib::mlir::Pass<MosaicSerdePass, ModuleOp> {
 
   // When this is bumped, we should file a TODO to update the forward-compatible
   // version in tpu_custom_call.py in a month!
-  static constexpr int kVersion = 13;
+  static constexpr int kVersion = 14;
 
   MosaicSerdePass() = default;
 

--- a/jaxlib/xla_client.py
+++ b/jaxlib/xla_client.py
@@ -45,7 +45,7 @@ ifrt_programs = _xla.ifrt_programs
 # Please suffix the version number with a brief description of your change
 # in a comment. The goal here is to force a merge conflict if two changes
 # attempt to grab the same version number.
-_version = 461  # custom compiler pass registration support
+_version = 462  # [Pallas/Mosaic] Add subcore_id to EnqueueDMA/SemaphoreSignal.
 
 # An internal increasing version number for protecting jaxlib code against
 # ifrt changes.

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -278,7 +278,7 @@ jax_multiplatform_test(
 jax_multiplatform_test(
     name = "xla_transform_test",
     srcs = ["xla_transform_test.py"],
-    enable_backends = ["cpu"],
+    enable_backends = ["cpu", "gpu"],
     deps = [
         "//jax/extend:xla",
         "//jaxlib:_xla",

--- a/tests/hijax_test.py
+++ b/tests/hijax_test.py
@@ -750,12 +750,23 @@ class HijaxTest(jtu.JaxTestCase):
 
   def test_tuple_vmap(self):
     tup = make_tup(jnp.arange(3.), jnp.arange(3.))
-    jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)), out_axes=TupSpec((0, 0)), axis_size=3)(tup)
+    out = jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)),
+                   out_axes=TupSpec((0, 0)), axis_size=3)(tup)
+    self.assertAllClose(out.elts, tup.elts)
 
   def test_tuple_vmap_infer(self):
     tup = make_tup(jnp.arange(3.), jnp.arange(3.))
     jax.vmap(lambda _: make_tup(jnp.ones(3), jnp.ones(3)),
              in_axes=TupSpec((0, 0)), out_axes=batching.infer, axis_size=3)(tup)
+
+  def test_tuple_nested_vmap(self):
+    tup = make_tup(jnp.arange(12.).reshape((3, 4)), jnp.arange(12.).reshape((3, 4)))
+    map1 = jax.vmap(lambda x: x, in_axes=TupSpec((0, 0)), out_axes=TupSpec((0, 0)),
+                    axis_size=3)
+    map2 = jax.vmap(map1, in_axes=TupSpec((1, 1)), out_axes=TupSpec((1, 1)),
+                    axis_size=4)
+    out = map2(tup)
+    self.assertAllClose(out.elts, tup.elts)
 
   # def test_tuple_vmap_match(self):
   #   tup = make_tup(jnp.arange(3.), jnp.arange(3.))

--- a/tests/hypothesis_test_util_test.py
+++ b/tests/hypothesis_test_util_test.py
@@ -14,8 +14,10 @@
 
 import functools
 import os
+import re
 
 from absl.testing import absltest
+from absl.testing import parameterized
 import hypothesis as hp
 from jax._src import hypothesis_test_util as htu
 from jax._src import test_util as jtu
@@ -111,6 +113,49 @@ class SingleShardTest(jtu.JaxTestCase):
 
   def test_z_absl_std3(self):
     self.assertEqual(shard_index, 2 % total_shards)
+
+
+# Avoid differing_executors if we run on unsharded environment.
+_helper_fail_suppressed_checks = [hp.HealthCheck.too_slow]
+if hasattr(hp.HealthCheck, "differing_executors"):
+  _helper_fail_suppressed_checks.append(hp.HealthCheck.differing_executors)
+
+
+# Verify that shrinking to minimal example still works when sharding.
+class HypothesisShrinkTest(htu.HypothesisShardedTestCase):
+
+  @hp.given(x=hp.strategies.integers(min_value=0, max_value=10000))
+  @hp.settings(
+      max_examples=100,
+      suppress_health_check=_helper_fail_suppressed_checks,
+      database=None,
+  )
+  def helper_fail(self, x):
+    self.assertLess(x, 10)
+
+  @classmethod
+  def setUpClass(cls):
+    super().setUpClass()
+    # Manually apply the sharding wrapper to helper_fail
+    handle = cls.helper_fail.hypothesis
+    handle.inner_test = htu._shard_aware_hypothesis_inner_test(
+        handle.inner_test
+    )
+
+  # Run 2 instances of the test so that it runs on both shards and can verify
+  # that hypothesis shrinking finds the right value (10) on both.
+  @parameterized.parameters(0, 1)
+  def test_meta_shrink(self, unused_id):
+    try:
+      self.helper_fail()
+    except AssertionError as e:
+      notes = getattr(e, "__notes__", [])
+      self.assertTrue(
+          any(re.search(r"\bx=10\b", note) for note in notes),
+          f"Exact match for 'x=10' not found in exception notes: {notes}",
+      )
+      return
+    self.fail("helper_fail did not raise AssertionError")
 
 
 if __name__ == "__main__":

--- a/tests/lax_numpy_operators_test.py
+++ b/tests/lax_numpy_operators_test.py
@@ -724,6 +724,14 @@ class JaxNumpyOperatorTests(jtu.JaxTestCase):
     self._CheckAgainstNumpy(np.floor_divide, jnp.floor_divide, args_maker)
     self._CompileAndCheck(jnp.floor_divide, args_maker)
 
+  @jtu.sample_product(dtype=float_dtypes)
+  def test_heaviside_nan(self, dtype):
+    # Regression test for https://github.com/jax-ml/jax/issues/38105
+    x = np.array([np.nan, -np.inf, -1, 0, 1, np.inf], dtype=dtype)
+    args_maker = lambda: [x[:, None], x[None, :]]
+    self._CheckAgainstNumpy(np.heaviside, jnp.heaviside, args_maker)
+    self._CompileAndCheck(jnp.heaviside, args_maker)
+
 
 if __name__ == "__main__":
   absltest.main(testLoader=jtu.JaxTestLoader())

--- a/tests/mosaic/gpu_test.py
+++ b/tests/mosaic/gpu_test.py
@@ -3683,8 +3683,12 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
       shape=((64, None),),
       dtype=(jnp.int32, jnp.int16),
       idx_dtype=(jnp.int32, jnp.int8),
+      idx_layout=(
+          fa.TMA_INDICES_LAYOUT,
+          fa.TMA_INDICES_4_LAYOUT,
+      )
   )
-  def test_tma_gather_basic(self, swizzle, shape, dtype, idx_dtype):
+  def test_tma_gather_basic(self, swizzle, shape, dtype, idx_dtype, idx_layout):
     if not jtu.is_cuda_compute_capability_at_least("10.0"):
       self.skipTest("TMA gather requires CUDA compute capability 10.0 or higher")
     i1 = ir.IntegerType.get_signless(1)
@@ -3694,7 +3698,7 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
     def kernel(ctx, src, idx, dst, smem):
       tmp, barrier = smem
       idxs = mgpu.FragmentedArray.load_untiled(
-          idx, layout=fa.TMA_INDICES_LAYOUT, optimized=False, is_signed=False
+          idx, layout=idx_layout, optimized=False, is_signed=False
       )
       ctx.async_copy(
           src_ref=src,
@@ -3706,8 +3710,9 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
       barrier.wait_parity(c(0, i1))
       copy(tmp, dst, swizzle=swizzle)
     x = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
-    idx = jax.random.permutation(jax.random.key(1234), 48).astype(idx_dtype)
-    out_type = jax.ShapeDtypeStruct((len(idx), col_slice), dtype)
+    num_items = 12 if idx_layout == fa.TMA_INDICES_4_LAYOUT else 48
+    idx = jax.random.permutation(jax.random.key(1234), 48).astype(idx_dtype)[:num_items]
+    out_type = jax.ShapeDtypeStruct((num_items, col_slice), dtype)
     smem = (out_type, mgpu.TMABarrier())
     y = mgpu.as_gpu_kernel(
         kernel, (1, 1, 1), (128, 1, 1), (x, idx), out_type, smem,
@@ -3719,8 +3724,12 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
       shape=((64, None),),
       dtype=(jnp.int32, jnp.int16),
       transpose_tiles=(False, True),
+      idx_layout=(
+          fa.TMA_INDICES_LAYOUT,
+          fa.TMA_INDICES_4_LAYOUT,
+      )
   )
-  def test_tma_gather_tiled(self, swizzle, shape, dtype, transpose_tiles):
+  def test_tma_gather_tiled(self, swizzle, shape, dtype, transpose_tiles, idx_layout):
     if not jtu.is_cuda_compute_capability_at_least("10.0"):
       self.skipTest("TMA gather requires CUDA compute capability 10.0 or higher")
     i1 = ir.IntegerType.get_signless(1)
@@ -3737,7 +3746,7 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
     def kernel(ctx, src, idx, dst, smem):
       tmp, barrier = smem
       idxs = mgpu.FragmentedArray.load_untiled(
-          idx, layout=fa.TMA_INDICES_LAYOUT, optimized=False, is_signed=False
+          idx, layout=idx_layout, optimized=False, is_signed=False
       )
       ctx.async_copy(
           src_ref=src,
@@ -3756,9 +3765,11 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
       )
       ctx.await_async_copy(0)
     x = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
-    idx = jax.random.permutation(jax.random.key(1234), 48).astype(jnp.int32)
-    out_type = jax.ShapeDtypeStruct((len(idx), 2 * col_slice), dtype)
-    smem_shape = tile_shape((len(idx), 2 * col_slice), tiling)
+    num_items = 12 if idx_layout == fa.TMA_INDICES_4_LAYOUT else 48
+    padded_num_items = (num_items + tiling[0] - 1) // tiling[0] * tiling[0]
+    idx = jax.random.permutation(jax.random.key(1234), padded_num_items).astype(jnp.int32)
+    out_type = jax.ShapeDtypeStruct((padded_num_items, 2 * col_slice), dtype)
+    smem_shape = tile_shape((padded_num_items, 2 * col_slice), tiling)
     if transpose_tiles:
       smem_shape = (smem_shape[1], smem_shape[0], *smem_shape[2:])
     smem = (
@@ -3768,21 +3779,28 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
     y = mgpu.as_gpu_kernel(
         kernel, (1, 1, 1), (128, 1, 1), (x, idx), out_type, smem,
     )(x, idx)
-    np.testing.assert_array_equal(y, x[idx, slice(col_slice, 3 * col_slice)])
+    np.testing.assert_array_equal(y[:num_items], x[idx[:num_items], slice(col_slice, 3 * col_slice)])
 
   @parameterized.product(
       swizzle=(16, 32, 64, 128),
       dtype=(jnp.int32, jnp.int16),
       transpose_tiles=(False, True),
+      idx_layout=(
+          fa.TMA_INDICES_LAYOUT,
+          fa.TMA_INDICES_4_LAYOUT,
+      )
   )
-  def test_tma_scatter_tiled(self, swizzle, dtype, transpose_tiles):
+  def test_tma_scatter_tiled(self, swizzle, dtype, transpose_tiles, idx_layout):
     self.skip_unless_tcgen05()  # .tile::scatter4 is not supported on sm_120, for example
     swizzle_elems = 8 * swizzle // bitwidth(dtype_to_ir_type(dtype))
     # Using `swizzle_elems` for `swizzle == 16` produces too short transfers
     # that result in misaligned SMEM addresses.
     n_cols = swizzle_elems if swizzle != 16 else 128
-    shape = (64, n_cols)
+    num_items = 12 if idx_layout == fa.TMA_INDICES_4_LAYOUT else 64
+    shape = (num_items, n_cols)
     tiling = (8, swizzle_elems) if swizzle != 16 else (8, 2 * swizzle_elems)
+    padded_num_items = (num_items + tiling[0] - 1) // tiling[0] * tiling[0]
+    shape = (padded_num_items, n_cols)
     if transpose_tiles:
       transforms = (
           mgpu.TileTransform(tiling),
@@ -3795,7 +3813,7 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
       tmp, barrier = smem
       idxs = mgpu.FragmentedArray.load_untiled(
           idx,
-          layout=fa.TMA_INDICES_LAYOUT,
+          layout=idx_layout,
           optimized=False,
           is_signed=False,
       )
@@ -3818,7 +3836,7 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
 
     x = np.arange(np.prod(shape), dtype=dtype).reshape(shape)
     idx = jax.random.permutation(jax.random.key(1234), 128)
-    idx = idx[: shape[0]].astype(jnp.int32)
+    idx = idx[:padded_num_items].astype(jnp.int32)
     out_shape = (128, 2 * n_cols)
     out_type = jax.ShapeDtypeStruct(out_shape, dtype)
     smem_shape = tile_shape(shape, tiling)
@@ -3828,7 +3846,7 @@ class AsyncCopyTest(TestCase, jtu.CudaArchSpecificTest):
     y = mgpu.as_gpu_kernel(
         kernel, (1, 1, 1), (128, 1, 1), (x, idx), out_type, smem
     )(x, idx)
-    np.testing.assert_array_equal(y[idx, slice(n_cols, 2 * n_cols)], x)
+    np.testing.assert_array_equal(y[idx[:num_items], slice(n_cols, 2 * n_cols)], x[:num_items])
 
   def test_tma_with_1d_tiling(self):
     swizzle = 128

--- a/tests/pallas/mosaic_gpu_test.py
+++ b/tests/pallas/mosaic_gpu_test.py
@@ -2405,6 +2405,24 @@ class PallasCallTest(PallasTest, jtu.CudaArchSpecificTest):
     x = jnp.arange(256, dtype=jnp.int32)
     np.testing.assert_array_equal(kernel(x), jnp.broadcast_to(jnp.sum(x) * 3, [256]))
 
+  def test_cond_constant_output(self):
+    # This is a regression test for a type error during lowering, due to
+    # returning a FragmentedArray on one side and a scalar on the other.
+    def kernel(x_ref, o_ref):
+      scale = _array_splat(1.0, ())
+      scale_one = jnp.float32(1.0)
+
+      o_ref[...] = jax.lax.cond(
+          x_ref[...] < 1.0,
+          lambda: scale_one,
+          lambda: scale,
+      )
+
+    f = self.kernel(
+        kernel, out_shape=jax.ShapeDtypeStruct((), jnp.float32)
+    )
+    self.assertArraysEqual(f(jnp.float32(0)), jnp.float32(1.0))
+
   def test_cond_get_arch(self):
     shape = (64, 256)
 


### PR DESCRIPTION
## Summary

- **`jax/_src/xla_transform.py`**: `register_hlo_module_transformation(platforms=None)` was silently skipping GPU plugin clients. The default platforms list only contained factory keys (e.g. `"rocm"`) while PJRT plugin clients report `client.platform` as `"gpu"`. Add `"gpu"` as an explicit entry so the backend initialization hook fires for all GPU plugin clients.
- **`tests/BUILD`**: Enable `xla_transform_test` for the GPU backend.

## Dependencies

Depends on the corresponding XLA change: https://github.com/ROCm/xla/pull/907

## Test plan

- Tested with `//tests:xla_transform_test_gpu` on ROCm (AMD Instinct MI355X)
- All 3 test cases pass: `test_sin_to_cos0` (PRE_SCHEDULER), `test_sin_to_cos1` (POST_SCHEDULER), `test_sin_to_cos_platform_filtering`