### PR TITLE
[ROCm] Split the multi-accelerator tests into their own script

### DIFF
--- a/ci/run_pytest_rocm.sh
+++ b/ci/run_pytest_rocm.sh
@@ -16,6 +16,9 @@
 # Runs Pytest ROCm tests. Requires the jaxlib and ROCm plugin wheels to be
 # present inside $JAXCI_OUTPUT_DIR (../dist)
 #
+# Runs the single-accelerator tests, then hands the multi-accelerator ones to
+# ci/run_pytest_rocm_multi.sh when the host has the GPUs for them.
+#
 # -e: abort script if one command fails
 # -u: error if undefined variable used
 # -x: log all commands
@@ -23,102 +26,13 @@
 # -o allexport: export all functions and variables to be available to subscripts
 set -exu -o history -o allexport
 
-# Source default JAXCI environment variables.
-source ci/envs/default.env
-
-# Install jaxlib and ROCm plugin wheels inside the $JAXCI_OUTPUT_DIR directory
-echo "Installing wheels locally..."
-source ./ci/utilities/install_wheels_locally.sh
-
-# Print all the installed packages
-echo "Installed packages:"
-"$JAXCI_PYTHON" -m uv pip freeze
-
-"$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
-
-rocm-smi
-
-# ==============================================================================
-# Set up the generic test environment variables
-# ==============================================================================
-export PY_COLORS=1
-export JAX_SKIP_SLOW_TESTS=true
-export NCCL_DEBUG=WARN
-export TF_CPP_MIN_LOG_LEVEL=0
-export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
-
-# ==============================================================================
-# Calculate the optimal number of parallel processes for pytest
-# This will be the minimum of: GPU capacity, CPU core count, and a system RAM limit.
-# ==============================================================================
-
-export gpu_count=$(rocminfo | egrep -c "Device Type:\s+GPU")
-echo "Number of GPUs detected: $gpu_count"
-
-# Query GPU 0 memory using rocm-smi
-export memory_per_gpu_mib=$(rocm-smi -d 0 --showmeminfo vram | grep -i "vram total" | awk '{print int($NF/1024/1024)}' | head -1)
-echo "Reported memory per GPU: $memory_per_gpu_mib MiB"
-
-# Convert effective memory from MiB to GiB.
-export memory_per_gpu_gib=$((memory_per_gpu_mib / 1024))
-echo "Effective memory per GPU: $memory_per_gpu_gib GiB"
-
-# Allow 2 GiB of GPU RAM per test.
-export max_tests_per_gpu=$((memory_per_gpu_gib / 2))
-echo "Max tests per GPU (assuming 2GiB/test): $max_tests_per_gpu"
-
-export num_processes=$((gpu_count * max_tests_per_gpu))
-echo "Initial number of processes based on GPU capacity: $num_processes"
-
-export num_cpu_cores=$(nproc)
-echo "Number of CPU cores available: $num_cpu_cores"
-
-# Reads total memory from /proc/meminfo (in KiB) and converts to GiB.
-export total_ram_gib=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
-echo "Total system RAM: $total_ram_gib GiB"
-
-# Set a safety limit for system RAM usage, e.g., 1/6th of total.
-export host_memory_limit=$((total_ram_gib / 6))
-echo "Host memory process limit (1/6th of total RAM): $host_memory_limit"
-
-if [[ $num_cpu_cores -lt $num_processes ]]; then
-  num_processes=$num_cpu_cores
-  echo "Adjusting num_processes to match CPU core count: $num_processes"
-fi
-
-if [[ $host_memory_limit -lt $num_processes ]]; then
-  num_processes=$host_memory_limit
-  echo "Adjusting num_processes to match host memory limit: $num_processes"
-fi
-
-if [[ 16 -lt $num_processes ]]; then
-  num_processes=16
-  echo "Reducing num_processes to $num_processes"
-fi
-
-echo "Final number of processes to run: $num_processes"
-
-export JAX_ENABLE_ROCM_XDIST="$gpu_count"
-export XLA_PYTHON_CLIENT_ALLOCATOR=default
-export XLA_PYTHON_CLIENT_PREALLOCATE=false
-if command -v rocm-sdk &>/dev/null; then
-  export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer= --xla_gpu_enable_cublaslt=false"
-else
-  export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
-fi
+source ./ci/utilities/prepare_rocm_tests.sh
 
 # ==============================================================================
 # Run tests
 # ==============================================================================
 
