### PR TITLE
Route ROCm pytest to do-dpx-testing JAX runner labels

### DIFF
--- a/.github/workflows/wheel_tests_continuous.yml
+++ b/.github/workflows/wheel_tests_continuous.yml
@@ -588,7 +588,7 @@ jobs:
         fail-fast: false
         matrix:
           runner:
-            - "amd-do-linux.jax.gpu.gfx950.1"
+            - "amd-do-linux.jax.gpu.gfx950.1-dpx"
             - "amd-do-linux.jax.gpu.gfx950.4-dpx"
             - "amd-sandbox-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12"]

--- a/.github/workflows/wheel_tests_nightly_release.yml
+++ b/.github/workflows/wheel_tests_nightly_release.yml
@@ -268,9 +268,9 @@ jobs:
     strategy:
         fail-fast: false # don't cancel all jobs on failure
         matrix:
-          # 1-GPU on prod DOKS; 4-GPU on DPX; 8-GPU on sandbox DPX (do 8-dpx label is prod cluster).
+          # All DPX pytest legs on do-atl1-amd-gpu-dra-dpx-cluster (do-dpx-testing).
           runner:
-            - "amd-do-linux.jax.gpu.gfx950.1"
+            - "amd-do-linux.jax.gpu.gfx950.1-dpx"
             - "amd-do-linux.jax.gpu.gfx950.4-dpx"
             - "amd-sandbox-linux.jax.gpu.gfx950.8-dpx"
           python: ["3.12", "3.13", "3.14"]


### PR DESCRIPTION
## Summary

Point wheel-test pytest matrix at the JAX runners on \do-atl1-amd-gpu-dra-dpx-cluster\ (do-dpx-testing):

| GPUs | Label |
|------|-------|
| 1 | \md-do-linux.jax.gpu.gfx950.1-dpx\ |
| 4 | \md-do-linux.jax.gpu.gfx950.4-dpx\ |
| 8 | \md-sandbox-linux.jax.gpu.gfx950.8-dpx\ |

Replaces prod \md-do-linux.jax.gpu.gfx950.1\ for 1-GPU legs.

## Test plan

- [ ] Merge to \dpx_pytest\
- [ ] Dispatch wheel tests; confirm pytest jobs land on do-dpx-testing listeners
- [ ] Verify 1/4/8-GPU legs complete after ArgoCD sync (rocOps #964)

Made with [Cursor](https://cursor.com)