### PR TITLE
Route ROCm pytest to prod 1-GPU and DPX 4/8-GPU runners

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -19,9 +19,11 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: choice
-        default: "amd-do-linux.jax.gpu.gfx950.1-dpx"
+        default: "amd-do-linux.jax.gpu.gfx950.1"
         options:
           - "amd-do-linux.jax.gpu.gfx950.1"
+          - "amd-do-linux.jax.gpu.gfx950.4-dpx"
+          - "amd-do-linux.jax.gpu.gfx950.8-dpx"
           - "amd-do-linux.jax.gpu.gfx950.4"
           - "amd-do-linux.jax.gpu.gfx950.8"
           - "amd-do-linux.jax.gpu.gfx950.1-dpx"
@@ -80,7 +82,7 @@ on:
       runner:
         description: "Which runner should the workflow run on?"
         type: string
-        default: "amd-do-linux.jax.gpu.gfx950.1-dpx"
+        default: "amd-do-linux.jax.gpu.gfx950.1"
       python:
         description: "Which Python version to use?"
         type: string

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -587,7 +587,10 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          runner: ["amd-do-linux.jax.gpu.gfx950.1", "amd-do-linux.jax.gpu.gfx950.4", "amd-do-linux.jax.gpu.gfx950.8"]
+          runner:
+            - "amd-do-linux.jax.gpu.gfx950.1"
+            - "amd-do-linux.jax.gpu.gfx950.4-dpx"
+            - "amd-do-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12"]
           rocm: [
             {label: "N (7.14.0)", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -268,8 +268,11 @@ jobs:
     strategy:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
-          # All nightly pytest combos run on the DPX node pool only.
-          runner: ["amd-do-linux.jax.gpu.gfx950.1-dpx"]
+          # 1-GPU on prod DOKS; 4/8-GPU on DPX (amd-gpu-dpx-claim-{4,8}).
+          runner:
+            - "amd-do-linux.jax.gpu.gfx950.1"
+            - "amd-do-linux.jax.gpu.gfx950.4-dpx"
+            - "amd-do-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12", "3.13", "3.14"]
           rocm: [
             {label: "N (7.14.0)", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},


### PR DESCRIPTION
## Summary
- Nightly wheel-test pytest matrix runs **1-GPU on prod** (\md-do-linux.jax.gpu.gfx950.1\) and **4/8-GPU on DPX** (\md-do-linux.jax.gpu.gfx950.4-dpx\, \md-do-linux.jax.gpu.gfx950.8-dpx\).
- Continuous wheel-test pytest matrix uses the same runner split.
- \pytest_rocm.yml\ workflow_dispatch adds DPX 4/8 labels and defaults manual runs to prod 1-GPU.

## Test plan
- [ ] Merge to \dpx_pytest\ and dispatch **CI - Wheel Tests (Nightly/Release)** on \dpx_pytest\
- [ ] Confirm 6 prod 1-GPU pytest legs queue on \gfx950.1\
- [ ] Confirm 12 DPX pytest legs (4/8 × py × ROCm) queue on \gfx950.4-dpx\ / \gfx950.8-dpx\
- [ ] Optional: dispatch **CI - Pytest ROCm** manually with each runner label


Made with [Cursor](https://cursor.com)