### PR TITLE
[ROCm] Replace rocm-smi with amd-smi in CI diagnostics (v0.10.2)

### DIFF
--- a/.github/workflows/rocm-ci.yml
+++ b/.github/workflows/rocm-ci.yml
@@ -31,7 +31,7 @@ jobs:
           ls
       - name: Print system info
         run: |
-          rocm-smi
+          amd-smi list
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           path: ${{ env.WORKSPACE_DIR }}

--- a/build/rocm/README.md
+++ b/build/rocm/README.md
@@ -140,8 +140,8 @@ Please follow [ROCm installation guide](https://rocm.docs.amd.com/en/latest/depl
 Once installed, verify ROCm installation using:
 
 ```Bash
-> rocm-smi
-============================================ ROCm System Management Interface ============================================
+> amd-smi list
+============================================ AMD System Management Interface ============================================
 ====================================================== Concise Info ======================================================
 Device  Node  IDs              Temp        Power     Partitions          SCLK    MCLK    Fan  Perf  PwrCap  VRAM%  GPU%
               (DID,     GUID)  (Junction)  (Socket)  (Mem, Compute, ID)
@@ -155,7 +155,7 @@ Device  Node  IDs              Temp        Power     Partitions          SCLK   
 6       8     0x74a1,   53667  42.0°C      140.0W    NPS1, SPX, 0        134Mhz  900Mhz  0%   auto  750.0W  0%     0%
 7       9     0x74a1,   63738  38.0°C      135.0W    NPS1, SPX, 0        133Mhz  900Mhz  0%   auto  750.0W  0%     0%
 ==========================================================================================================================
-================================================== End of ROCm SMI Log ===================================================
+================================================== End of amd-smi list ===================================================
 ```
 
 ### Step 2: Install the Latest Version of JAX

--- a/ci/utilities/prepare_rocm_tests.sh
+++ b/ci/utilities/prepare_rocm_tests.sh
@@ -37,7 +37,7 @@ echo "Installed packages:"
 
 "$JAXCI_PYTHON" -c "import jax; print(jax.default_backend()); print(jax.devices()); print(len(jax.devices()))"
 
-rocm-smi
+amd-smi list
 
 source ./ci/utilities/rocm_test_env.sh
 


### PR DESCRIPTION
## Summary
- Replace deprecated `rocm-smi` CLI with `amd-smi list` in pytest prep, post-merge CI, and build docs.

## Context
ROCm SMI is deprecated in favor of AMD SMI (ROCm/TheRock#6852). CLI-only; library migration is ROCm/xla#1113.

## Test plan
- [x] `amd-smi list` exits 0 on ROCm 7.14
- [x] `bash -n ci/utilities/prepare_rocm_tests.sh` passes