### PR TITLE
Add ROCm pytest smoke mode for fast DPX validation

### DIFF
--- a/.github/workflows/pytest_rocm.yml
+++ b/.github/workflows/pytest_rocm.yml
@@ -77,6 +77,28 @@ on:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
         default: 'no'
+      test-mode:
+        description: "full = entire suite; smoke = one test for fast DPX validation"
+        type: choice
+        default: full
+        options:
+          - full
+          - smoke
+      workers-per-gpu:
+        description: "Pytest xdist workers per GPU (smoke default 2; full default 4)"
+        type: string
+        default: ""
+      smoke-test:
+        description: "Pytest target when test-mode=smoke"
+        type: string
+        default: "tests/pmap_test.py::PythonPmapTest::testBasic"
+      smoke-use-xdist:
+        description: "Run smoke target with xdist (1=yes for single-accel targets only)"
+        type: choice
+        default: "0"
+        options:
+          - "0"
+          - "1"
   workflow_call:
     inputs:
       runner:
@@ -123,6 +145,22 @@ on:
         description: 'Should this workflow run wait for a remote connection?'
         type: string
         default: 'no'
+      test-mode:
+        description: "full = entire suite; smoke = one test for fast DPX validation"
+        type: string
+        default: full
+      workers-per-gpu:
+        description: "Pytest xdist workers per GPU (smoke default 2; full default 4)"
+        type: string
+        default: ""
+      smoke-test:
+        description: "Pytest target when test-mode=smoke"
+        type: string
+        default: "tests/pmap_test.py::PythonPmapTest::testBasic"
+      smoke-use-xdist:
+        description: "Run smoke target with xdist (1=yes for single-accel targets only)"
+        type: string
+        default: "0"
 permissions:
   id-token: write
   contents: read
@@ -147,7 +185,7 @@ jobs:
       options: --device=/dev/kfd --device=/dev/dri --security-opt seccomp=unconfined --group-add video --shm-size 64G --env-file /etc/podinfo/gha-gpu-isolation-settings
     name: "${{ (contains(inputs.runner, 'gfx950.1') && 'gfx950 1-GPU') ||
         (contains(inputs.runner, 'gfx950.4') && 'gfx950 4-GPU') ||
-        (contains(inputs.runner, 'gfx950.8') && 'gfx950 8-GPU') }}, ROCm ${{ inputs.rocm-release-version || inputs.rocm-version }}, py${{ inputs.python }}"
+        (contains(inputs.runner, 'gfx950.8') && 'gfx950 8-GPU') }}, ROCm ${{ inputs.rocm-release-version || inputs.rocm-version }}, py${{ inputs.python }}${{ inputs.test-mode == 'smoke' && ', smoke' || '' }}"
 
     env:
       INPUT_RUNNER: ${{ inputs.runner }}
@@ -159,6 +197,9 @@ jobs:
       # warning when this is unset; the env var must be in place before HIP
       # initialization, which happens at JAX import time.
       HSA_NO_SCRATCH_RECLAIM: "1"
+      ROCM_PYTEST_WORKERS_PER_GPU: ${{ inputs.workers-per-gpu != '' && inputs.workers-per-gpu || (inputs.test-mode == 'smoke' && '2') || '' }}
+      ROCM_PYTEST_SMOKE_TARGET: ${{ inputs.smoke-test }}
+      ROCM_PYTEST_SMOKE_USE_XDIST: ${{ inputs.smoke-use-xdist }}
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -186,8 +227,13 @@ jobs:
         with:
           halt-dispatch-input: ${{ inputs.halt-for-connection }}
       - name: Run Pytest ROCm tests
-        timeout-minutes: 120
-        run: ./ci/run_pytest_rocm.sh
+        timeout-minutes: ${{ inputs.test-mode == 'smoke' && 30 || 120 }}
+        run: |
+          if [[ "${{ inputs.test-mode }}" == "smoke" ]]; then
+            ./ci/run_pytest_rocm_smoke.sh
+          else
+            ./ci/run_pytest_rocm.sh
+          fi
       - name: Upload test artifacts
         if: always()
         continue-on-error: true

