### PR TITLE
[ROCm] Replace rocm-smi with amd-smi in CI diagnostics (v0.11.0)

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -31,7 +31,7 @@ jobs:
           ls
       - name: Print system info
         run: |
-          rocm-smi
+          amd-smi list
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           path: ${{ env.WORKSPACE_DIR }}

--- a/ci/utilities/prepare_rocm_tests.sh
+++ b/ci/utilities/prepare_rocm_tests.sh
@@ -37,7 +37,7 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
-rocm-smi
+amd-smi list
 
 source ./ci/utilities/rocm_test_env.sh
 


### PR DESCRIPTION
## Summary
- Replace deprecated `rocm-smi` CLI calls with `amd-smi list` in ROCm pytest prep and the post-merge CI workflow.
- Diagnostic-only change: no test logic or worker sizing affected on this branch.

## Context
ROCm SMI is deprecated in favor of AMD SMI (see ROCm/TheRock#6852). This is the CLI layer only; XLA library migration is tracked separately in ROCm/xla#1113.

## Test plan
- [x] `amd-smi list` exits 0 and enumerates GPUs on ROCm 7.14 runner
- [x] `bash -n ci/utilities/prepare_rocm_tests.sh` passes
- [ ] CI green on `rocm-jaxlib-v0.11.0` after merge