### PR TITLE
[ROCm] Bump XLA module pin to pick up the amd_smi migration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -31,9 +31,9 @@ archive_override(
 bazel_dep(name = "xla")
 archive_override(
     module_name = "xla",
-    integrity = "sha256-bfmW3QCO5YAi0JtHntsCraLyIaNN3Mav51gl2iHEqf4=",
-    strip_prefix = "xla-a530cc3ce3ecee6043372cb752630758b81e8d03",
-    urls = ["https://github.com/ROCm/xla/archive/a530cc3ce3ecee6043372cb752630758b81e8d03.tar.gz"],
+    integrity = "sha256-+CGIyE/5Ze0KXJ3CRgVHR5X4trI7DsbFp4sSf4Znlm0=",
+    strip_prefix = "xla-65f2f02d3166fc46fe4bd87618a6f790ff01a0ff",
+    urls = ["https://github.com/ROCm/xla/archive/65f2f02d3166fc46fe4bd87618a6f790ff01a0ff.tar.gz"],
 )
 
 # TODO: upstream, otherwise we have to duplicate the patches in jax


### PR DESCRIPTION
Points the XLA `archive_override` at
[ROCm/xla#1144](https://github.com/ROCm/xla/pull/1144), which migrates the SMI
device queries from `rocm_smi` to `amd_smi`. Needed for
[TheRock#6852](https://github.com/ROCm/TheRock/pull/6852), which removes
`librocm_smi64` from the ROCm SDK.

This branch builds with bzlmod (`common --enable_bzlmod --noenable_workspace`,
since upstream `aeff4e4bf`), so `MODULE.bazel` is the live XLA pin and
`third_party/xla/revision.bzl` is the dormant WORKSPACE path. #867 bumped
`revision.bzl` only, so the wheel build kept resolving the old pin and TheRock
CI still failed with:

```
SolibSymlink .../librocm_smi64.so failed: missing input file
@@xla++rocm_configure_ext+local_config_rocm//rocm:rocm_dist/lib/librocm_smi64.so
```

The previous pin, `a530cc3ce3e`, was the head of `rocm-jaxlib-0.11.1-alpha`
before the SMI migration landed there.

### Verification

Built against a full ROCm 7.14 SDK with `librocm_smi64.so*` deleted, resolving
XLA from this `archive_override` with no `--override_module`, so the pin itself
is exercised:

- `jax-rocm-pjrt` wheel builds; the pinned tarball fetches and its integrity matches.
- The resulting `xla_rocm_plugin.so` lists `libamd_smi.so.26` as `NEEDED`, with
  no `librocm_smi64` entry.