-# Disable core dumps just in case
-ulimit -c 0
-
 echo "Running ROCm tests..."
-export NPROC=32
-LOGS_DIR="logs"
-mkdir -p "${LOGS_DIR}"
-mkdir -p test-artifacts
 
 # Don't abort the script if one command fails to ensure we run both test
 # commands below.
@@ -129,26 +43,13 @@ set +e
 --json-report --json-report-file=${LOGS_DIR}/pytest_results_single.json \
 --junitxml=test-artifacts/junit-single.xml \
 -m "not multiaccelerator" \
---deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
---deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
---deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
+$rocm_pytest_deselect \
 tests
 
 first_cmd_retval=$?
 
 if [[ $gpu_count -gt 1 ]]; then
-  # Run multi-accelerator tests across all GPUs without xdist.
-  unset JAX_ENABLE_ROCM_XDIST
-
-  "$JAXCI_PYTHON" -m pytest --tb=short \
-    --json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
-    --junitxml=test-artifacts/junit-multi.xml \
-    -m "multiaccelerator" \
-    --deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
-    --deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
-    --deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric \
-    tests
-
+  ./ci/run_pytest_rocm_multi.sh
   second_cmd_retval=$?
 else
   echo "Skipping multi-accelerator tests (only $gpu_count GPU detected)"

--- a/ci/run_pytest_rocm_multi.sh
+++ b/ci/run_pytest_rocm_multi.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Runs the multi-accelerator ROCm tests, the only subset that needs more than
+# one GPU. Requires the jaxlib and ROCm plugin wheels to be present inside
+# $JAXCI_OUTPUT_DIR (../dist)
+#
+# ci/run_pytest_rocm.sh calls this for the second half of a full run, and CI
+# that puts this subset on a multi-GPU runner calls it on its own.
+#
+# -e: abort script if one command fails
+# -u: error if undefined variable used
+# -x: log all commands
+# -o history: record shell history
+# -o allexport: export all functions and variables to be available to subscripts
+set -exu -o history -o allexport
+
+source ./ci/utilities/prepare_rocm_tests.sh
+
+# Running this script is a request for these tests, so a host that cannot run
+# them fails instead of reporting success without having run anything.
+if [[ $gpu_count -le 1 ]]; then
+  echo "Multi-accelerator tests need more than one GPU, found $gpu_count" >&2
+  exit 1
+fi
+
+echo "Running multi-accelerator ROCm tests..."
+
+# Run multi-accelerator tests across all GPUs without xdist.
+unset JAX_ENABLE_ROCM_XDIST
+
+"$JAXCI_PYTHON" -m pytest --tb=short \
+--json-report --json-report-file=${LOGS_DIR}/pytest_results_multi.json \
+--junitxml=test-artifacts/junit-multi.xml \
+-m "multiaccelerator" \
+$rocm_pytest_deselect \
+tests

--- a/ci/utilities/prepare_rocm_tests.sh
+++ b/ci/utilities/prepare_rocm_tests.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# Everything a ROCm pytest run needs before it can call pytest: the JAXCI
+# defaults, the wheels under test, and the shared test environment. Sourced by
+# ci/run_pytest_rocm.sh and by ci/run_pytest_rocm_multi.sh, either of which may
+# be the one a caller starts, so doing this twice in a run is a no-op.
+
+if [[ -n "${rocm_tests_prepared:-}" ]]; then
+  return 0
+fi
+rocm_tests_prepared=1
+
+# Source default JAXCI environment variables.
+source ci/envs/default.env
+
+# Install jaxlib and ROCm plugin wheels inside the $JAXCI_OUTPUT_DIR directory
+echo "Installing wheels locally..."
+source ./ci/utilities/install_wheels_locally.sh
+
+# Print all the installed packages
+echo "Installed packages:"
+"$JAXCI_PYTHON" -m uv pip freeze
+
+"$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
+
+rocm-smi
+
+source ./ci/utilities/rocm_test_env.sh
+
+# Disable core dumps just in case
+ulimit -c 0
+
+export NPROC=32
+LOGS_DIR="logs"
+mkdir -p "${LOGS_DIR}"
+mkdir -p test-artifacts

