### PR TITLE
Derive the ROCm plugin package name from the ROCm major version

### DIFF
--- a/jax_plugins/rocm/__init__.py
+++ b/jax_plugins/rocm/__init__.py
@@ -26,7 +26,15 @@ logger = logging.getLogger(__name__)
 
 # rocm_plugin_extension locates inside jaxlib. `jaxlib` is for testing without
 # preinstalled jax rocm plugin packages.
-for pkg_name in ['jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm']:
+_pkg_names = [
+    'jax_rocm10_plugin', 'jax_rocm7_plugin', 'jax_rocm60_plugin', 'jaxlib.rocm'
+]
+# jax_plugins.xla_rocm<major> always ships paired with jax_rocm<major>_plugin.
+_rocm_major = (__package__ or '').rpartition('xla_rocm')[2]
+if _rocm_major.isdigit() and f'jax_rocm{_rocm_major}_plugin' not in _pkg_names:
+  _pkg_names.insert(0, f'jax_rocm{_rocm_major}_plugin')
+
+for pkg_name in _pkg_names:
   try:
     rocm_plugin_extension = importlib.import_module(
         f'{pkg_name}.rocm_plugin_extension'


### PR DESCRIPTION
Cherry-pick of f2251fe65a737d24c8e548634e171f3b2bd82cb2, already merged to
`rocm-jaxlib-v0.10.0`. Applied cleanly with no conflicts.

## Problem

On ROCm 10 the plugin wheel installs as `jax_rocm10_plugin`, but the PJRT shim
only tries `jax_rocm7_plugin`, `jax_rocm60_plugin` and `jaxlib.rocm`. The loop
exhausts, `rocm_plugin_extension` stays `None`, and no custom call targets or FFI
types/handlers are registered:

```
WARNING jax_plugins.xla_rocm10:__init__.py rocm_plugin_extension is not found.
NOT_FOUND: No FFI handler registered for hipsolver_getrf_ffi on a platform ROCM
```

All 15 `Test JAX` jobs in ROCm/TheRock run
[30561401221](https://github.com/ROCm/TheRock/actions/runs/30561401221) (ROCm
10.0.0.dev0) failed this way on every release branch, 1468 failures per job, of
which about 1240 are missing FFI handlers caused by this bug.

## Fix

The pjrt and kernel wheels are generated from the same `rocm_version`
placeholder, so they always share a ROCm major: `jax_plugins.xla_rocm<major>`
pairs with `jax_rocm<major>_plugin`. The major is read back out of this package's
own name and that plugin is tried first, which also covers future majors.

`jax_rocm10_plugin` is additionally in the static list, because that list is all
that gets consulted when running from a source checkout where the package is
still named `jax_plugins.rocm` and the major cannot be derived. The previously
hardcoded majors remain as fallbacks, so ROCm 7 and 6.0 installs and the
`jaxlib.rocm` testing path are unaffected.

## Testing

Discovery verified against this branch's patched file under simulated install
layouts: ROCm 10 pair resolves `jax_rocm10_plugin`; ROCm 7 and 6.0 pairs resolve
as before; `jax_plugins.rocm` still falls back to `jaxlib.rocm`; source layout
with only a ROCm 10 plugin resolves it; ROCm 10 pjrt with only a ROCm 7 plugin
prefers the one that exists; missing plugin and absent `__package__` return
`None` without raising; a hypothetical ROCm 11 pair resolves.

## Out of scope

The remaining failures per job come from a separate break in upstream
`jaxlib/plugin_support.py`, which has its own hardcoded
`"rocm": ["jax_rocm7_plugin", "jax_rocm60_plugin"]` and gates the GPU kernel
modules. Since `jaxlib` is installed from upstream PyPI on this branch, it cannot
be fixed here; it is patched in TheRock CI and being upstreamed separately.
