### PR TITLE
[ROCm] Deselect crashing FusedAttention bwd8 + add pytest-timeout (ROCM-25626)

### DIFF
--- a/build/test-requirements.txt
+++ b/build/test-requirements.txt
@@ -7,6 +7,7 @@ mpmath==1.3.0  # TODO(dsuo): Remove pin sinc(inf) is resolved as either nan or 0
 pillow>=11.3
 portpicker
 pytest<9.0  # Works around https://github.com/pytest-dev/pytest/issues/13895
+pytest-timeout
 pytest-xdist
 rich
 matplotlib

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -125,6 +125,7 @@ set +e
 
 # Run single-accelerator tests in parallel
 "$JAXCI_PYTHON" -m pytest -n $num_processes --tb=short \
+--timeout=1800 \
 --json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
 --junitxml=test-artifacts/junit-single.xml \
 --dist=loadfile \
@@ -132,6 +133,7 @@ set +e
 --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
 --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
 --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8 \
 tests
 
 first_cmd_retval=$?
@@ -141,6 +143,7 @@ if [[ $gpu_count -gt 1 ]]; then
   unset JAX_ENABLE_ROCM_XDIST
 
   "$JAXCI_PYTHON" -m pytest --tb=short \
+    --timeout=1800 \
     --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
     --junitxml=test-artifacts/junit-multi.xml \
     -m "multiaccelerator" \


### PR DESCRIPTION
## Summary

Fixes the 9+ hour JAX UT hang on gfx942 (MI300X/MI308X) by:
1. Deselecting the test that triggers an XLA compiler SEGFAULT
2. Adding a per-test timeout safety net

## Root Cause

`test_fused_attention_bwd8` causes a **SIGSEGV** in the XLA Triton compiler (`KernelReuseCache::GetWithStatus` via `ThunkEmitter::EmitTritonCustomCall`) on gfx942. pytest-xdist replaces the crashed worker, but the replacement **deadlocks during GPU runtime re-initialization** (corrupted GPU state from the SEGFAULT). With no `--timeout` flag, the stuck replacement worker blocks the entire suite for **9h44m** until the job-level 600-minute timeout fires.

### Why bwd8 is not caught by existing in-test skips

v0.9.2 already has `skipTest` guards in [`gpu_ops_test.py` lines 208-228](https://github.com/ROCm/jax/blob/rocm-jaxlib-v0.9.2/tests/pallas/gpu_ops_test.py#L208-L228) for `bwd{1,2,7,9}`, but **`bwd8` is not in the skip list**. This variant maps to a different parameter tuple that was not included in the upstream skip PR ([jax-ml/jax#34722](https://github.com/jax-ml/jax/pull/34722)).

### Why v0.9.1 doesn't hang

On v0.9.1, `bwd8` either doesn't hit the SEGFAULT codepath (different XLA/Triton version) or has been deselected ([ROCm/jax#797](https://github.com/ROCm/jax/pull/797)).

## Changes

### `ci/run_pytest_rocm.sh`
- Add `--deselect=tests/pallas/gpu_ops_test.py::FusedAttentionTest::test_fused_attention_bwd8` to the single-accelerator pytest invocation (sgpu only — FusedAttentionTest is not `multiaccelerator`)
- Add `--timeout=1800` (30 min) to **both** sgpu and mgpu pytest invocations. This is a safety net: if any future test hangs, it will be killed after 30 minutes instead of wasting the full 10-hour job budget

### `build/test-requirements.txt`
- Add `pytest-timeout` dependency (required for the `--timeout` flag)

## Evidence

- **Build #951** (2026-06-03): SEGFAULT at 21:53:33, hang until 07:42:18 — [log in ROCM-25626](https://amd-hub.atlassian.net/browse/ROCM-25626)
- **Build #20260608**: hang confirmed again by Radhika (2026-06-09)
- **dmesg analysis**: No GPU hardware failures in either attached dmesg log — the crash is entirely in userspace (XLA compiler memory corruption)

## What this does NOT fix

- The underlying XLA Triton compiler SEGFAULT — that requires an upstream fix ([openxla/xla#38972](https://github.com/openxla/xla/pull/38972) may be relevant if not already in the XLA pin)
- GPU isolation ([ROCm/jax#792](https://github.com/ROCm/jax/pull/792) — open, separate issue)
- PGLE test deselect ([ROCm/jax#790](https://github.com/ROCm/jax/pull/790) — open, separate issue)

## Test plan

- [ ] Verify nightly CI on gfx942 completes in ~1 hour (currently 9+ hours / timeout)
- [ ] Verify `pytest-timeout` installs correctly from test-requirements.txt
- [ ] Verify other FusedAttentionTest variants still run (bwd{0-6,9} should pass; bwd{1,2,7,9} skipped by in-test guards)
- [ ] Verify FusedAttentionInterpretTest::test_fused_attention_bwd8 still runs and passes (Interpret mode uses Python reference, no GPU kernel)

Tracked in: [ROCM-25626](https://amd-hub.atlassian.net/browse/ROCM-25626)
Related: [ROCm/jax#797](https://github.com/ROCm/jax/pull/797) (v0.9.1 LDS deselect)

[ROCM-25626]: https://amd-hub.atlassian.net/browse/ROCM-25626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