### PR TITLE
[ROCm] Bump XLA to pick up amd-smi migration (v0.10.2)

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,5 +21,5 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "40c2800533498f01e4d891b0112c255ec0defcc3"
-XLA_SHA256 = "5d9769472deef4d3fa2e8038bf852aede99e273d9b7d7508838b79542bc2f8a1"
+XLA_COMMIT = "01bf06311a935e6ad8a921f168888617cd59d868"
+XLA_SHA256 = "1de39fe3eb3eed4bc59c71796fea6ce0ac515ed3ba82910a75d1d8d4da9175b3"


### PR DESCRIPTION
## Summary

Bump the pinned XLA revision on `rocm-jaxlib-v0.10.2` to `01bf06311a935e6ad8a921f168888617cd59d868`, the merge commit of ROCm/xla#1138.

That XLA change replaces the `rocm_smi`/`librocm_smi64` device-query layer with `amd_smi`. Without this bump, jaxlib on this branch still asks Bazel for `librocm_smi64.so` and fails to build once the ROCm SDK stops shipping it:

```
ERROR: external/local_config_rocm/rocm/BUILD:319:16: SolibSymlink
  .../librocm_smi64.so failed: missing input file
  '@@local_config_rocm//rocm:rocm_dist/lib/librocm_smi64.so'
```

This is the JAX-side half of the ROCm/TheRock#6852 rollout, which disables the deprecated rocm-smi-lib build.

## Test plan

Built locally against a copy of the ROCm SDK with only `librocm_smi64*` removed, to simulate the post-TheRock#6852 state:

- [x] XLA targets `smi_util`, `rocm_pcie_bandwidth`, `rocm_xgmi_topology`, `rocm_executor`
- [x] `jax-rocm-pjrt` wheel builds end to end
- [x] `XLA_SHA256` verified by two independent downloads of the archive tarball