--- a/ci/utilities/rocm_test_env.sh
+++ b/ci/utilities/rocm_test_env.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+#
+# The environment the ROCm pytest runs share. Sourced by
+# ci/utilities/prepare_rocm_tests.sh, and on its own by anything that needs to
+# reproduce the environment of a run without starting one. Requires
+# ci/envs/default.env to have been sourced already.
+
+# ==============================================================================
+# Set up the generic test environment variables
+# ==============================================================================
+export PY_COLORS=1
+export JAX_SKIP_SLOW_TESTS=true
+export NCCL_DEBUG=WARN
+export TF_CPP_MIN_LOG_LEVEL=0
+export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
+
+# ==============================================================================
+# Calculate the optimal number of parallel processes for pytest
+# This will be the minimum of: GPU capacity, CPU core count, and a system RAM limit.
+# ==============================================================================
+
+export gpu_count=$(rocminfo | egrep -c "Device Type:\s+GPU")
+echo "Number of GPUs detected: $gpu_count"
+
+# Query GPU 0 memory using rocm-smi
+export memory_per_gpu_mib=$(rocm-smi -d 0 --showmeminfo vram | grep -i "vram total" | awk '{print int($NF/1024/1024)}' | head -1)
+echo "Reported memory per GPU: $memory_per_gpu_mib MiB"
+
+# Convert effective memory from MiB to GiB.
+export memory_per_gpu_gib=$((memory_per_gpu_mib / 1024))
+echo "Effective memory per GPU: $memory_per_gpu_gib GiB"
+
+# Allow 2 GiB of GPU RAM per test.
+export max_tests_per_gpu=$((memory_per_gpu_gib / 2))
+echo "Max tests per GPU (assuming 2GiB/test): $max_tests_per_gpu"
+
+export num_processes=$((gpu_count * max_tests_per_gpu))
+echo "Initial number of processes based on GPU capacity: $num_processes"
+
+export num_cpu_cores=$(nproc)
+echo "Number of CPU cores available: $num_cpu_cores"
+
+# Reads total memory from /proc/meminfo (in KiB) and converts to GiB.
+export total_ram_gib=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
+echo "Total system RAM: $total_ram_gib GiB"
+
+# Set a safety limit for system RAM usage, e.g., 1/6th of total.
+export host_memory_limit=$((total_ram_gib / 6))
+echo "Host memory process limit (1/6th of total RAM): $host_memory_limit"
+
+if [[ $num_cpu_cores -lt $num_processes ]]; then
+  num_processes=$num_cpu_cores
+  echo "Adjusting num_processes to match CPU core count: $num_processes"
+fi
+
+if [[ $host_memory_limit -lt $num_processes ]]; then
+  num_processes=$host_memory_limit
+  echo "Adjusting num_processes to match host memory limit: $num_processes"
+fi
+
+if [[ 16 -lt $num_processes ]]; then
+  num_processes=16
+  echo "Reducing num_processes to $num_processes"
+fi
+
+echo "Final number of processes to run: $num_processes"
+
+export JAX_ENABLE_ROCM_XDIST="$gpu_count"
+export XLA_PYTHON_CLIENT_ALLOCATOR=default
+export XLA_PYTHON_CLIENT_PREALLOCATE=false
+if command -v rocm-sdk &>/dev/null; then
+  export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer= --xla_gpu_enable_cublaslt=false"
+else
+  export XLA_FLAGS="--xla_gpu_force_compilation_parallelism=1 --xla_gpu_enable_nccl_comm_splitting=false --xla_gpu_enable_command_buffer="
+fi
+
+# Deselected by both subsets, listed here so the two runs cannot drift apart.
+# Expanded unquoted by the callers, which is why no entry may contain a space.
+export rocm_pytest_deselect="\
+--deselect=tests/multi_device_test.py::MultiDeviceTest::test_computation_follows_data \
+--deselect=tests/multiprocess_gpu_test.py::MultiProcessGpuTest::test_distributed_jax_visible_devices \
+--deselect=tests/compilation_cache_test.py::CompilationCacheTest::test_task_using_cache_metric"


