### PR TITLE
[ROCm] Pin pyenv clone to a fixed commit in Dockerfile.ms

### DIFF
--- a/.github/workflows/build_rocm_artifacts.yml
+++ b/.github/workflows/build_rocm_artifacts.yml
@@ -47,6 +47,14 @@ on:
         options:
         - "1"
         - "0"
+      artifact-type:
+        description: "Type of artifact to build (default/nightly/release). Controls wheel version stamping."
+        type: choice
+        default: "default"
+        options:
+        - "default"
+        - "nightly"
+        - "release"
       wheel-version-suffix:
         description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
         type: string
@@ -96,6 +104,10 @@ on:
         description: "S3 location prefix to where the artifacts should be uploaded"
         default: 's3://jax-ci-amd/jax-rocm-plugin-wheels'
         type: string
+      artifact-type:
+        description: "Type of artifact to build (default/nightly/release). Controls wheel version stamping."
+        type: string
+        default: "default"
       wheel-version-suffix:
         description: "Version suffix for post-releases (e.g., .post3). Leave empty for normal builds."
         type: string
@@ -137,6 +149,7 @@ jobs:
       JAXCI_HERMETIC_PYTHON_VERSION: "${{ inputs.python }}"
       JAXCI_CLONE_MAIN_XLA: "${{ inputs.clone_main_xla }}"
       JAXCI_OUTPUT_DIR: "${{ github.workspace }}/dist"
+      JAXCI_ARTIFACT_TYPE: "${{ inputs.artifact-type }}"
 
     name: "${{ inputs.artifact }}, py ${{ inputs.python }}, ROCm ${{ inputs.rocm-version }}"
 

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -129,7 +129,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"

--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -129,7 +129,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
+      options: --device=/dev/kfd --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950.1') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950.4') ||
         (contains(inputs.runner, 'gfx950.8') && 'gfx950.8') }}, ROCm ${{ inputs.rocm-version }}, py${{ inputs.python }}"

--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   build-jax-in-docker:
     if: github.repository_owner == 'jax-ml' || github.repository_owner == 'ROCm'
-    runs-on: linux-x86_64-cirrascale-64-8gpu-amd-mi250
+    runs-on: amd-do-linux.jax.gpu.gfx950.8
     env:
       BASE_IMAGE: "ubuntu:22.04"
       TEST_IMAGE: ubuntu-jax-upstream-${{ github.run_id }}_${{ github.run_number }}_${{ github.run_attempt }}

