### PR TITLE
[ROCm] Skip fused attention bwd tests that exceed device resources

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -259,7 +259,13 @@ class FusedAttentionTest(PallasBaseTest):
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, segment_ids, causal=causal).sum()
 
-    dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
+    try:
+      dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
+    except jax.errors.JaxRuntimeError as e:
+      if "RESOURCE_EXHAUSTED" in str(e):
+        self.skipTest(f"Skipped: block size configuration exceeds device "
+                      f"resources: {e}")
+      raise
     dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v)
     # TODO(sharadmv): Fix test.
     self.assertAllClose(dq, dq_ref, atol=5e-2)


### PR DESCRIPTION
## Summary

- Replaces the hardcoded ROCm skip list for `test_fused_attention_bwd` with a dynamic mechanism that catches `RESOURCE_EXHAUSTED` errors from the compiler.
- When a block size configuration requests more shared memory than the hardware supports, the test skips with a descriptive message rather than crashing or maintaining fragile parameter-specific lists.
- Works on any backend/device — the skip is driven by the actual hardware signal.

## Context

`test_fused_attention_bwd8` was crashing with a segfault on MI300X due to a null `error_handler` dereference in `CompileTritonToLLVM` (fixed in ROCm/xla#937). After that fix, the compiler correctly surfaces a `RESOURCE_EXHAUSTED` error when the `mha_backward` kernel requests 81920 bytes of shared memory, exceeding the 65536 byte hardware limit.

## Test plan

- [x] `test_fused_attention_bwd8` on MI300X: previously segfault → now `SKIPPED` with message `block size configuration exceeds device resources: RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 81920, available: 65536`
- [x] All other `test_fused_attention_bwd` variants continue to pass or skip as before