### PR TITLE
ci: deselect PGLE/FDO profiling tests on ROCm (ROCM-25581) [v0.9.2]

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -132,12 +132,12 @@ set +e
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
 --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+--deselect=tests/pgle_test.py::PgleTest::testAutoPgle \
+--deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers0 \
+--deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers1 \
+--deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithPersistentCache \
+--deselect=tests/pgle_test.py::PgleTest::testPGLEProfilerGetFDOProfile \
 tests
-
-first_cmd_retval=$?
-
-if [[ $gpu_count -gt 1 ]]; then
-  # Run multi-accelerator tests across all GPUs without xdist.
   unset JAX_ENABLE_ROCM_XDIST
 
   "$JAXCI_PYTHON" -m pytest --tb=short \
@@ -147,12 +147,12 @@ if [[ $gpu_count -gt 1 ]]; then
     --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
     --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
     --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+    --deselect=tests/pgle_test.py::PgleTest::testAutoPgle \
+    --deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers0 \
+    --deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithCommandBuffers1 \
+    --deselect=tests/pgle_test.py::PgleTest::testAutoPgleWithPersistentCache \
+    --deselect=tests/pgle_test.py::PgleTest::testPGLEProfilerGetFDOProfile \
     tests
-
-  second_cmd_retval=$?
-else
-  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
-  second_cmd_retval=0
 fi
 
 # Exit with failure if either command fails.


### PR DESCRIPTION
## Summary

Backport of [#788](https://github.com/ROCm/jax/pull/788) to `rocm-jaxlib-v0.9.2`. Deselects 5 failing PGLE/FDO profiling tests from the ROCm CI runner. These tests have never passed on any ROCm GPU.

Fixes [ROCM-25581](https://amd-hub.atlassian.net/browse/ROCM-25581)

## Problem

`tests/pgle_test.py` PGLE tests fail on all ROCm GPUs because:

1. **gfx120X (RDNA4):** [rocm-systems PR #307](https://github.com/ROCm/rocm-systems/pull/307) removed Navi4x support from rocprofiler v2. XLA's ROCm profiler backend still uses the legacy API — every HIP callback is dropped, producing empty FDO profiles.

2. **gfx94X/gfx950 (CDNA):** The ROCm collector doesn't produce CUPTI-equivalent XPlane annotations needed by `ConvertXplaneToProfiledInstructionsProto`.

These tests were already deselected in `ROCm/rocm-jax-internal ci/pytest_skips.ini` but `run_pytest_rocm.sh` does not consume that skip file.

## Tests deselected

| Test | Failure |
|---|---|
| `PgleTest::testAutoPgle` | `RuntimeWarning: PGLE collected an empty trace` |
| `PgleTest::testAutoPgleWithCommandBuffers0` | Same |
| `PgleTest::testAutoPgleWithCommandBuffers1` | Same |
| `PgleTest::testAutoPgleWithPersistentCache` | Same |
| `PgleTest::testPGLEProfilerGetFDOProfile` | `AssertionError: b'custom' not found` |

## Related

- [#788](https://github.com/ROCm/jax/pull/788) — same fix for `rocm-jaxlib-v0.9.1`
- [ROCM-25581](https://amd-hub.atlassian.net/browse/ROCM-25581) — gfx120X PGLE test failures
- [ROCM-24266](https://amd-hub.atlassian.net/browse/ROCM-24266) — same failures on gfx94X (resolved by skips in rocm-jax-internal)

[ROCM-25581]: https://amd-hub.atlassian.net/browse/ROCM-25581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ROCM-25581]: https://amd-hub.atlassian.net/browse/ROCM-25581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