### PR TITLE
ci: bump ROCm release wheel tests to TheRock 7.14 GA

### DIFF
--- a/.github/workflows/wheel_tests_rocm_release.yml
+++ b/.github/workflows/wheel_tests_rocm_release.yml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - id: set
         run: |
-          TV="7.14.0rc3"
+          TV="7.14"
           IMG="ghcr.io/rocm/jax-manylinux_2_28-therock-${TV}:latest"
           {
             echo "build-matrix<<JSON"


### PR DESCRIPTION
## Summary
TheRock 7.14 is now GA. Bump the single-source-of-truth `TV` in the `therock-config` job of `wheel_tests_rocm_release.yml` from `7.14.0rc3` to `7.14`, so the build / pytest / bazel matrices resolve the GA manylinux image `ghcr.io/rocm/jax-manylinux_2_28-therock-7.14:latest` and the `therock-7.14` test tag.

GA follow-up to #812 (which centralized the version in `therock-config`).

## Dependency
Requires ROCm/rocm-jax#487 to merge first so CI publishes the `jax-manylinux_2_28-therock-7.14` images; until then the TheRock lanes here will fail to pull the image (expected). The ROCm 7.2.0 lane is unaffected.

## Test plan
- [ ] After ROCm/rocm-jax#487 merges + images publish, `wheel_tests_rocm_release` build/pytest/bazel lanes for `TheRock 7.14` are green (ROCm 7.2.0 lane unchanged).