### PR TITLE
Move the XLA pin past the device-code bit_cast fix

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,6 +21,6 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "09e89cdfc6cf4d212a192929683fa08bda62e5c5"
-XLA_SHA256 = "549ecac3eb32add1cccfda455269f31d748144a75346f4f59bb7b28a33202fa0"
+XLA_COMMIT = "248ec02987704e64e8f6a88a2ea4c2d7753b6424"
+XLA_SHA256 = "37506af90f6445c376b6f89507bf29cc0be6b6144cdeddfc1e5c1e29b68222ed"
 

--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,6 +21,6 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "248ec02987704e64e8f6a88a2ea4c2d7753b6424"
-XLA_SHA256 = "37506af90f6445c376b6f89507bf29cc0be6b6144cdeddfc1e5c1e29b68222ed"
+XLA_COMMIT = "2418c88b5d24d14c412ca2f22223811466f3f5fb"
+XLA_SHA256 = "ebb95ad9c449968da543f6333d0e00df7e62d317b288d1fbc0302f7a90f48c73"
 


### PR DESCRIPTION
## Why

jaxlib does not build on this branch against the newer ROCm 10 compiler drops.
`buffer_debug_float_check_kernel_rocm.cu.cc` reaches `std::is_trivially_copyable`
from a `__device__ constexpr` initializer through `absl::bit_cast`, and libstdc++
13 and newer implement that trait with a host-only `__or_fn`, so the device
compiler rejects the file:

```
error: no matching function for call to '__or_fn'
note: in instantiation of template class 'std::is_trivially_copyable<_Float16>' requested here
note: candidate function not viable: call to __host__ function from __device__ function
    45 |     absl::bit_cast<_Float16>(uint16_t{0x7C00});
```

ROCm/xla#1110 fixed this on `rocm-jaxlib-v0.10.1` by using `__builtin_bit_cast`,
which instantiates no traits. This moves the pin to that merge commit,
`2418c88`, picking up one other commit on the way, the branch u-test cleanup
`abd6b95`.

`rocm-jaxlib-v0.10.2` and `rocm-jaxlib-v0.11.0` already carry the same fix.

## Test plan

* jax-rocm10 plugin and PJRT wheels build for `rocm-jaxlib-v0.10.1`, which is what fails today
* The JAX test suite passes on gfx942