### PR TITLE
[ROCm] Fix ROCm version in plugin wheel metadata

### DIFF
--- a/build/rocm/rocm.bazelrc
+++ b/build/rocm/rocm.bazelrc
@@ -15,6 +15,9 @@ common:rocm --action_env=TF_HIPCC_CLANG="1"
 common:rocm --action_env=TF_ROCM_CLANG="1"
 common:rocm --action_env=CLANG_COMPILER_PATH="/usr/lib/llvm-18/bin/clang"
 common:rocm --action_env=HIPCC_COMPILE_FLAGS_APPEND=--offload-compress
+# Provide a fallback for wheel metadata when WHEEL_VERSION_SUFFIX has no
+# +rocm segment; TheRock manylinux exports ROCM_VERSION.
+common:rocm --action_env=ROCM_VERSION
 common:rocm --copt=-Wno-gnu-offsetof-extensions
 common:rocm --copt=-Qunused-arguments
 common:rocm --repo_env=TF_ROCM_AMDGPU_TARGETS="gfx900,gfx906,gfx908,gfx90a,gfx942,gfx950,gfx90c,gfx1010,gfx1011,gfx1012,gfx1030,gfx1031,gfx1032,gfx1033,gfx1034,gfx1035,gfx1036,gfx1100,gfx1101,gfx1102,gfx1103,gfx1150,gfx1151,gfx1152,gfx1153,gfx1200,gfx1201"

--- a/jax_plugins/rocm/BUILD.bazel
+++ b/jax_plugins/rocm/BUILD.bazel
@@ -31,6 +31,7 @@ exports_files([
     "plugin_pyproject.toml",
     "plugin_setup.py",
     "pyproject.toml",
+    "rocm_version.py",
     "setup.py",
 ])
 

--- a/jax_plugins/rocm/plugin_setup.py
+++ b/jax_plugins/rocm/plugin_setup.py
@@ -16,19 +16,23 @@
 
 import importlib
 import os
+import sys
 from setuptools import setup
 from setuptools.dist import Distribution
+
+# The PEP 517 backend does not put the source root on sys.path.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rocm_version import DEFAULT_ROCM_PATH, detect_rocm_version
 
 __version__ = None
 rocm_version = 0  # placeholder
 project_name = f"jax-rocm{rocm_version}-plugin"
 package_name = f"jax_rocm{rocm_version}_plugin"
 
-# Extract ROCm version from the `ROCM_PATH` environment variable.
-default_rocm_path = "/opt/rocm"
-rocm_path = os.getenv("ROCM_PATH", default_rocm_path)
-rocm_detected_version = rocm_path.split('-')[-1] if '-' in rocm_path else "unknown"
+# Hermetic wheel actions expose WHEEL_VERSION_SUFFIX, but not ROCM_PATH.
+rocm_path = os.getenv("ROCM_PATH", DEFAULT_ROCM_PATH)
 rocm_tag = os.getenv("ROCM_VERSION_EXTRA")