--- a/.github/workflows/rocm_release_publish.yml
+++ b/.github/workflows/rocm_release_publish.yml
@@ -1,0 +1,78 @@
+# CI - ROCm Release: Publish Final Release Wheels
+#
+# Copies wheels from a release-validation build to the release/ path as the
+# canonical published artifacts. Lives in ROCm/jax only — not upstreamed.
+name: CI - ROCm Release Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      repository:
+        description: "Source repository (e.g. ROCm/jax)"
+        required: false
+        default: "ROCm/jax"
+        type: string
+      branch:
+        description: "Release branch name (e.g. rocm-jaxlib-v0.11.0)"
+        required: true
+        type: string
+      rocm-release-version:
+        description: "ROCm release version (e.g. 7.2.0, therock-7.13.0, therock-latest)"
+        required: true
+        type: string
+      run-number:
+        description: "Release-validation run number to publish"
+        required: true
+        type: string
+      run-attempt:
+        description: "Release-validation run attempt to publish"
+        required: false
+        default: "1"
+        type: string
+
+permissions: {}
+
+jobs:
+  publish-release:
+    if: github.repository_owner == 'ROCm'
+    runs-on: amd-do-linux.jax.gpu.gfx950.1
+    container:
+      image: ghcr.io/rocm/jax-base-ubu24.rocm720:latest  # zizmor: ignore[unpinned-images]
+    defaults:
+      run:
+        shell: bash
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # ratchet:aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: arn:aws:iam::661452401056:role/jax-ci-amd-s3-oidc
+          aws-region: us-east-1
+
+      - name: Publish wheels to release/
+        env:
+          REPOSITORY: ${{ inputs.repository }}
+          BRANCH: ${{ inputs.branch }}
+          ROCM_VERSION: ${{ inputs.rocm-release-version }}
+          RUN_NUMBER: ${{ inputs.run-number }}
+          RUN_ATTEMPT: ${{ inputs.run-attempt }}
+        run: |
+          SOURCE="s3://jax-ci-amd/rocm-wheels/${REPOSITORY}/${BRANCH}/${ROCM_VERSION}/release-validation/${RUN_NUMBER}/${RUN_ATTEMPT}"
+          DEST="s3://jax-ci-amd/rocm-wheels/${REPOSITORY}/${BRANCH}/${ROCM_VERSION}/release"
+
+          echo "Publishing: ${SOURCE} -> ${DEST}"
+
+          WHEEL_COUNT=$(aws s3 ls --recursive "${SOURCE}/" | grep -c '\.whl$' || true)
+          if [[ "${WHEEL_COUNT}" -eq 0 ]]; then
+            echo "Error: no .whl files found at ${SOURCE}. Aborting."
+            exit 1
+          fi
+          echo "Found ${WHEEL_COUNT} wheel(s) to publish."
+
+          aws s3 sync --delete --only-show-errors "${SOURCE}/" "${DEST}/"
+
+          echo "Published wheels at ${DEST}:"
+          aws s3 ls "${DEST}/" | grep '\.whl'

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -355,7 +355,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+          runner: ["amd-do-linux.jax.cpu"]
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -359,7 +359,9 @@ jobs:
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", manylinux-image: ""},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        manylinux-image: ""},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-7.13.0:latest"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
           ]
           exclude:
             - artifact: "jax-rocm-pjrt"
@@ -392,7 +394,9 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  tag: "therock-7.13.0"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
     name: "Pytest ROCm (${{ matrix.rocm.label }})"
     with:
@@ -419,7 +423,9 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  tag: "therock-7.13.0"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
           enable-x64: [0]
     name: "Bazel ROCm (${{ matrix.rocm.label }})"

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -181,7 +181,9 @@ jobs:
           artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", manylinux-image: ""},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        manylinux-image: ""},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-7.13.0:latest"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"},
           ]
           exclude:
             - artifact: "jax-rocm-pjrt"
@@ -214,7 +216,9 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  tag: "therock-7.13.0"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
     name: "Pytest ROCm (${{ matrix.rocm.label }})"
     with:
