### PR TITLE
[ROCm] Drop the rocm-sdk PATH block from run_pytest_rocm.sh

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -36,17 +36,6 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
-# TheRock (pip) ROCm images are intentionally /opt/rocm-less, so ROCm CLI tools
-# (rocminfo, rocm-smi, ...) live in the SDK bin dir rather than on PATH. Put
-# them on PATH via rocm-sdk. apt-ROCm images lack rocm-sdk and already have
-# these tools on PATH, so the gate leaves them untouched.
-if command -v rocm-sdk >/dev/null 2>&1; then
-  sdk_bin="$(rocm-sdk path --bin)"
-  if [[ -n "$sdk_bin" ]]; then
-    export PATH="$sdk_bin:$PATH"
-  fi
-fi
-
 rocm-smi
 
 # ==============================================================================


### PR DESCRIPTION
Cherry-pick of #827 onto `rocm-jaxlib-v0.10.2`.

## Motivation
The suite cannot run with `rocm[libraries]`. `rocm-sdk path --bin` needs `rocm[devel]` and exits 1 without it. The script runs under `set -exu`, so it stops there, before any test runs. Tests do not need `rocm[devel]`.
## Technical details
The block was meant to put `rocminfo` and `rocm-smi` on PATH in the `/opt/rocm`-less pip images. It cannot be what puts them there:
- `rocm-sdk-core` installs `rocminfo`, `rocm-smi` and `amd-smi` as pip console scripts. `rocm-sdk` is a console script too, from the `rocm` package. They all go to the same directory: `/usr/local/bin` in `ghcr.io/rocm/jax-base-ubu24.therock-7.14`.
- These tools do not need devel. `rocm_sdk_core._cli.rocm_smi` calls `_exec("bin/rocm-smi", expand_devel=False)`, so it runs the copy in the core wheel.
- The binaries find their libraries through their own RPATH (`$ORIGIN/../lib`), so no `LD_LIBRARY_PATH` is needed.
So the gate is pointless: if `command -v rocm-sdk` works, the tools are already on PATH. If it fails, the block does nothing.
## Test plan
8-GPU host, container from `ghcr.io/rocm/jax-base-ubu24.therock-7.14`, jax 0.11.0 with `jax-rocm7-plugin` 0.11.0, `LD_LIBRARY_PATH` unset.
Run twice: once with `rocm-sdk-devel` installed, once with it removed (the `rocm[libraries]` case). Each time check:
1. `rocminfo` and `rocm-smi` work without touching PATH
2. `ldd` finds every library for the plugin and pjrt `.so` files
3. GPU ops: matmul, cholesky, eigh, conv, 8-way `psum`
4. `pytest tests/nn_test.py -k Softmax` and `pytest tests/pmap_test.py -k testPsum`
## Test result
Same in both cases:
| Check | Result |
| --- | --- |
| `rocminfo` / `rocm-smi` | 8 GPUs, VRAM reported, both from `/usr/local/bin` |
| `ldd` on 8 `.so` files | 0 missing |
| GPU ops | backend `gpu`, 8 devices, all results correct |
| `nn_test -k Softmax` | 10 passed, 1 skipped |
| `pmap_test -k testPsum` | 5 passed |

Without devel, the removed command fails as expected:
`$ rocm-sdk path --bin ERROR: rocm_sdk_devel module for the ROCm SDK development package is not installed. exit=1`



