### PR TITLE
Cherry-pick: [ROCm] Reduce pallas input/output aliasing test size on ROCm

### DIFF
--- a/tests/pallas/pallas_test.py
+++ b/tests/pallas/pallas_test.py
@@ -1398,8 +1398,8 @@ class PallasCallInputOutputAliasingTest(ptu.PallasTest):
   def test_vector_input_output_aliasing(self):
     # Input needs to be big so it doesn't fit in VMEM
     size = 1024
-    if jtu.is_device_cuda():
-      # Reduce the size on CUDA to avoid OOM.
+    if jtu.is_device_cuda() or jtu.is_device_rocm():
+      # Reduce the size on GPU to avoid OOM.
       size = 256
     x = jnp.ones((32, size, size))
     expected = x + 1


### PR DESCRIPTION
Cherry-pick of jax-ml/jax#40097 onto `rocm-jaxlib-v0.10.2`.

`PallasCallInputOutputAliasingTest::test_vector_input_output_aliasing` now uses
the same reduced input size on ROCm that it already uses on CUDA, because on
our older HW MI200 we noticed this test causing OOM.