### PR TITLE
[ROCm] Add release pipeline CI workflows

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -47,6 +47,14 @@ on:
         options:
         - "1"
         - "0"
+      artifact-type:
+        description: "Type of artifact to build (default/nightly/release). Controls wheel version stamping."
+        type: choice
+        default: "default"
+        options:
+        - "default"
+        - "nightly"
+        - "release"
       wheel-version-suffix:
         description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
         type: string
@@ -96,6 +104,10 @@ on:
         description: "S3 location prefix to where the artifacts should be uploaded"
         default: 's3://jax-ci-amd/jax-rocm-plugin-wheels'
         type: string
+      artifact-type:
+        description: "Type of artifact to build (default/nightly/release). Controls wheel version stamping."
+        type: string
+        default: "default"
       wheel-version-suffix:
         description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
         type: string
@@ -137,6 +149,7 @@ jobs:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
       JAXCI_CLONE_MAIN_XLA: "${{ inputs.clone_main_xla }}"
       JAXCI_OUTPUT_DIR: "${{ github.workspace }}/dist"
+      JAXCI_ARTIFACT_TYPE: "${{ inputs.artifact-type }}"
 
     name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-version }}"
 

--- a/.github/workflows/rocm_release_promote_gate.yml
+++ b/.github/workflows/rocm_release_promote_gate.yml
@@ -1,0 +1,85 @@
+# CI - ROCm Release: Promote Staging Build to Upstream Gate Pin
+#
+# Copies a specific staging build to upstream/GATE_CHECK/<rocm-release-version>/,
+# making it the stable path used by the blocking-gate presubmit check for PRs
+# targeting upstream main. This is a deliberate human action — the gate pin does
+# not move unless this workflow is explicitly triggered.
+#
+# Run this once a release branch staging build has passed testing and is ready
+# to serve as the upstream gate reference.
+# Lives in ROCm/jax only — not upstreamed.
+name: CI - ROCm Release Promote Upstream Gate Pin
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch the staging build came from (e.g. rocm-jaxlib-v0.11.0)"
+        required: true
+        type: string
+      run-number:
+        description: "Workflow run number of the staging build to promote"
+        required: true
+        type: string
+      run-attempt:
+        description: "Run attempt of the staging build to promote"
+        required: false
+        default: "1"
+        type: string
+      rocm-release-version:
+        description: "ROCm release version (e.g. 7.2.0, therock-7.13.0, therock-latest)"
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  promote-gate-pin:
+    if: github.repository_owner == 'ROCm'
+    runs-on: amd-do-linux.jax.gpu.gfx950.1
+    container:
+      image: ghcr.io/rocm/jax-base-ubu24.rocm720:latest  # zizmor: ignore[unpinned-images]
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+
+      - name: Promote staging build to upstream/GATE_CHECK
+        env:
+          BRANCH: ${{ inputs.branch }}
+          RUN_NUMBER: ${{ inputs.run-number }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+          ROCM_VERSION: ${{ inputs.rocm-release-version }}
+        run: |
+          SOURCE="s3://jax-ci-amd/rocm-wheels/${BRANCH}/${ROCM_VERSION}/staging/${RUN_NUMBER}/${RUN_ATTEMPT}"
+          DEST="s3://jax-ci-amd/rocm-wheels/upstream/GATE_CHECK/${ROCM_VERSION}"
+
+          echo "Promoting: ${SOURCE} -> ${DEST}"
+
+          # Verify source exists and has wheels before overwriting the gate pin.
+          WHEEL_COUNT=$(aws s3 ls --recursive "${SOURCE}/" | grep -c '\.whl$' || true)
+          if [[ "${WHEEL_COUNT}" -eq 0 ]]; then
+            echo "Error: no .whl files found at ${SOURCE}. Aborting."
+            exit 1
+          fi
+          echo "Found ${WHEEL_COUNT} wheel(s) in staging build."
+
+          aws s3 sync --delete --only-show-errors "${SOURCE}/" "${DEST}/"
+
+          # Write provenance so it is clear which build this gate pin came from.
+          printf "branch=%s\nrocm_version=%s\nrun_number=%s\nrun_attempt=%s\npromoted_by=%s\npromoted_at=%s\n" \
+            "${BRANCH}" "${ROCM_VERSION}" "${RUN_NUMBER}" "${RUN_ATTEMPT}" \
+            "${{ github.actor }}" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" | \
+            aws s3 cp --only-show-errors - "${DEST}/PROMOTED_FROM"
+
+          echo "Gate pin updated. Wheels at ${DEST}:"
+          aws s3 ls "${DEST}/" | grep '\.whl'

--- a/.github/workflows/rocm_release_publish.yml
+++ b/.github/workflows/rocm_release_publish.yml
@@ -1,0 +1,74 @@
+# CI - ROCm Release: Publish Final Release Wheels
+#
+# Copies wheels to rocm-jaxlib-v<version>/<rocm-ver>/release/ as the canonical
+# published artifacts. Source is a specific staging build (the one that passed
+# testing and was promoted to the upstream gate pin).
+# Lives in ROCm/jax only — not upstreamed.
+name: CI - ROCm Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch name (e.g. rocm-jaxlib-v0.11.0)"
+        required: true
+        type: string
+      rocm-release-version:
+        description: "ROCm release version (e.g. 7.2.0, therock-7.13.0, therock-latest)"
+        required: true
+        type: string
+      run-number:
+        description: "Staging run number to publish"
+        required: true
+        type: string
+      run-attempt:
+        description: "Staging run attempt to publish"
+        required: false
+        default: "1"
+        type: string
+
+permissions: {}
+
+jobs:
+  publish-release:
+    if: github.repository_owner == 'ROCm'
+    runs-on: amd-do-linux.jax.gpu.gfx950.1
+    container:
+      image: ghcr.io/rocm/jax-base-ubu24.rocm720:latest  # zizmor: ignore[unpinned-images]
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+
+      - name: Publish wheels to release/
+        env:
+          BRANCH: ${{ inputs.branch }}
+          ROCM_VERSION: ${{ inputs.rocm-release-version }}
+          RUN_NUMBER: ${{ inputs.run-number }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+        run: |
+          SOURCE="s3://jax-ci-amd/rocm-wheels/${BRANCH}/${ROCM_VERSION}/staging/${RUN_NUMBER}/${RUN_ATTEMPT}"
+          DEST="s3://jax-ci-amd/rocm-wheels/${BRANCH}/${ROCM_VERSION}/release"
+
+          echo "Publishing: ${SOURCE} -> ${DEST}"
+
+          WHEEL_COUNT=$(aws s3 ls --recursive "${SOURCE}/" | grep -c '\.whl$' || true)
+          if [[ "${WHEEL_COUNT}" -eq 0 ]]; then
+            echo "Error: no .whl files found at ${SOURCE}. Aborting."
+            exit 1
+          fi
+          echo "Found ${WHEEL_COUNT} wheel(s) to publish."
+
+          aws s3 sync --delete --only-show-errors "${SOURCE}/" "${DEST}/"
+
+          echo "Published wheels at ${DEST}:"
+          aws s3 ls "${DEST}/" | grep '\.whl'

--- a/.github/workflows/wheel_tests_rocm_release.yml
+++ b/.github/workflows/wheel_tests_rocm_release.yml
@@ -1,0 +1,126 @@
+# CI - ROCm Release Wheel Build + Test
+#
+# Builds jax-rocm-plugin and jax-rocm-pjrt wheels stamped with the release version,
+# uploads them to a per-run staging path in S3, and runs ROCm tests against that
+# exact build. Lives in ROCm/jax only — not upstreamed.
+#
+# S3 layout under s3://jax-ci-amd/rocm-wheels/<branch>/<rocm-ver>/:
+#   staging/<run_number>/<run_attempt>/   ← this workflow uploads here
+#   upstream/GATE_CHECK/                  ← promoted by rocm_release_promote_gate.yml
+#   release/                              ← published by rocm_release_publish.yml
+name: CI - ROCm Release Wheel Build + Test
+
+on:
+  push:
+    branches:
+      - 'rocm-jaxlib-v*'
+  workflow_dispatch:
+    inputs:
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection? (yes/no)'
+        required: false
+        default: 'no'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-rocm-artifacts:
+    if: github.repository_owner == 'ROCm'
+    uses: ./.github/workflows/build_rocm_artifacts.yml
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+        artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        manylinux-image: ""}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"}
+        exclude:
+          - artifact: "jax-rocm-pjrt"
+            python: "3.11"
+          - artifact: "jax-rocm-pjrt"
+            python: "3.13"
+          - artifact: "jax-rocm-pjrt"
+            python: "3.14"
+    name: "Build ROCm artifacts (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      artifact: ${{ matrix.artifact }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      manylinux-image: ${{ matrix.rocm.manylinux-image }}
+      artifact-type: release
+      clone_main_xla: 0
+      upload_artifacts_to_s3: true
+      s3_upload_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/staging/${{ github.run_number }}/${{ github.run_attempt }}'
+
+  run-pytest-rocm:
+    if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
+    needs: [build-rocm-artifacts]
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    uses: ./.github/workflows/pytest_rocm.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+    name: "Pytest ROCm (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      jaxlib-version: head
+      download-jax-from-gcs: 0
+      skip-download-jaxlib-and-plugins-from-gcs: 0
+      s3_download_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/staging/${{ github.run_number }}/${{ github.run_attempt }}'
+
+  run-bazel-test-rocm:
+    if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
+    needs: [build-rocm-artifacts]
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/bazel_rocm.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.8"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+        enable-x64: [0]
+    name: "Bazel ROCm (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      enable-x64: ${{ matrix.enable-x64 }}
+      jaxlib-version: head
+      download-jax-from-gcs: 0
+      build_jaxlib: 'false'
+      build_jax: 'false'
+      s3_download_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/staging/${{ github.run_number }}/${{ github.run_attempt }}'
+      run_multiaccelerator_tests: 'true'
+      clone_main_xla: 0


### PR DESCRIPTION
## Overview

This PR implements the ROCm release pipeline for the `ROCm/jax` fork. It introduces three new fork-only workflows and a small, upstream-candidate extension to `build_rocm_artifacts.yml` that together cover the full lifecycle of a ROCm release: build → stage → test → promote gate pin → publish.

All new workflows are scoped to `github.repository_owner == 'ROCm'` and are not intended to be upstreamed.

## S3 layout

```
s3://jax-ci-amd/rocm-wheels/
  upstream/
    GATE_CHECK/
      <rocm-release-version>/      ← pinned wheels for upstream main PR gate
                                     promoted from a release branch staging build

  rocm-jaxlib-v<version>/          ← e.g. rocm-jaxlib-v0.11.0
    <rocm-release-version>/
      staging/<run>/<run_attempt>/ ← built and tested by wheel_tests_rocm_release.yml
      release/                     ← final published wheels
```

## How the pieces fit together

### 1. Build + Test (`wheel_tests_rocm_release.yml`)

Triggered automatically on every push to a `rocm-jaxlib-v*` branch and manually via `workflow_dispatch`.

- Builds `jax-rocm-plugin` and `jax-rocm-pjrt` with `artifact-type: release`, producing clean version numbers (e.g. `0.11.0`, no `.devYYYYMMDD` suffix).
- Matrix covers ROCm 7.2.0, TheRock 7.13, TheRock latest × Python 3.12/3.13/3.14.
- Uploads wheels to `rocm-jaxlib-v<N>/<rocm-ver>/staging/<run>/<attempt>/`.
- Immediately runs `pytest_rocm.yml` and `bazel_rocm.yml` against that exact staging build.

Each push to the release branch produces a new, independently testable staging build. Post-release bug-fix commits produce their own staging builds without disturbing any previously promoted artifacts.

### 2. Promote upstream gate pin (`rocm_release_promote_gate.yml`)

Manual `workflow_dispatch`. Takes a branch name, run number, run attempt, and ROCm version as inputs.

Once a staging build has passed testing and is considered blessed, this workflow copies it to `upstream/GATE_CHECK/<rocm-ver>/` — the stable path used by the `blocking-gate` presubmit check in [`rocm-blocking-gate-upstream`](https://github.com/ROCm/jax/tree/rocm-blocking-gate-upstream) for PRs targeting `jax-ml/jax` main.

A `PROMOTED_FROM` provenance file is written alongside the wheels recording the source branch, run number, and the actor who triggered the promotion.

The gate pin does not move unless this workflow is explicitly triggered. Subsequent commits to the release branch — including post-release fixes — do not silently shift what upstream PRs are validated against.

### 3. Publish final release (`rocm_release_publish.yml`)

Manual `workflow_dispatch`. Takes a branch name, ROCm version, run number, and run attempt as inputs.

Copies the specified staging build to `rocm-jaxlib-v<N>/<rocm-ver>/release/` as the canonical published artifacts.

### Supporting change: `build_rocm_artifacts.yml`

Adds an `artifact-type` input (default `"default"`, options: `default` / `nightly` / `release`) wired to `JAXCI_ARTIFACT_TYPE` in the build container env. This is required because GitHub Actions called workflows cannot inherit environment variables from their caller — only explicitly declared inputs.

With `artifact-type: release`, the build script sets `ML_WHEEL_TYPE=release`, producing clean release version numbers from `version.py`. All existing callers (nightly, continuous) are unaffected by the default.

This change is a candidate for upstreaming to `jax-ml/jax`.

## Relationship to `rocm-blocking-gate-upstream`

The companion PR [`rocm-blocking-gate-upstream`](https://github.com/ROCm/jax/tree/rocm-blocking-gate-upstream) (draft upstream PR to `jax-ml/jax`) needs a corresponding update:

- `blocking-gate` job: change `jaxlib-version: "pypi_latest"` → `jaxlib-version: "head"` + `s3_download_uri: 's3://jax-ci-amd/rocm-wheels/upstream/GATE_CHECK/7.2.0'`
- PR trigger: extend `branches:` to include `rocm-jaxlib-v*` so the existing `run-tests` job (full-stack source build) gates PRs to release branches without any GATE_CHECK dependency.

PRs to `rocm-jaxlib-v*` branches build the full stack from source (jax + jaxlib + pjrt + plugin) — avoiding a chicken-and-egg problem since those PRs are what produce the blessed builds that feed the gate pin.

## Operational flow

```
1. push → rocm-jaxlib-v0.11.0
   └─ wheel_tests_rocm_release.yml
      ├─ build pjrt + plugin (release-stamped) → staging/<run>/<attempt>/
      ├─ pytest against staging build
      └─ bazel tests against staging build

2. Build passes → human triggers rocm_release_promote_gate.yml
   └─ staging/<run>/<attempt>/ → upstream/GATE_CHECK/7.2.0/
      (gate pin for upstream main PRs updated)

3. PRs → jax-ml/jax main
   └─ blocking-gate downloads from upstream/GATE_CHECK/7.2.0/

4. Ready to ship → human triggers rocm_release_publish.yml
   └─ staging/<run>/<attempt>/ → rocm-jaxlib-v0.11.0/7.2.0/release/
```

## Testing

- [ ] Push a commit to a `rocm-jaxlib-v*` test branch and verify `wheel_tests_rocm_release.yml` triggers, wheels carry a clean version stamp, and land under `staging/`.
- [ ] Trigger `rocm_release_promote_gate.yml` and verify `upstream/GATE_CHECK/<rocm-ver>/` is populated with the correct wheels and `PROMOTED_FROM` provenance file.
- [ ] Trigger `rocm_release_publish.yml` and verify `release/` contains the published wheels.
- [ ] Verify existing nightly workflow (`wheel_tests_nightly_release.yml`) is unaffected by the `artifact-type` default.