### PR TITLE
[ROCm] Bump XLA to pick up amd-smi migration (v0.10.1)

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,6 +21,6 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "2418c88b5d24d14c412ca2f22223811466f3f5fb"
-XLA_SHA256 = "ebb95ad9c449968da543f6333d0e00df7e62d317b288d1fbc0302f7a90f48c73"
+XLA_COMMIT = "e837ab6a8fd56173dea2fd9dd8f86ac84aa90f01"
+XLA_SHA256 = "87b9101931605e00968b8d0170a76e62f02e3a7259aa3f4d38cf7202f5d04cea"
 


### PR DESCRIPTION
## Summary

Bump the pinned XLA revision on `rocm-jaxlib-v0.10.1` to `e837ab6a8fd56173dea2fd9dd8f86ac84aa90f01`, the merge commit of ROCm/xla#1137.

That XLA change replaces the `rocm_smi`/`librocm_smi64` device-query layer with `amd_smi`. Without this bump, jaxlib on this branch still asks Bazel for `librocm_smi64.so` and fails to build once the ROCm SDK stops shipping it:

```
ERROR: external/local_config_rocm/rocm/BUILD:319:16: SolibSymlink
  .../librocm_smi64.so failed: missing input file
  '@@local_config_rocm//rocm:rocm_dist/lib/librocm_smi64.so'
```

This is the JAX-side half of the ROCm/TheRock#6852 rollout, which disables the deprecated rocm-smi-lib build.

## Test plan

Built locally against a copy of the ROCm SDK with only `librocm_smi64*` removed, to simulate the post-TheRock#6852 state:

- [x] XLA targets `smi_util`, `rocm_pcie_bandwidth`, `rocm_xgmi_topology`, `rocm_executor`
- [x] `jax-rocm-pjrt` wheel builds end to end
- [x] `XLA_SHA256` verified by two independent downloads of the archive tarball