@@ -241,7 +245,9 @@ jobs:
           runner: ["amd-do-linux.jax.gpu.gfx950.1"]
           python: ["3.12", "3.13", "3.14"]
           rocm: [
-            {label: "ROCm 7.2.0", wheel-version: "7", release-version: "7.2.0", tag: "rocm720"},
+            {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"},
+            {label: "TheRock 7.13",   wheel-version: "7", release-version: "therock-7.13.0",  tag: "therock-7.13.0"},
+            {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"},
           ]
           enable-x64: [0]
     name: "Bazel ROCm (${{ matrix.rocm.label }})"

--- a/.github/workflows/wheel_tests_rocm_release.yml
+++ b/.github/workflows/wheel_tests_rocm_release.yml
@@ -33,6 +33,31 @@ concurrency:
 permissions: {}
 
 jobs:
+  therock-config:
+    # Single source of truth for the TheRock ROCm version, reused by the
+    # build / pytest / bazel matrices below so the version is defined once.
+    # TODO: bump the TV value here when moving to the next TheRock rc/release.
+    if: github.repository_owner == 'ROCm'
+    runs-on: ubuntu-latest
+    outputs:
+      build-matrix: ${{ steps.set.outputs.build-matrix }}
+      test-matrix: ${{ steps.set.outputs.test-matrix }}
+    steps:
+      - id: set
+        run: |
+          TV="7.14.0rc3"
+          IMG="ghcr.io/rocm/jax-manylinux_2_28-therock-${TV}:latest"
+          {
+            echo "build-matrix<<JSON"
+            echo "[{\"label\": \"ROCm 7.2.0\", \"wheel-version\": \"7\", \"release-version\": \"7.2.0\", \"manylinux-image\": \"\"},"
+            echo " {\"label\": \"TheRock ${TV}\", \"wheel-version\": \"7\", \"release-version\": \"therock-${TV}\", \"manylinux-image\": \"${IMG}\"}]"
+            echo "JSON"
+            echo "test-matrix<<JSON"
+            echo "[{\"label\": \"ROCm 7.2.0\", \"wheel-version\": \"7\", \"release-version\": \"7.2.0\", \"tag\": \"rocm720\"},"
+            echo " {\"label\": \"TheRock ${TV}\", \"wheel-version\": \"7\", \"release-version\": \"therock-${TV}\", \"tag\": \"therock-${TV}\"}]"
+            echo "JSON"
+          } >> "$GITHUB_OUTPUT"
+
   compute-post-suffix:
     if: github.repository_owner == 'ROCm'
     runs-on: ubuntu-latest
@@ -72,7 +97,7 @@ jobs:
 
   build-rocm-artifacts:
     if: github.repository_owner == 'ROCm'
-    needs: [compute-post-suffix]
+    needs: [compute-post-suffix, therock-config]
     uses: ./.github/workflows/build_rocm_artifacts.yml
     permissions:
       id-token: write
@@ -84,9 +109,7 @@ jobs:
         runner: ["amd-do-linux.jax.gpu.gfx950.1"]
         artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
         python: ["3.11", "3.12", "3.13", "3.14"]
-        rocm:
-          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        manylinux-image: ""}
-          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"}
+        rocm: ${{ fromJSON(needs.therock-config.outputs.build-matrix) }}
         exclude:
           - artifact: "jax-rocm-pjrt"
             python: "3.11"
@@ -110,7 +133,7 @@ jobs:
 
   run-pytest-rocm:
     if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
-    needs: [build-rocm-artifacts]
+    needs: [build-rocm-artifacts, therock-config]
     permissions:
       id-token: write
       contents: read
@@ -121,9 +144,7 @@ jobs:
       matrix:
         runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
         python: ["3.11", "3.12", "3.13", "3.14"]
-        rocm:
-          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
-          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+        rocm: ${{ fromJSON(needs.therock-config.outputs.test-matrix) }}
     name: "Pytest ROCm (${{ matrix.rocm.label }})"
     with:
       runner: ${{ matrix.runner }}
@@ -138,7 +159,7 @@ jobs:
 
   run-bazel-test-rocm:
     if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
-    needs: [build-rocm-artifacts]
+    needs: [build-rocm-artifacts, therock-config]
     permissions:
       id-token: write
       contents: read
@@ -148,9 +169,7 @@ jobs:
       matrix:
         runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.8"]
         python: ["3.11", "3.12", "3.13", "3.14"]
-        rocm:
-          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
-          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+        rocm: ${{ fromJSON(needs.therock-config.outputs.test-matrix) }}
         enable-x64: [0]
     name: "Bazel ROCm (${{ matrix.rocm.label }})"
     with:

--- a/.github/workflows/wheel_tests_rocm_release.yml
+++ b/.github/workflows/wheel_tests_rocm_release.yml
@@ -1,0 +1,169 @@
+# CI - ROCm Release Wheel Build + Test
+#
+# Builds jax-rocm-plugin and jax-rocm-pjrt wheels stamped with the release version,
+# uploads them to a per-run staging path in S3, and runs ROCm tests against that
+# exact build. Lives in ROCm/jax only — not upstreamed.
+#
+# S3 layout under s3://jax-ci-amd/rocm-wheels/<repo>/<branch>/<rocm-ver>/:
+#   release-validation/<run_number>/<run_attempt>/   ← this workflow uploads here
+#   release/                                         ← published by rocm_release_publish.yml
+name: CI - ROCm Release Wheel Build + Test
+
+on:
+  push:
+    branches:
+      - 'rocm-jaxlib-v*'
+  workflow_dispatch:
+    inputs:
+      halt-for-connection:
+        description: 'Should this workflow run wait for a remote connection? (yes/no)'
+        required: false
+        default: 'no'
+        type: string
+      wheel-version-suffix:
+        description: "Version suffix (e.g., .post1). Use 'auto' to compute from PyPI. Leave empty for no suffix."
+        required: false
+        default: ''
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  compute-post-suffix:
+    if: github.repository_owner == 'ROCm'
+    runs-on: ubuntu-latest
+    outputs:
+      suffix: ${{ steps.compute.outputs.suffix }}
+      jax_version: ${{ steps.compute.outputs.jax_version }}
+    steps:
+      - id: compute
+        run: |
+          SUFFIX_INPUT="${{ inputs.wheel-version-suffix }}"
+
+          # Determine latest JAX version from PyPI
+          BASE_VERSION=$(pip index versions jax 2>/dev/null | head -1 | grep -oP '\(.*?\)' | tr -d '()')
+          echo "jax_version=${BASE_VERSION}" >> $GITHUB_OUTPUT
+
+          # Determine suffix
+          if [[ -n "${SUFFIX_INPUT}" && "${SUFFIX_INPUT}" != "auto" ]]; then
+            echo "suffix=${SUFFIX_INPUT}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          if [[ "${SUFFIX_INPUT}" == "auto" ]]; then
+            VERSIONS=$(pip index versions jax-rocm7-plugin 2>/dev/null | grep "Available versions" | sed 's/.*: //')
+            LATEST_POST=$(echo "$VERSIONS" | tr ',' '\n' | tr -d ' ' | grep "^${BASE_VERSION}\.post" | sort -V | tail -1)
+
+            if [[ -n "$LATEST_POST" ]]; then
+              N=$(echo "$LATEST_POST" | grep -oP 'post\K\d+')
+              echo "suffix=.post$((N+1))" >> $GITHUB_OUTPUT
+            elif echo "$VERSIONS" | tr ',' '\n' | tr -d ' ' | grep -q "^${BASE_VERSION}$"; then
+              echo "suffix=.post1" >> $GITHUB_OUTPUT
+            else
+              echo "suffix=" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "suffix=" >> $GITHUB_OUTPUT
+          fi
+
+  build-rocm-artifacts:
+    if: github.repository_owner == 'ROCm'
+    needs: [compute-post-suffix]
+    uses: ./.github/workflows/build_rocm_artifacts.yml
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1"]
+        artifact: ["jax-rocm-plugin", "jax-rocm-pjrt"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        manylinux-image: ""}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", manylinux-image: "ghcr.io/rocm/jax-manylinux_2_28-therock-latest:latest"}
+        exclude:
+          - artifact: "jax-rocm-pjrt"
+            python: "3.11"
+          - artifact: "jax-rocm-pjrt"
+            python: "3.13"
+          - artifact: "jax-rocm-pjrt"
+            python: "3.14"
+    name: "Build ROCm artifacts (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      artifact: ${{ matrix.artifact }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      manylinux-image: ${{ matrix.rocm.manylinux-image }}
+      artifact-type: release
+      wheel-version-suffix: ${{ needs.compute-post-suffix.outputs.suffix }}
+      clone_main_xla: 0
+      upload_artifacts_to_s3: true
+      s3_upload_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.repository }}/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/release-validation/${{ github.run_number }}/${{ github.run_attempt }}'
+
+  run-pytest-rocm:
+    if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
+    needs: [build-rocm-artifacts]
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+    uses: ./.github/workflows/pytest_rocm.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+    name: "Pytest ROCm (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      jaxlib-version: head
+      download-jax-from-gcs: '0'
+      skip-download-jaxlib-and-plugins-from-gcs: '0'
+      s3_download_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.repository }}/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/release-validation/${{ github.run_number }}/${{ github.run_attempt }}'
+
+  run-bazel-test-rocm:
+    if: ${{ !cancelled() && github.repository_owner == 'ROCm' }}
+    needs: [build-rocm-artifacts]
+    permissions:
+      id-token: write
+      contents: read
+    uses: ./.github/workflows/bazel_rocm.yml
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.8"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
+        rocm:
+          - {label: "ROCm 7.2.0",     wheel-version: "7", release-version: "7.2.0",        tag: "rocm720"}
+          - {label: "TheRock latest", wheel-version: "7", release-version: "therock-latest", tag: "therock-latest"}
+        enable-x64: [0]
+    name: "Bazel ROCm (${{ matrix.rocm.label }})"
+    with:
+      runner: ${{ matrix.runner }}
+      python: ${{ matrix.python }}
+      rocm-version: ${{ matrix.rocm.wheel-version }}
+      rocm-release-version: ${{ matrix.rocm.release-version }}
+      rocm-tag: ${{ matrix.rocm.tag }}
+      enable-x64: ${{ matrix.enable-x64 }}
+      jaxlib-version: head
+      download-jax-from-gcs: '0'
+      build_jaxlib: 'false'
+      build_jax: 'false'
+      s3_download_uri: 's3://jax-ci-amd/rocm-wheels/${{ github.repository }}/${{ github.ref_name }}/${{ matrix.rocm.release-version }}/release-validation/${{ github.run_number }}/${{ github.run_attempt }}'
+      run_multiaccelerator_tests: 'true'
+      clone_main_xla: 0

