### PR TITLE
[ROCm] Bump XLA to pick up amd-smi migration (v0.11.1)

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,5 +21,5 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "a530cc3ce3ecee6043372cb752630758b81e8d03"
-XLA_SHA256 = "6df996dd008ee58022d09b479edb02ada2f221a34ddcc6afe75825da21c4a9fe"
+XLA_COMMIT = "7d7e1c314db9f2e0b35bc92293592ea526e92a94"
+XLA_SHA256 = "48c9f437134f84d4c7f7366019543cd4ba259b57f83c3bb00f2f93ce4606c8a4"


### PR DESCRIPTION
## Summary

Bump the pinned XLA revision on `rocm-jaxlib-v0.11.1` to `7d7e1c314db9f2e0b35bc92293592ea526e92a94`, the merge commit of ROCm/xla#1140.

That XLA change replaces the `rocm_smi`/`librocm_smi64` device-query layer with `amd_smi`. Without this bump, jaxlib on this branch still asks Bazel for `librocm_smi64.so` and fails to build once the ROCm SDK stops shipping it:

```
ERROR: external/local_config_rocm/rocm/BUILD:319:16: SolibSymlink
  .../librocm_smi64.so failed: missing input file
  '@@local_config_rocm//rocm:rocm_dist/lib/librocm_smi64.so'
```

This is the JAX-side half of the ROCm/TheRock#6852 rollout, which disables the deprecated rocm-smi-lib build.

## Test plan

Built locally against a copy of the ROCm SDK with only `librocm_smi64*` removed, to simulate the post-TheRock#6852 state:

- [x] XLA targets `smi_util`, `rocm_pcie_bandwidth`, `rocm_xgmi_topology`, `rocm_executor`
- [x] `jax-rocm-pjrt` wheel builds end to end
- [x] `XLA_SHA256` verified by two independent downloads of the archive tarball