### PR TITLE
[ROCm][Pallas] Skip fused attention fwd tests that exceed device resources - backport v0.10.2

### DIFF
--- a/tests/pallas/gpu_ops_test.py
+++ b/tests/pallas/gpu_ops_test.py
@@ -155,7 +155,14 @@ class FusedAttentionTest(PallasBaseTest):
           segment_ids=segment_ids,
           interpret=self.INTERPRET,
       )
-    o = impl(q, k, v)
+
+    try:
+      o = impl(q, k, v)
+    except jax.errors.JaxRuntimeError as e:
+      if "RESOURCE_EXHAUSTED" in str(e):
+        self.skipTest(f"Skipped: block size configuration exceeds device "
+                      f"resources: {e}")
+      raise
     o_ref = attention.mha_reference(q, k, v, segment_ids, causal=causal)
     np.testing.assert_allclose(o, o_ref, atol=0.05)
 


### PR DESCRIPTION
## Summary

This PR is ported from an upstream commit implementing this skip: https://github.com/jax-ml/jax/commit/64392b5751aa7fa6f3939f045f4813abd4ff24b4

Similar to the bwd fused attention case, instead of keeping a hardcoded list of parameter combinations, we catch RESOURCE_EXHAUSTED errors from the compiler and skip the test dynamically. This handles cases where a kernel's shared memory requirements exceed the hardware's limits.

This was added due to similar failures as described in the earlier PR on MI300X machines where certain variants of the fused attention kernel requested more memory than was available, resulting in RESOURCE_EXHAUSTED errors.

## Changes
All changes are contained to the `tests/pallas/gpu_ops_test.py` unit test file. The change is implemented in the `FusedAttentionTest::test_fused_attention_fwd` unit test.

## Test Plan
The variants of the fused attention fwd test that were in question are now skipped when appropriate. Specifically, these were:
- `FusedAttentionTest::test_fused_attention_fwd1`
- `FusedAttentionTest::test_fused_attention_fwd4`

All other `FusedAttentionTest::test_fused_attention_fwd` tests still pass or skip as before.