### PR DESCRIPTION
## Motivation

* `run_pytest_rocm.sh` runs the single-accelerator tests and then the multi-accelerator ones in a single invocation, and a caller cannot ask for just one of them. The two therefore cannot be sent to runners with different GPU counts, even though only the multi-accelerator subset needs more than one GPU.
* That subset is a small part of the run: roughly 855 multi-accelerator tests against 29k single-accelerator ones. TheRock CI wants the single-accelerator subset on 1-GPU runners and the multi-accelerator subset on an 8-GPU runner at a lower cadence, and occupying a multi-GPU runner for the whole suite just to reach those tests wastes it.
* The environment cannot express this: `PYTEST_ADDOPTS` cannot override the marker the script passes, because a command-line `-m` takes precedence over one from the environment.
* This revision replaces the `JAXCI_ROCM_TEST_SUBSET` knob of the first one with a script that can be reused on its own, as asked for in review. Same change as jax-ml/jax#39850, for this release branch.

## Technical details

* `ci/run_pytest_rocm_multi.sh` (new) runs the multi-accelerator tests. `ci/run_pytest_rocm.sh` calls it when `gpu_count > 1`, and CI aiming that subset at a multi-GPU runner calls it directly.
* `ci/utilities/prepare_rocm_tests.sh` (new) holds what both need before pytest: the JAXCI defaults, the wheels, the diagnostics, and the environment below. It returns early if it has already run, so a combined run does not install the wheels twice.
* `ci/utilities/rocm_test_env.sh` (new) exports the environment the two runs share, along with the three `--deselect` rules, which used to be spelled out once per invocation and can no longer drift apart.
* `ci/run_pytest_rocm.sh` behaves as it did: the single-accelerator tests, then the multi-accelerator ones when the host has the GPUs for them, exiting with the first non-zero status of the two.
* Running the multi script where one GPU is visible is an error rather than a skip. Calling it is a request for those tests, so a job aimed at the wrong runner fails instead of reporting success without having run anything.
* There is nothing for a caller to set, so `ci/envs/default.env` is untouched.
* The branch's own settings move into `ci/utilities/rocm_test_env.sh` unchanged: `XLA_PYTHON_CLIENT_ALLOCATOR=default` and the `rocm-sdk` conditional that adds `--xla_gpu_enable_cublaslt=false`, which is still evaluated at run time rather than fixed here.

## Test plan

This changes which script makes which pytest call rather than what the tests do, so it is verified by driving the scripts with `pytest` stubbed out and `gpu_count` injected, rather than on a GPU host.

1. Differential check against the scripts before this change, for `gpu_count` in {1, 8} with the stub returning success and failure: compare the full pytest argument list, the exit status, and the environment pytest is handed.
2. `ci/run_pytest_rocm_multi.sh` on its own, on 8 GPUs and on 1.
3. Count the wheel installs per run, including the combined run where one script starts the other.
4. `bash -n` on all four files.

## Test result

| entry point | gpu_count | pytest invocations | exit |
| --- | --- | --- | --- |
| `run_pytest_rocm.sh` | 1 | `not multiaccelerator`; multi skipped (only 1 GPU detected) | 0 |
| `run_pytest_rocm.sh` | 8 | `not multiaccelerator`, then `multiaccelerator` | 0 |
| `run_pytest_rocm_multi.sh` | 8 | `multiaccelerator` only | 0 |
| `run_pytest_rocm_multi.sh` | 1 | none; errors with `needs more than one GPU, found 1` | 1 |

* Differential check: the pytest arguments, the exit status and the environment pytest is handed are identical before and after, for both GPU counts and with the stub returning 0 and 5. The one new name in the environment is the deselect list the two runs now share.
* A failing subset still decides the result: with the stub returning 5, every run above that reached pytest exits 5.
* One wheel install per run in all four cases, so the guard holds where `run_pytest_rocm.sh` starts the multi script.
* The parallelism this branch computes is unchanged, and the multi-accelerator run still uses no xdist.
* `bash -n` passes on all four files.