+rocm_detected_version = detect_rocm_version(rocm_path, rocm_tag)
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -56,8 +60,8 @@ setup(
     description=f"JAX Plugin for AMD GPUs (ROCm:{rocm_detected_version})",
     long_description="",
     long_description_content_type="text/markdown",
-    author="Ruturaj4",
-    author_email="Ruturaj.Vaidya@amd.com",
+    author="ROCm JAX Devs",
+    author_email="dl.dl-JAX@amd.com",
     packages=[package_name],
     python_requires=">=3.11",
     install_requires=[f"jax-rocm{rocm_version}-pjrt=={__version__}"],

--- a/jax_plugins/rocm/rocm_version.py
+++ b/jax_plugins/rocm/rocm_version.py
@@ -1,0 +1,52 @@
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helpers for ROCm version strings in plugin/PJRT wheel metadata."""
+
+from __future__ import annotations
+
+import os
+import re
+
+DEFAULT_ROCM_PATH = "/opt/rocm"
+
+
+def _rocm_version_from_wheel_suffix(suffix: str) -> str | None:
+  """Extract the ROCm version from a wheel version suffix, if present."""
+  if not suffix:
+    return None
+  local = suffix.rsplit("+", 1)[-1] if "+" in suffix else suffix.lstrip("+")
+  match = re.search(r"(?i)(?:dev)?rocm(.+)$", local)
+  return match.group(1) if match else None
+
+
+def detect_rocm_version(path: str, tag: str | None) -> str:
+  """Resolve a ROCm version string for package metadata."""
+  if tag:
+    return tag
+  from_suffix = _rocm_version_from_wheel_suffix(
+      os.getenv("WHEEL_VERSION_SUFFIX", "")
+  )
+  if from_suffix:
+    return from_suffix
+  rocm_ver_env = os.getenv("ROCM_VERSION")
+  if rocm_ver_env:
+    return rocm_ver_env
+  for candidate in (path, os.path.realpath(path)):
+    match = re.search(
+        r"(\d+(?:\.\d+)+(?:[._-]?[a-zA-Z]+\d*)*)", candidate
+    )
+    if match:
+      return match.group(1)
+  return "unknown"

--- a/jax_plugins/rocm/setup.py
+++ b/jax_plugins/rocm/setup.py
@@ -16,18 +16,22 @@
 
 import importlib
 import os
+import sys
 from setuptools import setup, find_namespace_packages
+
+# The PEP 517 backend does not put the source root on sys.path.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from rocm_version import DEFAULT_ROCM_PATH, detect_rocm_version
 
 __version__ = None
 rocm_version = 0  # placeholder
 project_name = f"jax-rocm{rocm_version}-pjrt"
 package_name = f"jax_plugins.xla_rocm{rocm_version}"
 
-# Extract ROCm version from the `ROCM_PATH` environment variable.
-default_rocm_path = "/opt/rocm"
-rocm_path = os.getenv("ROCM_PATH", default_rocm_path)
-rocm_detected_version = rocm_path.split('-')[-1] if '-' in rocm_path else "unknown"
+# Hermetic wheel actions expose WHEEL_VERSION_SUFFIX, but not ROCM_PATH.
+rocm_path = os.getenv("ROCM_PATH", DEFAULT_ROCM_PATH)
 rocm_tag = os.getenv("ROCM_VERSION_EXTRA")
+rocm_detected_version = detect_rocm_version(rocm_path, rocm_tag)
 
 def load_version_module(pkg_path):
   spec = importlib.util.spec_from_file_location(
@@ -54,8 +58,8 @@ setup(
     description=f"JAX XLA PJRT Plugin for AMD GPUs (ROCm:{rocm_detected_version})",
     long_description="",
     long_description_content_type="text/markdown",
-    author="Ruturaj4",
-    author_email="Ruturaj.Vaidya@amd.com",
+    author="ROCm JAX Devs",
+    author_email="dl.dl-JAX@amd.com",
     packages=packages,
     install_requires=[],
     url="https://github.com/jax-ml/jax",

--- a/jaxlib/tools/BUILD.bazel
+++ b/jaxlib/tools/BUILD.bazel
@@ -236,6 +236,7 @@ wheel_sources(
     ]) + if_rocm([
         "//jax_plugins/rocm:plugin_pyproject.toml",
         "//jax_plugins/rocm:plugin_setup.py",
+        "//jax_plugins/rocm:rocm_version.py",
     ]),
 )
 
@@ -345,6 +346,7 @@ wheel_sources(
     ]) + if_rocm([
         "//jax_plugins/rocm:pyproject.toml",
         "//jax_plugins/rocm:setup.py",
+        "//jax_plugins/rocm:rocm_version.py",
         "//jax_plugins/rocm:__init__.py",
     ]),
 )

--- a/jaxlib/tools/build_gpu_kernels_wheel.py
+++ b/jaxlib/tools/build_gpu_kernels_wheel.py
@@ -180,6 +180,10 @@ def prepare_wheel_rocm(
       dst_dir=wheel_sources_path,
       dst_filename="setup.py",
   )
+  copy_files(
+      f"{source_file_prefix}jax_plugins/rocm/rocm_version.py",
+      dst_dir=wheel_sources_path,
+  )
   build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)
   write_setup_cfg(wheel_sources_path, cpu)
 

--- a/jaxlib/tools/build_gpu_plugin_wheel.py
+++ b/jaxlib/tools/build_gpu_plugin_wheel.py
@@ -161,6 +161,7 @@ def prepare_rocm_plugin_wheel(
         src_files=[
           f"{source_file_prefix}jax_plugins/rocm/pyproject.toml",
           f"{source_file_prefix}jax_plugins/rocm/setup.py",
+          f"{source_file_prefix}jax_plugins/rocm/rocm_version.py",
       ],
   )
   build_utils.update_setup_with_rocm_version(wheel_sources_path, rocm_version)


### PR DESCRIPTION
# Description

Hermetic ROCm wheel builds publish `ROCm:unknown` in the plugin and PJRT package Summary because setup.py only parsed a hyphenated `/opt/rocm-<ver>` path. That layout is absent for TheRock/`rocm-sdk` installs, so PyPI metadata has been wrong since packaging moved off `rocm-jax`.

- Prefer `WHEEL_VERSION_SUFFIX` (already injected into the hermetic wheel action, e.g. `+rocm10.0.0rc2`) when forming the Summary.
- Fall back to `ROCM_VERSION_EXTRA`, then `ROCM_VERSION`, then a versioned `ROCM_PATH`.
- Propagate `ROCM_VERSION` into ROCm actions via `--action_env` for suffix-free builds.
- Attribute the wheels to the ROCm JAX dev list (`dl.dl-JAX@amd.com`).

Package versions are unchanged; only Summary metadata is affected.

### Testing

- Executed both setup scripts under hermetic-style envs (`+rocm10.0.0rc2`, nightly/dev suffixes, `ROCM_VERSION`, `ROCM_VERSION_EXTRA`, legacy `/opt/rocm-<ver>`, bare `/opt/rocm`).
- Built PJRT and plugin wheels with `WHEEL_VERSION_SUFFIX=+rocm10.0.0rc2` and confirmed METADATA `Summary: ... (ROCm:10.0.0rc2)`.