--- a/ci/run_pytest_rocm_smoke.sh
+++ b/ci/run_pytest_rocm_smoke.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Copyright 2026 The JAX Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+# Fast DPX/ROCm validation: GPU preflight + one pytest target.
+#
+# Defaults: 2 xdist workers/GPU, pmap smoke test on all visible GPUs.
+# Override with ROCM_PYTEST_WORKERS_PER_GPU, ROCM_PYTEST_SMOKE_TARGET, and
+# ROCM_PYTEST_SMOKE_USE_XDIST (set to 1 for a single-accel test with xdist).
+set -exu -o history -o allexport
+
+export ROCM_PYTEST_WORKERS_PER_GPU="${ROCM_PYTEST_WORKERS_PER_GPU:-2}"
+
+source ./ci/utilities/prepare_rocm_tests.sh
+
+smoke_target="${ROCM_PYTEST_SMOKE_TARGET:-tests/pmap_test.py::PythonPmapTest::testBasic}"
+use_xdist="${ROCM_PYTEST_SMOKE_USE_XDIST:-0}"
+
+echo "ROCm pytest smoke: target=${smoke_target}"
+echo "ROCm pytest smoke: workers_per_gpu=${ROCM_PYTEST_WORKERS_PER_GPU}, num_processes=${num_processes}"
+
+mkdir -p "${LOGS_DIR}" test-artifacts
+
+if [[ "${use_xdist}" == "1" ]]; then
+  echo "Running smoke with xdist (-n ${num_processes})..."
+  "$JAXCI_PYTHON" -m pytest -n "${num_processes}" --tb=short \
+    --json-report --json-report-file="${LOGS_DIR}/pytest_results_smoke.json" \
+    --junitxml=test-artifacts/junit-smoke.xml \
+    "${smoke_target}"
+else
+  echo "Running smoke without xdist (multi-GPU / single-process)..."
+  unset JAX_ENABLE_ROCM_XDIST
+  "$JAXCI_PYTHON" -m pytest --tb=short \
+    --json-report --json-report-file="${LOGS_DIR}/pytest_results_smoke.json" \
+    --junitxml=test-artifacts/junit-smoke.xml \
+    "${smoke_target}"
+fi

--- a/ci/utilities/rocm_test_env.sh
+++ b/ci/utilities/rocm_test_env.sh
@@ -70,7 +70,9 @@ if [[ "$expected_gpus" -gt 0 && "$gpu_count" -ne "$expected_gpus" ]]; then
   exit 1
 fi
 
-export num_processes=$((gpu_count * 4))
+workers_per_gpu="${ROCM_PYTEST_WORKERS_PER_GPU:-4}"
+export num_processes=$((gpu_count * workers_per_gpu))
+echo "Workers per GPU: $workers_per_gpu"
 echo "Number of processes to run: $num_processes"
 
 export JAX_ENABLE_ROCM_XDIST="$gpu_count"


### PR DESCRIPTION
## Summary
- Add \	est-mode: smoke\ to \CI - Pytest ROCm\ workflow_dispatch for fast DPX infra validation without running the full 68328-test suite.
- Smoke defaults: **2 workers/GPU**, **30 min timeout**, one test (\pmap testBasic\ on all visible GPUs).
- \ROCM_PYTEST_WORKERS_PER_GPU\ env var overrides worker count for both smoke and full runs.

## How to validate 4-GPU DPX
1. Dispatch **CI - Pytest ROCm** from this branch
2. runner: \md-do-linux.jax.gpu.gfx950.4-dpx\
3. test-mode: **smoke**
4. workers-per-gpu: **2** (optional; smoke default)

Expected: preflight passes with 4 GPUs, \Workers per GPU: 2\, pmap smoke test passes in minutes.

Optional xdist worker check: set \smoke-use-xdist=1\ and \smoke-test=tests/version_test.py::JaxVersionTest::testVersionValidity\.

## Test plan
- [ ] Smoke dispatch on \md-do-linux.jax.gpu.gfx950.4-dpx\ completes in <30 min
- [ ] Full wheel matrix still uses \	est-mode: full\ (unchanged)

Made with [Cursor](https://cursor.com)