### PR TITLE
ci: use default allocator in ROCm pytest run

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -110,7 +110,7 @@ fi
 echo "Final number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
-export XLA_PYTHON_CLIENT_ALLOCATOR=address
+export XLA_PYTHON_CLIENT_ALLOCATOR=default
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
 


### PR DESCRIPTION
## Summary
- Switch `XLA_PYTHON_CLIENT_ALLOCATOR` from `address` to `default` (BFC) in `ci/run_pytest_rocm.sh`.

## Test plan
- CI pytest run on ROCm.