### PR TITLE
[ROCm] Put TheRock SDK bin on PATH for CLI tools

### DIFF
--- a/.github/workflows/bazel_rocm.yml
+++ b/.github/workflows/bazel_rocm.yml
@@ -132,6 +132,12 @@ jobs:
           persist-credentials: false
       - name: ROCm Info
         run: |
+          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
+          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
+          # rocm-sdk and already have rocminfo on PATH.
+          if command -v rocm-sdk >/dev/null 2>&1; then
+            export PATH="$(rocm-sdk path --bin):$PATH"
+          fi
           rocminfo
       - name: Configure AWS Credentials
         if: inputs.build_jaxlib == 'false' && inputs.jaxlib-version == 'head'

--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -150,7 +150,14 @@ jobs:
           curl -fSsL -o /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
           chmod +x /usr/local/bin/bazel
       - name: ROCm Info
-        run: rocminfo
+        run: |
+          # TheRock (pip) ROCm images are /opt/rocm-less; rocminfo lives in the
+          # SDK bin dir, so put it on PATH via rocm-sdk. apt-ROCm images lack
+          # rocm-sdk and already have rocminfo on PATH.
+          if command -v rocm-sdk >/dev/null 2>&1; then
+            export PATH="$(rocm-sdk path --bin):$PATH"
+          fi
+          rocminfo
       # Halt for testing
       - name: Wait For Connection
         uses: google-ml-infra/actions/ci_connection@7f5ca0c263a81ed09ea276524c1b9192f1304e3c

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -36,6 +36,14 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
+# TheRock (pip) ROCm images are intentionally /opt/rocm-less, so ROCm CLI tools
+# (rocminfo, rocm-smi, ...) live in the SDK bin dir rather than on PATH. Put
+# them on PATH via rocm-sdk. apt-ROCm images lack rocm-sdk and already have
+# these tools on PATH, so the gate leaves them untouched.
+if command -v rocm-sdk >/dev/null 2>&1; then
+  export PATH="$(rocm-sdk path --bin):$PATH"
+fi
+
 rocm-smi
 
 # ==============================================================================


### PR DESCRIPTION
# Summary
The TheRock base/manylinux images are now /opt/rocm-less, so ROCm CLI tools (rocminfo, rocm-smi) are no longer on PATH and the "ROCm Info" / pytest GPU-detection steps fail with exit 127. This prepends the SDK bin dir (rocm-sdk path --bin) to PATH, gated on rocm-sdk existing so apt-ROCm images are unaffected — mirroring the existing ROCM_PATH handling in build_rocm_artifacts.sh.

# Changes
ci/run_pytest_rocm.sh, .github/workflows/build_rocm_artifacts.yml, .github/workflows/bazel_rocm.yml: add gated export PATH="$(rocm-sdk path --bin):$PATH".

# Test plan

-  build-rocm-artifacts (TheRock) passes the "ROCm Info" step.
-  run-pytest-rocm (TheRock) detects GPUs and runs the suite.
-  apt-ROCm jobs unchanged.

<!--

Thanks for taking the time to contribute to JAX! A couple things to keep in mind:

* Contributing to JAX requires signing the Contributor License Agreement: https://docs.jax.dev/en/latest/contributing.html#google-contributor-license-agreement

* Please run lint checks and tests locally: https://docs.jax.dev/en/latest/contributing.html#contributing-code-using-pull-requests

* If applicable, read our policy on AI generated code: https://docs.jax.dev/en/latest/contributing.html#can-i-contribute-ai-generated-code

-->