### PR TITLE
Move the XLA pin to the head of rocm-jaxlib-v0.10.2

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,5 +21,5 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "55f5563f2ff8b0d5459f4b36e77cf1d005ce56fd"
-XLA_SHA256 = "a392ed67a3e20ade33e6d3ea660b688ef41afe3b00cd2c97e17f8cad83c3ae86"
+XLA_COMMIT = "40c2800533498f01e4d891b0112c255ec0defcc3"
+XLA_SHA256 = "5d9769472deef4d3fa2e8038bf852aede99e273d9b7d7508838b79542bc2f8a1"


### PR DESCRIPTION
## Why

The pin sits five commits behind `rocm-jaxlib-v0.10.2` in ROCm/xla, and those
five carry fixes this branch does not have:

| commit | |
| --- | --- |
| `7907eb3094` | Important fixes for GpuBlasLt MatmulPlan cache (#995) |
| `3d4bea10cf` | [XLA:GPU][ROCm] Fix absl::bit_cast in device code for GCC 13 compatibility (#1016) |
| `7b5ecf1c92` | Update expected ROCm fingerprint |
| `ea2bcb9f72` | Clean up release branch 0.10.2 (#1069) |
| `40c2800533` | [ROCm] Make sure CreateOwningCudaCubinInMemorySpec interns its cubin buffer |

`3d4bea10cf` is the one that matters most here. Without it,
`buffer_debug_float_check_kernel_rocm.cu.cc` reaches `std::is_trivially_copyable`
from a `__device__ constexpr` initializer through `absl::bit_cast`, and libstdc++
13 and newer implement that trait with a host-only `__or_fn`. A device compiler
that applies its host/device check inside the unevaluated `decltype` rejects the
file:

```
error: no matching function for call to '__or_fn'
note: in instantiation of template class 'std::is_trivially_copyable<_Float16>' requested here
note: candidate function not viable: call to __host__ function from __device__ function
```

This branch builds today, so this is not a fix for a current failure. It is
worth taking because `rocm-jaxlib-v0.10.1` fails exactly this way on the newer
compiler drops, and nothing in the pinned source protects this branch from the
same fate; what spares it today is the surrounding build configuration, not the
code.

## Test plan

* jax-rocm10 plugin and PJRT wheels build for `rocm-jaxlib-v0.10.2`
* The JAX test suite passes on gfx942