### PR TITLE
Use sandbox DPX label for 8-GPU pytest runners

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -23,7 +23,7 @@ on:
         options:
           - "amd-do-linux.jax.gpu.gfx950.1"
           - "amd-do-linux.jax.gpu.gfx950.4-dpx"
-          - "amd-do-linux.jax.gpu.gfx950.8-dpx"
+          - "amd-sandbox-linux.jax.gpu.gfx950.8-dpx"
           - "amd-do-linux.jax.gpu.gfx950.4"
           - "amd-do-linux.jax.gpu.gfx950.8"
           - "amd-do-linux.jax.gpu.gfx950.1-dpx"

--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -590,7 +590,7 @@ jobs:
           runner:
             - "amd-do-linux.jax.gpu.gfx950.1"
             - "amd-do-linux.jax.gpu.gfx950.4-dpx"
-            - "amd-do-linux.jax.gpu.gfx950.8-dpx"
+            - "amd-sandbox-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12"]
           rocm: [
             {label: "N (7.14.0)", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -268,11 +268,11 @@ jobs:
     strategy:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
-          # 1-GPU on prod DOKS; 4/8-GPU on DPX (amd-gpu-dpx-claim-{4,8}).
+          # 1-GPU on prod DOKS; 4-GPU on DPX; 8-GPU on sandbox DPX (do 8-dpx label is prod cluster).
           runner:
             - "amd-do-linux.jax.gpu.gfx950.1"
             - "amd-do-linux.jax.gpu.gfx950.4-dpx"
-            - "amd-do-linux.jax.gpu.gfx950.8-dpx"
+            - "amd-sandbox-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12", "3.13", "3.14"]
           rocm: [
             {label: "N (7.14.0)", wheel-version: "7", release-version: "7.14.0", tag: "therock-7.14"},


### PR DESCRIPTION
## Summary
- Replace \md-do-linux.jax.gpu.gfx950.8-dpx\ with \md-sandbox-linux.jax.gpu.gfx950.8-dpx\ in nightly/continuous pytest matrices and \pytest_rocm.yml\ dispatch options.
- \md-do-linux.jax.gpu.gfx950.8-dpx\ is owned by the prod DPX rocOps cluster; the ATL1 sandbox cluster uses the sandbox label instead.
- 1-GPU prod (\.1\) and 4-GPU DPX (\.4-dpx\) labels unchanged.

## Test plan
- [ ] Merge and re-dispatch wheel tests on \dpx_pytest\
- [ ] Confirm 6 pytest legs queue on \md-sandbox-linux.jax.gpu.gfx950.8-dpx\
- [ ] Confirm 4-dpx and prod 1-GPU legs unchanged


Made with [Cursor](https://cursor.com)