### PR TITLE
Enable additional single-GPU bazel tests in ROCm CI

### DIFF
--- a/build/rocm/ci_test_targets.txt
+++ b/build/rocm/ci_test_targets.txt
@@ -7,49 +7,25 @@
 //tests/pallas:gpu_tests
 //tests/pallas:backend_independent_tests
 //jaxlib/tools:check_gpu_wheel_sources_test
--//tests/pallas:pallas_test_gpu
--//tests/pallas:ops_test_gpu
+
+# Multi-accelerator test (not single-GPU; excluded from single_gpu runs anyway).
 -//tests/pallas:ops_test_mgpu_gpu
--//tests/pallas:pallas_shape_poly_test_gpu
+
+# Flaky: test cases pass but the process hangs during GPU teardown (tracked separately).
 -//tests/pallas:pallas_vmap_test_gpu
--//tests/pallas:triton_pallas_test_gpu
+-//tests:cholesky_update_test_gpu
+
+# Excluded for reasons unrelated to complex GEMM; not yet re-validated on ROCm CI.
 -//tests:export_harnesses_multi_platform_test_gpu
--//tests:jet_test_gpu
--//tests:lax_autodiff_test_gpu
--//tests:lax_numpy_setops_test_gpu
 -//tests:lax_numpy_test_gpu
 -//tests:lax_test_gpu
--//tests:linalg_test_gpu
--//tests:logging_test_gpu
 -//tests:random_lax_test_gpu
--//tests:scipy_signal_test_gpu
--//tests:stax_test_gpu
--//tests:ode_test_gpu
--//tests:lobpcg_test_gpu
--//tests:scipy_stats_test_gpu
--//tests:nn_test_gpu
 -//tests:lax_scipy_sparse_test_gpu
 -//tests:lax_scipy_spectral_dac_test_gpu
--//tests:lax_scipy_special_functions_test_gpu
--//tests:cholesky_update_test_gpu
 -//tests:api_test_gpu
--//tests:ann_test_gpu
--//tests:experimental_rnn_test_gpu
--//tests:lax_vmap_test_gpu
 -//tests:qdwh_test_gpu
--//tests:scaled_dot_test_gpu
--//tests:scipy_spatial_test_gpu
 -//tests:shape_poly_test_gpu
--//tests:sparsify_test_gpu
--//tests:lax_numpy_reducers_test_gpu
--//tests:scipy_optimize_test_gpu
--//tests:lax_numpy_einsum_test_gpu
--//tests:lax_scipy_test_gpu
--//tests:sparse_test_gpu
--//tests:sparse_bcoo_bcsr_test_gpu
--//tests:svd_test_gpu
--//tests:eigh_test_gpu
--//tests:image_test_gpu
+
 # buffer_callback_test_gpu uses py_import deps that are incompatible with
 # pre-built plugin wheels (build_jaxlib=false); exclude it unconditionally.
 -//tests:buffer_callback_test_gpu


### PR DESCRIPTION
## What

Enable 31 additional JAX single-GPU tests in the ROCm CI Bazel suite by removing them from the exclusion list in `build/rocm/ci_test_targets.txt`.

## Why

These tests were previously excluded from the ROCm CI suite:
- 23 were held back but pass on current ROCm GPUs.
- 7 complex (c64/c128) GEMM suites (`lax_numpy_einsum`, `lax_scipy`, `sparse`, `sparse_bcoo_bcsr`, `svd`, `eigh`, `image`) were skipped in jax-ml/jax#38065 pending hipBLASLt complex-GEMM support, which has since landed.
- `linalg_test` — enabled per reviewer request; covers many commonly used functions.

Enabling them increases single-GPU test coverage without any product code changes.

## How

Removed 31 `-//...` exclusion entries from `build/rocm/ci_test_targets.txt`. Remaining exclusions:
- `//tests/pallas:ops_test_mgpu_gpu` — multi-accelerator (not single-GPU)
- `//tests/pallas:pallas_vmap_test_gpu` — flaky: passes but hangs during GPU teardown
- `//tests:cholesky_update_test_gpu` — kept excluded
- `//tests:buffer_callback_test_gpu` — py_import deps incompatible with pre-built plugin wheels
- 9 suites excluded for reasons unrelated to complex GEMM, not yet re-validated on ROCm CI (`export_harnesses_multi_platform`, `lax_numpy`, `lax`, `random_lax`, `lax_scipy_sparse`, `lax_scipy_spectral_dac`, `api`, `qdwh`, `shape_poly`)
