### PR TITLE
[ROCm] Point XLA at ROCm/xla and bump to pick up amd-smi migration (v0.11.0)

### DIFF
--- a/third_party/xla/revision.bzl
+++ b/third_party/xla/revision.bzl
@@ -21,5 +21,5 @@
 #    and update XLA_SHA256 with the result.
 
 # buildifier: disable=module-docstring
-XLA_COMMIT = "5147dd650ee50af6608861bb5464c60afba7de41"
-XLA_SHA256 = "cba3e5ea0ccc9461a8fb4b53ef855f696a9032e47f0c8a5d83ef72a9e9db9f24"
+XLA_COMMIT = "2cab052f3d5a6b3cc7b1664f6e77bee51616c2f9"
+XLA_SHA256 = "e0bb5d7f39651b7e530dd7c2b9ae6f54845206bb95d7c5fa8f39a34f965f0188"

--- a/third_party/xla/workspace.bzl
+++ b/third_party/xla/workspace.bzl
@@ -21,7 +21,7 @@ def repo():
         name = "xla",
         sha256 = XLA_SHA256,
         strip_prefix = "xla-{commit}".format(commit = XLA_COMMIT),
-        urls = tf_mirror_urls("https://github.com/openxla/xla/archive/{commit}.tar.gz".format(commit = XLA_COMMIT)),
+        urls = tf_mirror_urls("https://github.com/ROCm/xla/archive/{commit}.tar.gz".format(commit = XLA_COMMIT)),
         patch_file = [
             # Add any patch files here.
             # "//third_party/xla:temporary.patch


### PR DESCRIPTION
## Summary

Bump the pinned XLA revision on `rocm-jaxlib-v0.11.0` to `2cab052f3d5a6b3cc7b1664f6e77bee51616c2f9`, the merge commit of ROCm/xla#1139, **and switch the XLA source from `openxla/xla` to `ROCm/xla`.**

Unlike the other release branches, this one was still pinned to upstream `openxla/xla`, which does not carry the release-branch amd-smi migration. Bumping the hash alone would have had no effect, so `third_party/xla/workspace.bzl` moves to the ROCm fork as well.

The XLA change replaces the `rocm_smi`/`librocm_smi64` device-query layer with `amd_smi`. Without it, jaxlib still asks Bazel for `librocm_smi64.so` and fails to build once the ROCm SDK stops shipping it:

```
ERROR: external/local_config_rocm/rocm/BUILD:319:16: SolibSymlink
  .../librocm_smi64.so failed: missing input file
  '@@local_config_rocm//rocm:rocm_dist/lib/librocm_smi64.so'
```

This is the JAX-side half of the ROCm/TheRock#6852 rollout, which disables the deprecated rocm-smi-lib build.

## Why the repo switch is safe

`ROCm/xla@rocm-jaxlib-v0.11.0` is the previously pinned upstream commit plus exactly two commits, and is not behind it at all (`git` merge base is the old pin, `ahead_by: 2`, `behind_by: 0`):

| Commit | Description |
|---|---|
| `feacc6c4f40` | Replace rocm-smi CLI with amd-smi in ROCm test scripts (ROCm/xla#1133) |
| `2cab052f3d5` | [ROCm] Migrate SMI device queries from rocm_smi to amd_smi (ROCm/xla#1139) |

Every file they touch is SMI-related, so this pulls in no unrelated upstream drift:

```
build_tools/rocm/run_xla.sh
build_tools/rocm/run_xla_multi_gpu.sh
third_party/gpus/rocm/BUILD.tpl
xla/stream_executor/rocm/{BUILD, rocm_executor.cc, rocm_pcie_bandwidth.*,
  rocm_smi_util.h, rocm_xgmi_topology.*, rocm_xgmi_topology_test.cc,
  smi_util.*, smi_util_amd_smi.cc, smi_util_rocm_smi.cc}
```

## Test plan

Built locally against a copy of the ROCm SDK with only `librocm_smi64*` removed, to simulate the post-TheRock#6852 state:

- [x] XLA targets `smi_util`, `rocm_pcie_bandwidth`, `rocm_xgmi_topology`, `rocm_executor`
- [x] `jax-rocm-pjrt` wheel builds end to end
- [x] `XLA_SHA256` verified by two independent downloads of the archive tarball