### PR TITLE
[ROCm] Simplify pytest parallelism calculation for ROCm CI

### DIFF
--- a/ci/utilities/prepare_rocm_tests.sh
+++ b/ci/utilities/prepare_rocm_tests.sh
@@ -44,7 +44,6 @@ source ./ci/utilities/rocm_test_env.sh
 # Disable core dumps just in case
 ulimit -c 0
 
-export NPROC=32
 LOGS_DIR="logs"
 mkdir -p "${LOGS_DIR}"
 mkdir -p test-artifacts

--- a/ci/utilities/rocm_test_env.sh
+++ b/ci/utilities/rocm_test_env.sh
@@ -29,55 +29,14 @@ export TF_CPP_MIN_LOG_LEVEL=0
 export JAX_ENABLE_X64="$JAXCI_ENABLE_X64"
 
 # ==============================================================================
-# Calculate the optimal number of parallel processes for pytest
-# This will be the minimum of: GPU capacity, CPU core count, and a system RAM limit.
+# Number of parallel processes for pytest: 4 test workers per GPU.
 # ==============================================================================
 
 export gpu_count=$(rocminfo | egrep -c "Device Type:\s+GPU")
 echo "Number of GPUs detected: $gpu_count"
 
-# Query GPU 0 memory using rocm-smi
-export memory_per_gpu_mib=$(rocm-smi -d 0 --showmeminfo vram | grep -i "vram total" | awk '{print int($NF/1024/1024)}' | head -1)
-echo "Reported memory per GPU: $memory_per_gpu_mib MiB"
-
-# Convert effective memory from MiB to GiB.
-export memory_per_gpu_gib=$((memory_per_gpu_mib / 1024))
-echo "Effective memory per GPU: $memory_per_gpu_gib GiB"
-
-# Allow 2 GiB of GPU RAM per test.
-export max_tests_per_gpu=$((memory_per_gpu_gib / 2))
-echo "Max tests per GPU (assuming 2GiB/test): $max_tests_per_gpu"
-
-export num_processes=$((gpu_count * max_tests_per_gpu))
-echo "Initial number of processes based on GPU capacity: $num_processes"
-
-export num_cpu_cores=$(nproc)
-echo "Number of CPU cores available: $num_cpu_cores"
-
-# Reads total memory from /proc/meminfo (in KiB) and converts to GiB.
-export total_ram_gib=$(awk '/MemTotal/ {printf "%.0f", $2/1048576}' /proc/meminfo)
-echo "Total system RAM: $total_ram_gib GiB"
-
-# Set a safety limit for system RAM usage, e.g., 1/6th of total.
-export host_memory_limit=$((total_ram_gib / 6))
-echo "Host memory process limit (1/6th of total RAM): $host_memory_limit"
-
-if [[ $num_cpu_cores -lt $num_processes ]]; then
-  num_processes=$num_cpu_cores
-  echo "Adjusting num_processes to match CPU core count: $num_processes"
-fi
-
-if [[ $host_memory_limit -lt $num_processes ]]; then
-  num_processes=$host_memory_limit
-  echo "Adjusting num_processes to match host memory limit: $num_processes"
-fi
-
-if [[ 16 -lt $num_processes ]]; then
-  num_processes=16
-  echo "Reducing num_processes to $num_processes"
-fi
-
-echo "Final number of processes to run: $num_processes"
+export num_processes=$((gpu_count * 4))
+echo "Number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"
 export XLA_PYTHON_CLIENT_ALLOCATOR=platform


### PR DESCRIPTION
Cherry-pick of jax-ml/jax#39845 by @magaonka-amd, adapted to where that code lives on this branch. The upstream PR is still open; the companion cherry-picks are on the other three `rocm-jaxlib-v*` branches.

## Motivation

- `num_processes` came from a VRAM / CPU-core / host-RAM heuristic whose last step capped it at 16, so a 1-GPU runner and an 8-GPU runner both ran 16 workers: too many for one GPU and too few for eight.
- Per the infra team, with the way our cluster is set up, four workers per GPU is the number that can be given guaranteed resources.

## Technical details

- Replaces the heuristic with `num_processes=$((gpu_count * 4))` and drops the unused `NPROC` export.
- The upstream commit changed `ci/run_pytest_rocm.sh`. On this branch the test script split moved that code, so the heuristic comes out of `ci/utilities/rocm_test_env.sh` and `NPROC` out of `ci/utilities/prepare_rocm_tests.sh`. Both files end up identical to the ones in jax-ml/jax#39850, apart from the allocator and `XLA_FLAGS` this branch sets.
- The commit keeps its original author.

## Test plan

This changes one number, so it is checked by reading the environment the scripts export rather than on a GPU host.

1. Diff both edited files against the upstream PR's copies, allowing only this branch's allocator and `XLA_FLAGS` lines to differ.
2. Source `ci/utilities/rocm_test_env.sh` with `rocminfo` stubbed at 1 and at 8 GPUs, and compare every variable it exports before and after.
3. `bash -n` on the four `ci` scripts.

## Test result

- Both files match the upstream PR apart from this branch's own environment.
- `num_processes` is the only exported variable that changes: 16 to 4 on one GPU, 16 to 32 on eight. `gpu_count`, `JAX_ENABLE_ROCM_XDIST`, the allocator, `XLA_FLAGS` and the deselect list are untouched, and the heuristic's intermediates are no longer exported.
- `bash -n` passes on all four scripts.
- Timings are in the upstream PR: roughly 15 minutes slower on a 1-GPU runner, near-identical on 4 and 8 GPUs.
