### PR TITLE
[ROCm][Pallas] Skip fused attention bwd tests that exceed device resources

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -224,7 +224,13 @@ class FusedAttentionTest(PallasBaseTest):
     def f_ref(q, k, v):
       return attention.mha_reference(q, k, v, segment_ids, causal=causal).sum()
 
-    dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
+    try:
+      dq, dk, dv = jax.grad(f, argnums=(0, 1, 2))(q, k, v)
+    except jax.errors.JaxRuntimeError as e:
+      if "RESOURCE_EXHAUSTED" in str(e):
+        self.skipTest(f"Skipped: block size configuration exceeds device "
+                      f"resources: {e}")
+      raise
     dq_ref, dk_ref, dv_ref = jax.grad(f_ref, argnums=(0, 1, 2))(q, k, v)
     # TODO(sharadmv): Fix test.
     self.assertAllClose(dq, dq_ref, atol=5e-2)


### PR DESCRIPTION
## Summary

Add a dynamic skip for `test_fused_attention_bwd` when the compiler reports that a kernel's shared memory requirements exceed what the hardware supports. When this happens the test is skipped with a descriptive message rather than failing with an unhandled `RESOURCE_EXHAUSTED` runtime error.

This is hardware-agnostic — the skip is driven by the actual error from the compiler, so it works correctly on any backend or device without requiring a hardcoded list of parameter combinations.

## Context

On MI300X, the `mha_backward` kernel for certain block size combinations (e.g. `bwd8`: `batch=1, seq=128, heads=1, head_dim=32`, `block_q_dkv=64, block_kv_dkv=32, block_q_dq=32, block_kv_dq=64`, `causal=True`, `use_segment_ids=True`) requests 81920 bytes of shared memory, exceeding the 65536 byte hardware limit. The XLA compiler correctly surfaces this as a `RESOURCE_EXHAUSTED` error, but without this fix the error propagates as a test failure.

## Test plan

- [x] `test_fused_attention_bwd8` on MI300X: previously `FAILED` with `RESOURCE_EXHAUSTED` → now `SKIPPED` with message `Skipped: block size configuration exceeds device resources: RESOURCE_EXHAUSTED: Shared memory size limit exceeded: requested 81920, available: 65536`
- [x] All other `test_fused_attention_bwd` variants continue to pass or skip as before

Cherry-pick of jax-ml/jax#38372 (cherry picked from commit `97dddce72f3697c3a2796fb290cf519c1227d775`).