### PR TITLE
pytest_rocm: add sandbox DPX runner for workflow_dispatch

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -25,6 +25,7 @@ on:
           - "amd-do-linux.jax.gpu.gfx950.4"
           - "amd-do-linux.jax.gpu.gfx950.8"
           - "amd-do-linux.jax.gpu.gfx950.1-dpx"
+          - "amd-sandbox-linux.jax.gpu.gfx950.dpx.1"
       python:
         description: "Which Python version to use?"
         type: choice
@@ -34,9 +35,10 @@ on:
       rocm-version:
         description: "Which ROCm version to test?"
         type: choice
-        default: "7.2.0"
+        default: "7.14.0"
         options:
           - "7.2.0"
+          - "7.14.0"
       rocm-tag:
         description: "ROCm tag for container image (e.g., rocm720)"
         type: string


### PR DESCRIPTION
## Summary
- Add `amd-sandbox-linux.jax.gpu.gfx950.dpx.1` to the `pytest_rocm.yml` workflow_dispatch runner dropdown.
- Add `7.14.0` to the `rocm-version` choices so DPX wheel-test runs can be configured from the GitHub UI.

## Why
The sandbox DPX runner is live on `doks-mi350x-frameworks-dpx-atl1`, but it is not selectable in the workflow UI today. After merge, we can trigger DPX pytest validation without asking for admin workflow_dispatch on `ROCm/jax`.

## Example manual run (after merge)
| Input | Value |
|-------|-------|
| runner | `amd-sandbox-linux.jax.gpu.gfx950.dpx.1` |
| python | `3.12` |
| rocm-version | `7.14.0` |
| rocm-tag | `therock-7.14` |
| s3_download_uri | `s3://jax-ci-amd/rocm-wheels/ROCm/jax/dpx_pytest/7.14.0/wheel-tests-nightly/484/1` |
| jax-jaxlib-source | `s3` |

## Test plan
- [ ] Merge to `dpx_pytest`
- [ ] Trigger **CI - Pytest ROCm** from GitHub Actions UI with the inputs above
- [ ] Confirm job picks up `amd-sandbox-linux.jax.gpu.gfx950.dpx.1` and downloads wheels from the S3 path