--- a/build/rocm/Dockerfile.ms
+++ b/build/rocm/Dockerfile.ms
@@ -41,7 +41,9 @@ RUN --mount=type=cache,target=/var/cache/apt \
 
 # Install pyenv with different python versions
 ARG PYTHON_VERSION=3.11.13
-RUN git clone https://github.com/pyenv/pyenv.git /pyenv
+ARG PYENV_COMMIT=135adbb192d32142a648cae7c2f7e491f5c57202
+RUN git clone https://github.com/pyenv/pyenv.git /pyenv && \
+    git -C /pyenv checkout ${PYENV_COMMIT}
 ENV PYENV_ROOT /pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 RUN pyenv install $PYTHON_VERSION

--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -110,7 +110,7 @@ fi
 echo "Final number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
-export XLA_PYTHON_CLIENT_ALLOCATOR=address
+export XLA_PYTHON_CLIENT_ALLOCATOR=default
 export XLA_PYTHON_CLIENT_PREALLOCATE=false
 export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
 

--- a/jaxlib/rocm/rocm_rpath.bzl
+++ b/jaxlib/rocm/rocm_rpath.bzl
@@ -65,7 +65,6 @@ def _rocm_wheel_rpaths():
     where TheRock is in the container's system Python). The legacy `/opt/rocm`
     fallback is appended by the caller so it stays last.
     """
-
     # `_rocm_sdk_core/lib` holds the non-arch runtime libs; `_rocm_sdk_libraries
     # [...]/lib` holds the math libs + per-arch kernel data. site_libs covers the
     # multi-arch + per-family packages; core_libs is the cross-Python/absolute


### PR DESCRIPTION
## What
Pin the pyenv clone in `build/rocm/Dockerfile.ms` to a fixed commit (`135adbb192d32142a648cae7c2f7e491f5c57202`, tag `v2.8.0`) instead of cloning `master` at floating HEAD.

## Why
The wheel-build container cloned `pyenv/pyenv` at default-branch HEAD with no commit pin, then sourced its shell hooks into every subsequent build step. Reported by Mythos AI scan as SEC-00814 (ROCM-26967).

Fixes ROCM-26967 / SEC-00814.