### PR TITLE
Revert "CI: Remove --device=/dev/dri from pytest_rocm container options"

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -129,7 +129,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"


### PR DESCRIPTION
Reverts the removal of `--device=/dev/dri` from the `pytest_rocm` container options.

This restores commit [`91512a3`](https://github.com/jax-ml/jax/commit/91512a349d893527df41b54b3f6587ec65a8fc26), re-adding `--device=/dev/dri` to the container `options` in `.github/workflows/pytest_rocm.yml` so containers regain access to the DRI render nodes.