### PR TITLE
[ROCm] Skip 6 Pallas FusedAttentionTest variants exceeding gfx942 LDS limit

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -145,15 +145,15 @@ first_cmd_retval=$?
 if [[ $gpu_count -gt 1 ]]; then
   # Run multi-accelerator tests across all GPUs without xdist.
   unset JAX_ENABLE_ROCM_XDIST
+
+  "$JAXCI_PYTHON" -m pytest --tb=short \
+    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
+    --junitxml=test-artifacts/junit-multi.xml \
+    -m "multiaccelerator" \
+    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
     --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
     --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
     tests
-
-  second_cmd_retval=$?
-else
-  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
-  second_cmd_retval=0
-fi
 
 # Exit with failure if either command fails.
 if [[ $first_cmd_retval -ne 0 ]]; then

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -128,6 +128,7 @@ set +e
 --json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
 --junitxml=test-artifacts/junit-single.xml \
 --dist=loadfile \
+-m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
 --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
@@ -138,13 +139,12 @@ set +e
 --deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd7 \
 --deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8 \
 tests
-  unset JAX_ENABLE_ROCM_XDIST
 
-  "$JAXCI_PYTHON" -m pytest --tb=short \
-    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
-    --junitxml=test-artifacts/junit-multi.xml \
-    -m "multiaccelerator" \
-    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+first_cmd_retval=$?
+
+if [[ $gpu_count -gt 1 ]]; then
+  # Run multi-accelerator tests across all GPUs without xdist.
+  unset JAX_ENABLE_ROCM_XDIST
     --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
     --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
     tests

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -128,16 +128,16 @@ set +e
 --json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
 --junitxml=test-artifacts/junit-single.xml \
 --dist=loadfile \
--m "not multiaccelerator" \
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
 --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd0 \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd1 \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd4 \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_fwd7 \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd7 \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8 \
 tests
-
-first_cmd_retval=$?
-
-if [[ $gpu_count -gt 1 ]]; then
-  # Run multi-accelerator tests across all GPUs without xdist.
   unset JAX_ENABLE_ROCM_XDIST
 
   "$JAXCI_PYTHON" -m pytest --tb=short \

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -155,6 +155,12 @@ if [[ $gpu_count -gt 1 ]]; then
     --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
     tests
 
+  second_cmd_retval=$?
+else
+  echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"
+  second_cmd_retval=0
+fi
+
 # Exit with failure if either command fails.
 if [[ $first_cmd_retval -ne 0 ]]; then
   exit $first_cmd_retval


### PR DESCRIPTION
## Summary

Deselect 6 `FusedAttentionTest` variants from ROCm CI that fail on all gfx942 GPUs (MI300X/MI308X) with `RESOURCE_EXHAUSTED: Shared memory size limit exceeded`.

## Root Cause

Pallas fused-attention tile configs are designed for NVIDIA's 128KB+ shared memory per SM. AMD gfx942 has 64KB LDS per CU. The XLA autotuner does not pre-filter configs exceeding the target GPU's LDS limit.

| Test | LDS Requested | LDS Available |
|---|---|---|
| `test_fused_attention_fwd0` | 98,304 | 65,536 |
| `test_fused_attention_fwd1` | 98,304 | 65,536 |
| `test_fused_attention_fwd4` | 81,920 | 65,536 |
| `test_fused_attention_fwd7` | 81,920 | 65,536 |
| `test_fused_attention_bwd7` | 98,304 | 65,536 |
| `test_fused_attention_bwd8` | 81,920 | 65,536 |

## Approach

Uses `--deselect` in `ci/run_pytest_rocm.sh` (single-accelerator block only) rather than in-test `skipTest` guards. This is preferred for v0.9.1 because:

- **Stable test IDs** — v0.9.1 is a release branch; parameterization won't change
- **Provably correct** — test IDs confirmed across two independent CI runs (TheRock #1391 and #1451)
- **Matches existing pattern** — 3 `--deselect` entries already present in the file
- **No variant numbering risk** — upstream [jax-ml/jax#34722](https://github.com/jax-ml/jax/pull/34722) uses `skipTest` with parameter tuples, but `sample_product` variant numbering differs between `main` and v0.9.1

`FusedAttentionInterpretTest` variants are **not** deselected — they use a reference Python implementation (no GPU kernel) and continue to validate correctness.

## Context

- v0.9.2 already has in-test `skipTest` guards ([ROCm/jax@8790d5b](https://github.com/ROCm/jax/blob/rocm-jaxlib-v0.9.2/tests/pallas/gpu_ops_test.py#L103-L115)) but with different variant-to-parameter mappings
- Upstream: [jax-ml/jax#34722](https://github.com/jax-ml/jax/pull/34722) (main), [openxla/xla#39050](https://github.com/openxla/xla/pull/39050) (split_k fix, not in v0.9.1 XLA pin)
- Tracked in: [ROCM-24925](https://amd-hub.atlassian.net/browse/ROCM-24925), [ROCM-25777](https://amd-hub.atlassian.net/browse/ROCM-25777)

## Test plan

- [ ] Verify nightly CI on gfx942 reports 0 failures (currently 6)
- [ ] Verify `FusedAttentionInterpretTest` variants still run and pass
- [ ] Verify other `FusedAttentionTest` variants (fwd2, fwd3, fwd5, fwd6, fwd8, fwd9, bwd0-6, bwd9) still run and pass

[ROCM-24925]: https://amd-hub.atlassian.net/browse/ROCM-24925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